### PR TITLE
Refactoring parameters vs. subjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 0.4
 ---
 
+- Ability to place parameter tokens in descriptions
+- Each parameter set now considered as a separate subject
 - Removed default report.
 - Show memory in `simple_table` report (#87).
 - `footer` option now available to show aggregate values for columns (#86)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,14 @@ following annotations:
 
 **singular**
 
-A description of the benchmark subject.
+A description of the benchmark subject. If you have parameterized the subject
+you may use the parameter values in the description as follows:
+
+````php
+/**
+ * @description Do something %param_name% times with the %another_param% thing.
+ */
+````
 
 ### @group
 

--- a/lib/Benchmark/Subject.php
+++ b/lib/Benchmark/Subject.php
@@ -11,30 +11,49 @@
 
 namespace PhpBench\Benchmark;
 
+/**
+ * Represents a subject that is tested by a method
+ * in a benchmark class.
+ *
+ */
 class Subject
 {
     private $methodName;
     private $beforeMethods;
-    private $parameterProviders;
+    private $parameters;
     private $nbIterations;
     private $description;
     private $processIsolation;
     private $revs;
     private $groups;
+    private $identifier;
 
+    /**
+     * @param integer $identifier
+     * @param mixed $methodName
+     * @param array $beforeMethods
+     * @param array $parameters
+     * @param mixed $nbIterations
+     * @param array $revs
+     * @param mixed $description
+     * @param mixed $processIsolation
+     * @param array $groups
+     */
     public function __construct(
+        $identifier,
         $methodName,
         array $beforeMethods,
-        array $parameterProviders,
+        array $parameters,
         $nbIterations,
         array $revs,
         $description,
         $processIsolation,
         array $groups
     ) {
+        $this->identifier = $identifier;
         $this->methodName = $methodName;
         $this->beforeMethods = $beforeMethods;
-        $this->parameterProviders = $parameterProviders;
+        $this->parameters = $parameters;
         $this->nbIterations = $nbIterations;
         $this->revs = $revs;
         $this->description = $description;
@@ -42,43 +61,95 @@ class Subject
         $this->groups = $groups;
     }
 
+    /**
+     * Return the methods that should be executed before this subject
+     *
+     * @return string[]
+     */
     public function getBeforeMethods()
     {
         return $this->beforeMethods;
     }
 
-    public function getParameterProviders()
+    /**
+     * Return the parameter provider methods for this subject
+     *
+     * @return string[]
+     */
+    public function getParameters()
     {
-        return $this->parameterProviders;
+        return $this->parameters;
     }
 
+    /**
+     * Return the number of iterations that should be executed
+     * on the subject.
+     *
+     * @return integer
+     */
     public function getNbIterations()
     {
         return $this->nbIterations;
     }
 
+    /**
+     * Return a description of this subject
+     *
+     * @return string
+     */
     public function getDescription()
     {
         return $this->description;
     }
 
+    /**
+     * Return the method in the bechmark class which this subject
+     * represents.
+     *
+     * @return string
+     */
     public function getMethodName()
     {
         return $this->methodName;
     }
 
+    /**
+     * Return the process isolation policy for this subject
+     *
+     * @return string
+     */
     public function getProcessIsolation()
     {
         return $this->processIsolation;
     }
 
+    /**
+     * Return the number of revolutions which should be executed.
+     *
+     * @return integer
+     */
     public function getRevs()
     {
         return $this->revs;
     }
 
+    /**
+     * Return the groups to which this subject belongs
+     *
+     * @return string[]
+     */
     public function getGroups()
     {
         return $this->groups;
+    }
+
+    /**
+     * Return the identifier of this subject
+     *
+     * @return integer
+     */
+    public function getIdentifier() 
+    {
+        return $this->identifier;
     }
 }

--- a/lib/Console/Command/RunCommand.php
+++ b/lib/Console/Command/RunCommand.php
@@ -68,7 +68,7 @@ EOT
         $configFile = $input->getOption('config');
         $processIsolation = $input->getOption('process-isolation') ?: null;
         $processIsolation = $processIsolation === 'none' ? false : $processIsolation;
-        $parameters = null;
+        $parameters = array();
 
         Runner::validateProcessIsolation($processIsolation);
 
@@ -169,7 +169,7 @@ EOT
         }
 
         $benchFinder = new CollectionBuilder($finder);
-        $subjectBuilder = new SubjectBuilder($subjects, $groups);
+        $subjectBuilder = new SubjectBuilder($subjects, $parameters, $groups);
 
         $benchRunner = new Runner(
             $benchFinder,
@@ -177,7 +177,6 @@ EOT
             $progressLogger,
             $processIsolation,
             !$noSetup,
-            $parameters,
             $iterations,
             $revs,
             $configFile

--- a/lib/Report/Cellular/CellularConverter.php
+++ b/lib/Report/Cellular/CellularConverter.php
@@ -46,6 +46,7 @@ class CellularConverter
         $table->setAttribute('class', $benchmark->getClass());
         $table->setAttribute('subject', $subject->getName());
         $table->setAttribute('groups', $subject->getGroups());
+        $table->setAttribute('parameters', $subject->getParameters());
 
         foreach ($subject->getIterationsResults() as $runIndex => $aggregateResult) {
             foreach ($aggregateResult->getIterationResults() as $iterationIndex => $iteration) {
@@ -53,7 +54,6 @@ class CellularConverter
                 $row = $table->createAndAddRow(array('main'));
                 $row->set('run', $runIndex);
                 $row->set('iter', $iterationIndex);
-
                 $row->set('params', json_encode($subject->getParameters()));
 
                 $stat = $iteration->getStatistics();

--- a/lib/Report/Cellular/CellularConverter.php
+++ b/lib/Report/Cellular/CellularConverter.php
@@ -41,6 +41,7 @@ class CellularConverter
     private static function convertSubject(SubjectResult $subject, BenchmarkResult $benchmark, Workspace $workspace)
     {
         $table = $workspace->createAndAddTable(array('main'));
+        $table->setAttribute('identifier', $subject->getIdentifier());
         $table->setAttribute('description', $subject->getDescription());
         $table->setAttribute('class', $benchmark->getClass());
         $table->setAttribute('subject', $subject->getName());
@@ -53,7 +54,7 @@ class CellularConverter
                 $row->set('run', $runIndex);
                 $row->set('iter', $iterationIndex);
 
-                $row->set('params', json_encode($aggregateResult->getParameters()));
+                $row->set('params', json_encode($subject->getParameters()));
 
                 $stat = $iteration->getStatistics();
                 $row->set('pid', $stat['pid']);

--- a/lib/Report/Cellular/Step/AggregateSubjectStep.php
+++ b/lib/Report/Cellular/Step/AggregateSubjectStep.php
@@ -27,16 +27,20 @@ class AggregateSubjectStep extends AggregateRunStep
                 if (!$workspace->first()) {
                     return;
                 }
+                $table = $workspace->first();
 
                 if (!isset($newWorkspace[0])) {
                     $newTable = $newWorkspace->createAndAddTable();
+                    foreach (array('class', 'groups', 'subject') as $name) {
+                        $newTable->setAttribute($name, $table->getAttribute($name));
+                    }
                 } else {
                     $newTable = $newWorkspace->first();
                 }
 
-                $table = $workspace->first();
                 $row = $newTable->createAndAddRow();
                 $row->set('iters', $table->count());
+                $row->set('params', $table->getAttribute('parameters'));
                 $row->set('class', $table->getAttribute('class'));
                 $row->set('subject', $table->getAttribute('subject'));
                 $row->set('description', $table->getAttribute('description'));

--- a/lib/Report/Cellular/Step/AggregateSubjectStep.php
+++ b/lib/Report/Cellular/Step/AggregateSubjectStep.php
@@ -21,7 +21,7 @@ class AggregateSubjectStep extends AggregateRunStep
     {
         $workspace
             ->partition(function (Table $table) {
-                return $table->getAttribute('class') . $table->getAttribute('subject');
+                return $table->getAttribute('identifier');
             })
             ->aggregate(function (Workspace $workspace, $newWorkspace) {
                 if (!$workspace->first()) {

--- a/lib/Report/Cellular/Step/ReplaceDescriptionTokensStep.php
+++ b/lib/Report/Cellular/Step/ReplaceDescriptionTokensStep.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the PHP Bench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Report\Cellular\Step;
+
+use DTL\Cellular\Calculator;
+use DTL\Cellular\Table;
+use PhpBench\Report\Cellular\Step;
+use DTL\Cellular\Workspace;
+
+/**
+ * Replace the tokens in the table descriptions with subject parameters
+ */
+class ReplaceDescriptionTokensStep implements Step
+{
+    public function step(Workspace $workspace)
+    {
+        $workspace->each(function (Table $table) {
+            if (!$table->hasAttribute('parameters')) {
+                return;
+            }
+            $parameters = $table->getAttribute('parameters');
+
+            $description = preg_replace_callback('{{(.+?)}}', function ($matches) use ($parameters) {
+                if (isset($parameters[$matches[1]])) {
+                    return json_encode($parameters[$matches[1]]);
+                }
+
+                return $matches[0];
+            }, $table->getAttribute('description'));
+            $table->setAttribute('description', $description);
+        });
+    }
+}

--- a/lib/Report/Generator/BaseTabularReportGenerator.php
+++ b/lib/Report/Generator/BaseTabularReportGenerator.php
@@ -26,6 +26,7 @@ use PhpBench\Report\Cellular\Step\SortStep;
 use PhpBench\Report\Cellular\Step\AggregateRunStep;
 use PhpBench\Report\Cellular\StepChain;
 use DTL\Cellular\Row;
+use PhpBench\Report\Cellular\Step\ReplaceDescriptionTokensStep;
 
 /**
  * This base class generates a table (a data table, not a UI table) with
@@ -88,6 +89,7 @@ abstract class BaseTabularReportGenerator implements ReportGenerator
 
         $stepChain = new StepChain();
         $stepChain->add(new RpsStep());
+        $stepChain->add(new ReplaceDescriptionTokensStep());
 
         if ($options['aggregate'] === 'run') {
             $stepChain->add(new AggregateRunStep($this->availableFuncs));

--- a/lib/Report/Generator/ConsoleTableReportGenerator.php
+++ b/lib/Report/Generator/ConsoleTableReportGenerator.php
@@ -47,6 +47,9 @@ class ConsoleTableReportGenerator extends BaseTabularReportGenerator
             'blue', new OutputFormatterStyle('blue', null, array())
         );
         $output->getFormatter()->setStyle(
+            'red', new OutputFormatterStyle('red', null, array())
+        );
+        $output->getFormatter()->setStyle(
             'dark', new OutputFormatterStyle('black', null, array('bold'))
         );
         $output->getFormatter()->setStyle(
@@ -88,6 +91,14 @@ class ConsoleTableReportGenerator extends BaseTabularReportGenerator
                         implode(', ', $data->getAttribute('groups'))
                     );
                 }
+
+                if ($data->hasAttribute('parameters') && $data->getAttribute('parameters')) {
+                    $line[] = sprintf(
+                        '<comment>[%s]</comment>',
+                        trim(json_encode($data->getAttribute('parameters')), '{}')
+                    );
+                }
+
 
                 if ($line) {
                     $output->writeln(implode(' ', $line));

--- a/lib/Result/Dumper/XmlDumper.php
+++ b/lib/Result/Dumper/XmlDumper.php
@@ -73,8 +73,12 @@ class XmlDumper
     private function dumpSubject(SubjectResult $subjectResult, $dom)
     {
         $subjectEl = $dom->createElement('subject');
+        $subjectEl->setAttribute('identifier', $subjectResult->getIdentifier());
         $subjectEl->setAttribute('name', $subjectResult->getName());
         $subjectEl->setAttribute('description', $subjectResult->getDescription());
+
+        $parameters = $subjectResult->getParameters();
+        $this->appendParameters($subjectEl, $parameters);
 
         foreach ($subjectResult->getGroups() as $group) {
             $groupEl = $dom->createElement('group');
@@ -93,8 +97,6 @@ class XmlDumper
     private function dumpIterations(IterationsResult $iterationsResults, $dom)
     {
         $iterationsEl = $dom->createElement('iterations');
-        $parameters = $iterationsResults->getParameters();
-        $this->appendParameters($iterationsEl, $parameters);
 
         foreach ($iterationsResults->getIterationResults() as $iterationResult) {
             $iterationResultEl = $this->dumpIteration($iterationResult, $dom);

--- a/lib/Result/IterationsResult.php
+++ b/lib/Result/IterationsResult.php
@@ -14,68 +14,14 @@ namespace PhpBench\Result;
 class IterationsResult
 {
     private $iterationResults;
-    private $parameters;
 
-    public function __construct(array $iterationResults, array $parameters)
+    public function __construct(array $iterationResults)
     {
         $this->iterationResults = $iterationResults;
-        $this->parameters = $parameters;
     }
 
     public function getIterationResults()
     {
         return $this->iterationResults;
-    }
-
-    public function getParameters()
-    {
-        return $this->parameters;
-    }
-
-    public function getMinTime()
-    {
-        $min = null;
-
-        foreach ($this->iterationResults as $iterationResult) {
-            $iterationTime = $iterationResult->get('time');
-            if (!$min || $iterationTime < $min) {
-                $min = $iterationTime;
-            }
-        }
-
-        return $min;
-    }
-
-    public function getMaxTime()
-    {
-        $max = null;
-        foreach ($this->iterationResults as $iterationResult) {
-            $iterationTime = $iterationResult->get('time');
-            if (!$max || $iterationTime > $max) {
-                $max = $iterationTime;
-            }
-        }
-
-        return $max;
-    }
-
-    public function getTotalTime()
-    {
-        $total = 0;
-        foreach ($this->iterationResults as $iterationResult) {
-            $total += $iterationResult->get('time');
-        }
-
-        return $total;
-    }
-
-    public function getIterationCount()
-    {
-        return count($this->iterationResults);
-    }
-
-    public function getAverageTime()
-    {
-        return $this->getTotalTime() / $this->getIterationCount();
     }
 }

--- a/lib/Result/Loader/XmlLoader.php
+++ b/lib/Result/Loader/XmlLoader.php
@@ -55,11 +55,13 @@ class XmlLoader
     {
         $subjectResults = array();
         foreach ($xpath->query('./subject', $benchmarkEl) as $subjectEl) {
+            $identifier = $subjectEl->getAttribute('identifier');
             $name = $subjectEl->getAttribute('name');
             $description = $subjectEl->getAttribute('description');
             $iterationsResults = $this->getIterationsResults($xpath, $subjectEl);
             $groups = $this->getGroups($xpath, $subjectEl);
-            $subjectResults[] = new SubjectResult($name, $description, $groups, $iterationsResults);
+            $parameters = $this->getParametersForNode($xpath, $subjectEl);
+            $subjectResults[] = new SubjectResult($identifier, $name, $description, $groups, $parameters, $iterationsResults);
         }
 
         return $subjectResults;
@@ -80,8 +82,7 @@ class XmlLoader
         $iterationsResults = array();
         foreach ($xpath->query('./iterations', $subjectEl) as $iterationsEl) {
             $iterationResults = $this->getIterationResults($xpath, $iterationsEl);
-            $parameters = $this->getParametersForNode($xpath, $iterationsEl);
-            $iterationsResults[] = new IterationsResult($iterationResults, $parameters);
+            $iterationsResults[] = new IterationsResult($iterationResults);
         }
 
         return $iterationsResults;

--- a/lib/Result/SubjectResult.php
+++ b/lib/Result/SubjectResult.php
@@ -13,17 +13,21 @@ namespace PhpBench\Result;
 
 class SubjectResult
 {
+    private $identifier;
     private $name;
     private $description;
     private $groups;
     private $iterationsResults;
+    private $parameters;
 
-    public function __construct($name, $description, array $groups, array $iterationsResults)
+    public function __construct($identifier, $name, $description, array $groups, array $parameters, array $iterationsResults)
     {
+        $this->identifier = $identifier;
         $this->iterationsResults = $iterationsResults;
         $this->name = $name;
         $this->description = $description;
         $this->groups = $groups;
+        $this->parameters = $parameters;
     }
 
     public function getName()
@@ -44,5 +48,15 @@ class SubjectResult
     public function getGroups()
     {
         return $this->groups;
+    }
+
+    public function getParameters() 
+    {
+        return $this->parameters;
+    }
+
+    public function getIdentifier() 
+    {
+        return $this->identifier;
     }
 }

--- a/tests/Functional/Console/Command/RunCommandTest.php
+++ b/tests/Functional/Console/Command/RunCommandTest.php
@@ -148,8 +148,9 @@ class RunCommandTest extends BaseCommandTestCase
         $dom = new \DOMDocument();
         $dom->loadXml($display);
         $xpath = new \DOMXPath($dom);
+        $dom->formatOutput = true;
         $benchmarkEls = $xpath->query('//subject');
-        $this->assertEquals(3, $benchmarkEls->length);
+        $this->assertEquals(6, $benchmarkEls->length);
     }
 
     /**

--- a/tests/Functional/benchmarks/BenchmarkBench.php
+++ b/tests/Functional/benchmarks/BenchmarkBench.php
@@ -48,7 +48,8 @@ class BenchmarkBench implements Benchmark
     /**
      * @paramProvider provideParamsOne
      * @paramProvider provideParamsTwo
-     * @description Parameterized bench mark
+     * @description Parameterized bench mark strategy: {strategy}, length: {length}
+     * @group parameterized
      * @iterations 1
      */
     public function benchParameterized(Iteration $iteration)

--- a/tests/Unit/Benchmark/ParserTest.php
+++ b/tests/Unit/Benchmark/ParserTest.php
@@ -13,9 +13,6 @@ namespace PhpBench\Tests\Benchmark;
 
 use PhpBench\Benchmark\Parser;
 
-require_once __DIR__ . '/parsertest/ParserCase.php';
-require_once __DIR__ . '/parsertest/ParserCaseInvalidAnnotation.php';
-
 class ParserTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()

--- a/tests/Unit/Benchmark/RunnerTest.php
+++ b/tests/Unit/Benchmark/RunnerTest.php
@@ -35,13 +35,12 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
     /**
      * It should run the tests.
      *
-     * - With 1 iteration, 1 revolution and with two parameter providers
-     * - With 1 iteration, 4 revolution and zero parameter providers
-     * - With 1 iteration, 4 iterations and one parameter provider
+     * - With 1 iteration, 1 revolution
+     * - With 1 iteration, 4 revolutions
      *
      * @dataProvider provideRunner
      */
-    public function testRunner($iterations, $revs, $paramProviders, $expectedNbCalls)
+    public function testRunner($iterations, $revs, $expectedNbCalls)
     {
         $this->collectionBuilder->buildCollection()->willReturn($this->collection);
         $this->collection->getBenchmarks()->willReturn(array(
@@ -51,10 +50,11 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
             $this->subject->reveal(),
         ));
         $this->subject->getNbIterations()->willReturn($iterations);
-        $this->subject->getParameterProviders()->willReturn($paramProviders);
         $this->subject->getMethodName()->willReturn('benchFoo');
         $this->subject->getBeforeMethods()->willReturn(array('beforeFoo'));
         $this->subject->getDescription()->willReturn('Hello world');
+        $this->subject->getIdentifier()->willReturn(1);
+        $this->subject->getParameters()->willReturn(array());
         $this->subject->getGroups()->willReturn(array());
         $this->subject->getProcessIsolation()->willReturn(false);
         $this->subject->getRevs()->willReturn($revs);
@@ -74,21 +74,16 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
             array(
                 1,
                 array(1),
-                array(
-                    'paramSetOne', 'paramSetTwo',
-                ),
-                2,
+                1,
             ),
             array(
                 1,
                 array(1, 3),
-                array(),
                 4,
             ),
             array(
                 1,
                 array(1, 3),
-                array('paramSetTwo'),
                 4,
             ),
         );
@@ -110,32 +105,11 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
             $this->subject->reveal(),
         ));
         $this->subject->getNbIterations()->willReturn(1);
-        $this->subject->getParameterProviders()->willReturn(array());
+        $this->subject->getIdentifier()->willReturn(1);
+        $this->subject->getParameters()->willReturn(array());
         $this->subject->getBeforeMethods()->willReturn(array('beforeFooNotExisting'));
         $this->subject->getProcessIsolation()->willReturn(false);
         $this->subject->getRevs()->willReturn(array(1));
-
-        $this->runner->runAll();
-    }
-
-    /**
-     * It should throw an exception if a parameter provider does not exist.
-     *
-     * @expectedException PhpBench\Exception\InvalidArgumentException
-     * @expectedExceptionMessage Unknown param provider "notExistingParam" for bench benchmark
-     */
-    public function testInvalidParamProvider()
-    {
-        $this->collectionBuilder->buildCollection()->willReturn($this->collection);
-        $this->collection->getBenchmarks()->willReturn(array(
-            $this->case,
-        ));
-        $this->subjectBuilder->buildSubjects($this->case)->willReturn(array(
-            $this->subject->reveal(),
-        ));
-        $this->subject->getNbIterations()->willReturn(1);
-        $this->subject->getParameterProviders()->willReturn(array('notExistingParam'));
-        $this->subject->getProcessIsolation()->willReturn(false);
 
         $this->runner->runAll();
     }
@@ -152,7 +126,8 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         $this->subjectBuilder->buildSubjects($this->case)->willReturn(array(
             $this->subject->reveal(),
         ));
-        $this->subject->getParameterProviders()->willReturn(array());
+        $this->subject->getIdentifier()->willReturn(1);
+        $this->subject->getParameters()->willReturn(array());
         $this->subject->getMethodName()->willReturn('benchFoo');
         $this->subject->getDescription()->willReturn('benchFoo');
         $this->subject->getGroups()->willReturn(array());
@@ -185,7 +160,8 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         $this->subjectBuilder->buildSubjects($this->case)->willReturn(array(
             $this->subject->reveal(),
         ));
-        $this->subject->getParameterProviders()->willReturn(array());
+        $this->subject->getIdentifier()->willReturn(1);
+        $this->subject->getParameters()->willReturn(array());
         $this->subject->getMethodName()->willReturn('benchFoo');
         $this->subject->getDescription()->willReturn('benchFoo');
         $this->subject->getGroups()->willReturn(array());

--- a/tests/Unit/Benchmark/subject-builder-test/SubjectBuilderCase.php
+++ b/tests/Unit/Benchmark/subject-builder-test/SubjectBuilderCase.php
@@ -15,12 +15,11 @@ use PhpBench\Benchmark;
 /**
  * @group group1
  */
-class ParserCase implements Benchmark
+class SubjectBuilderCase implements Benchmark
 {
     /**
      * @beforeMethod beforeSelectSql
-     * @paramProvider provideNodes
-     * @paramProvider provideColumns
+     * @paramProvider provideNumbers
      * @iterations 3
      * @description Run a select query
      */
@@ -30,12 +29,19 @@ class ParserCase implements Benchmark
 
     /**
      * @beforeMethod setupSelectSql
-     * @paramProvider provideNodes
-     * @paramProvider provideColumns
      * @iterations 3
      * @description Run a select query
      */
     public function benchTraverseSomething(BenchIteration $iteration)
     {
+    }
+
+    public function provideNumbers()
+    {
+        return array(
+            array(
+                'one', 'two',
+            )
+        );
     }
 }

--- a/tests/Unit/Benchmark/subject-builder-test/SubjectBuilderCaseInvalidParamProvider.php
+++ b/tests/Unit/Benchmark/subject-builder-test/SubjectBuilderCaseInvalidParamProvider.php
@@ -12,10 +12,10 @@
 use PhpBench\BenchIteration;
 use PhpBench\Benchmark;
 
-class ParserCaseInvalidAnnotation implements Benchmark
+class SubjectBuilderCaseInvalidParamProvider implements Benchmark
 {
     /**
-     * @inasdld beforeSelectSql
+     * @paramProvider notExistingParam
      */
     public function benchSelectSql(BenchIteration $iteration)
     {

--- a/tests/Unit/Report/Cellular/CellularConverterTest.php
+++ b/tests/Unit/Report/Cellular/CellularConverterTest.php
@@ -33,9 +33,9 @@ class CellularConverterTest extends \PHPUnit_Framework_TestCase
             'memory_diff' => 123,
             'pid' => 1234,
         ));
-        $iterations = new IterationsResult(array($iteration1), array());
-        $subject1 = new SubjectResult('mySubject1', 'My Subject\'s description', array('one', 'two'), array($iterations));
-        $subject2 = new SubjectResult('mySubject2', 'My Subject\'s description', array('one', 'two'), array($iterations));
+        $iterations = new IterationsResult(array($iteration1));
+        $subject1 = new SubjectResult(1, 'mySubject1', 'My Subject\'s description', array('one', 'two'), array(), array($iterations));
+        $subject2 = new SubjectResult(2, 'mySubject2', 'My Subject\'s description', array('one', 'two'), array(), array($iterations));
         $benchmark1 = new BenchmarkResult('Benchmark\Foo', array($subject1, $subject2));
         $suite = new SuiteResult(array($benchmark1));
 

--- a/tests/Unit/Report/Cellular/Step/ReplaceDescriptionTokensStepTest.php
+++ b/tests/Unit/Report/Cellular/Step/ReplaceDescriptionTokensStepTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace PhpBench\Tests\Unit\Report\Cellular\Step;
+
+use PhpBench\Report\Cellular\Step\ReplaceDescriptionTokensStep;
+use DTL\Cellular\Workspace;
+
+class ReplaceDescriptionTokensStepTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * It should replace the description tokens with the subject parameters
+     */
+    public function testReplaceTokens()
+    {
+        $workspace = Workspace::create();
+        $table = $workspace->createAndAddTable();
+        $table->setAttribute('description', 'Hello {name}, look! there is a {animal}');
+        $table->setAttribute('parameters', array('name' => 'Daniel', 'animal' => 'Elephant'));
+
+        $table = $workspace->createAndAddTable();
+        $table->setAttribute('description', 'Hello {name}, look! there is a {animal}');
+        $table->setAttribute('parameters', array('name' => 'Amy', 'animal' => 'Rabbit'));
+
+        $step = new ReplaceDescriptionTokensStep();
+        $step->step($workspace);
+
+        $this->assertEquals(
+            'Hello "Daniel", look! there is a "Elephant"',
+            $workspace->getTable(0)->getAttribute('description')
+        );
+
+        $this->assertEquals(
+            'Hello "Amy", look! there is a "Rabbit"',
+            $workspace->getTable(1)->getAttribute('description')
+        );
+    }
+
+    /**
+     * It should leave any non-matching tokens in-place
+     */
+    public function testReplaceTokensNonMatching()
+    {
+        $workspace = Workspace::create();
+        $table = $workspace->createAndAddTable();
+        $table->setAttribute('description', 'Hello {name}, look! there is a {animal}');
+        $table->setAttribute('parameters', array('name' => 'Daniel'));
+
+        $step = new ReplaceDescriptionTokensStep();
+        $step->step($workspace);
+
+        $this->assertEquals(
+            'Hello "Daniel", look! there is a {animal}',
+            $workspace->getTable(0)->getAttribute('description')
+        );
+    }
+}

--- a/tests/Unit/Result/Dumper/XmlDumperTest.php
+++ b/tests/Unit/Result/Dumper/XmlDumperTest.php
@@ -33,19 +33,19 @@ class XmlDumperTest extends \PHPUnit_Framework_TestCase
         $expected = <<<EOT
   <suite>
     <benchmark class="Benchmark\Class">
-      <subject name="mySubject" description="My Subject's description">
+      <subject identifier="1" name="mySubject" description="My Subject's description">
+        <parameter name="foo" value="bar"/>
+        <parameter name="array" multiple="1">
+          <parameter name="0" value="one"/>
+          <parameter name="1" value="two"/>
+        </parameter>
+        <parameter name="assoc_array" multiple="1">
+          <parameter name="one" value="two"/>
+          <parameter name="three" value="four"/>
+        </parameter>
         <group name="one"/>
         <group name="two"/>
         <iterations>
-          <parameter name="foo" value="bar"/>
-          <parameter name="array" multiple="1">
-            <parameter name="0" value="one"/>
-            <parameter name="1" value="two"/>
-          </parameter>
-          <parameter name="assoc_array" multiple="1">
-            <parameter name="one" value="two"/>
-            <parameter name="three" value="four"/>
-          </parameter>
           <iteration revs="1" time="100"/>
         </iterations>
       </subject>
@@ -63,15 +63,22 @@ EOT;
     protected function getSuite()
     {
         $iteration1 = new IterationResult(array('revs' => 1, 'time' => 100));
-        $iterations = new IterationsResult(array($iteration1), array(
-            'foo' => 'bar',
-            'array' => array('one', 'two'),
-            'assoc_array' => array(
-                'one' => 'two',
-                'three' => 'four',
+        $iterations = new IterationsResult(array($iteration1));
+        $subject = new SubjectResult(
+            1,
+            'mySubject',
+            'My Subject\'s description',
+            array('one', 'two'),
+            array(
+                'foo' => 'bar',
+                'array' => array('one', 'two'),
+                'assoc_array' => array(
+                    'one' => 'two',
+                    'three' => 'four',
+                ),
             ),
-        ));
-        $subject = new SubjectResult('mySubject', 'My Subject\'s description', array('one', 'two'), array($iterations));
+            array($iterations)
+        );
         $benchmark = new BenchmarkResult('Benchmark\Class', array($subject));
         $suite = new SuiteResult(array($benchmark));
 


### PR DESCRIPTION
Parameter sets are now unique for each Subject.

TODO:

- Allow token substitution in subject description for parameters
- `runs` are now not required, and should probably be removed if so.
- If above, remove `runs` aggregation step, consider making aggregation a boolean for reports.

Will fix #92