### PR TITLE
Use the benchmark class name in results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 CHANGELOG
 =========
 
+0.5
+---
+
+- Configuration changed to JSON format
+- Dependency Injection Container
+- Extension API
+- Major refactoring of reports, old console report does not exist.
+- Separation of reports and generators. Reports are registered as
+  configurations, reports must be explicitly called on the CLI in order for
+  them to be generated.
+- New "composite" report for generating multiple reports at one time.
+- Removal of the "description" annotation.
+
 0.4
 ---
 

--- a/README.md
+++ b/README.md
@@ -64,19 +64,6 @@ accepts an `Iteration` from which can be accessed contextual information.
 You can annotate **both** the class and the subject methods with any of the 
 following annotations:
 
-### @description
-
-**singular**
-
-A description of the benchmark subject. If you have parameterized the subject
-you may use the parameter values in the description as follows:
-
-````php
-/**
- * @description Do something %param_name% times with the %another_param% thing.
- */
-````
-
 ### @group
 
 **plural**
@@ -231,9 +218,6 @@ use PhpBench\Benchmark;
  */
 class SomeBenchmarkBench implements Benchmark
 {
-    /**
-     * @description randomBench
-     */
     public function benchRandom(Iteration $iteration)
     {
         usleep(rand(0, 50000));
@@ -241,14 +225,12 @@ class SomeBenchmarkBench implements Benchmark
 
     /**
      * @iterations 3
-     * @description Do nothing three times
      */
     public function benchDoNothing(Iteration $iteration)
     {
     }
 
     /**
-     * @description Each iteration will be in an isolated process
      * @processIsolation iteration
      */
     public function benchSomethingIsolated()
@@ -256,7 +238,6 @@ class SomeBenchmarkBench implements Benchmark
     /**
      * @paramProvider provideParamsOne
      * @paramProvider provideParamsTwo
-     * @description Parameterized bench mark
      * @iterations 1
      */
     public function benchParameterized(Iteration $iteration)

--- a/examples/ArrayKeysBench.php
+++ b/examples/ArrayKeysBench.php
@@ -35,25 +35,16 @@ class ArrayKeysBench implements Benchmark
         $this->values = array_combine(array_keys($this->array), array_keys($this->array));
     }
 
-    /**
-     * @description array_key_exists
-     */
     public function benchArrayKeyExists($iteration, $revolution)
     {
         array_key_exists($revolution, $this->array);
     }
 
-    /**
-     * @description isset
-     */
     public function benchIsset($iteration, $revolution)
     {
         isset($this->array[$revolution]);
     }
 
-    /**
-     * @description in_array
-     */
     public function benchInArray($iteration, $revolution)
     {
         in_array($revolution, $this->values);

--- a/examples/CostOfReflectionBench.php
+++ b/examples/CostOfReflectionBench.php
@@ -33,7 +33,6 @@ class CostOfReflectionBench implements Benchmark
     }
 
     /**
-     * @description Set public class property via. a setter
      * @group cost_of_setting
      */
     public function benchMethodSet()
@@ -42,7 +41,6 @@ class CostOfReflectionBench implements Benchmark
     }
 
     /**
-     * @description Set public class property
      * @group cost_of_setting
      */
     public function benchPublicProperty()
@@ -51,7 +49,6 @@ class CostOfReflectionBench implements Benchmark
     }
 
     /**
-     * @description Set public class property via. reflection
      * @group cost_of_setting
      */
     public function benchPublicReflection()
@@ -60,7 +57,6 @@ class CostOfReflectionBench implements Benchmark
     }
 
     /**
-     * @description Set private class property via. reflection
      * @group cost_of_setting
      */
     public function benchPrivateReflection()
@@ -69,7 +65,6 @@ class CostOfReflectionBench implements Benchmark
     }
 
     /**
-     * @description Instantiate new class
      * @group cost_of_instantiation
      */
     public function benchNewClass()
@@ -78,7 +73,6 @@ class CostOfReflectionBench implements Benchmark
     }
 
     /**
-     * @description Reflection new class
      * @group cost_of_instantiation
      */
     public function benchReflectionNewInstance()

--- a/lib/Benchmark/Parser.php
+++ b/lib/Benchmark/Parser.php
@@ -23,14 +23,13 @@ class Parser
             'beforeMethod' => array(),
             'paramProvider' => array(),
             'iterations' => array(),
-            'description' => array(),
             'processIsolation' => array(),
             'group' => array(),
             'revs' => array(),
         );
 
         // singular annotations
-        foreach (array('description', 'iterations', 'processIsolation') as $key) {
+        foreach (array('iterations', 'processIsolation') as $key) {
             if (isset($defaults[$key]) && $defaults[$key]) {
                 $meta[$key][] = $defaults[$key];
             }
@@ -62,7 +61,7 @@ class Parser
         }
 
         // Do not allow these annotations to be redelared twice in the same docblock
-        foreach (array('description', 'iterations', 'processIsolation') as $key) {
+        foreach (array('iterations', 'processIsolation') as $key) {
             // allow overriding single values
             if (count($meta[$key] == 2) && !empty($defaults[$key]) && count($defaults[$key]) == 1) {
                 $value = array_pop($meta[$key]);
@@ -76,7 +75,6 @@ class Parser
             }
         }
 
-        $meta['description'] = reset($meta['description']);
         $meta['processIsolation'] = reset($meta['processIsolation']);
         $iterations = $meta['iterations'];
         $meta['iterations'] = empty($iterations) ? 1 : (int) reset($iterations);

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -162,7 +162,6 @@ class Runner
         $subjectResult = new SubjectResult(
             $subject->getIdentifier(),
             $subject->getMethodName(),
-            $subject->getDescription(),
             $subject->getGroups(),
             $subject->getParameters(),
             $iterationsResults

--- a/lib/Benchmark/Subject.php
+++ b/lib/Benchmark/Subject.php
@@ -22,7 +22,6 @@ class Subject
     private $beforeMethods;
     private $parameters;
     private $nbIterations;
-    private $description;
     private $processIsolation;
     private $revs;
     private $groups;
@@ -35,7 +34,6 @@ class Subject
      * @param array $parameters
      * @param mixed $nbIterations
      * @param array $revs
-     * @param mixed $description
      * @param mixed $processIsolation
      * @param array $groups
      */
@@ -46,7 +44,6 @@ class Subject
         array $parameters,
         $nbIterations,
         array $revs,
-        $description,
         $processIsolation,
         array $groups
     ) {
@@ -56,7 +53,6 @@ class Subject
         $this->parameters = $parameters;
         $this->nbIterations = $nbIterations;
         $this->revs = $revs;
-        $this->description = $description;
         $this->processIsolation = $processIsolation;
         $this->groups = $groups;
     }
@@ -90,16 +86,6 @@ class Subject
     public function getNbIterations()
     {
         return $this->nbIterations;
-    }
-
-    /**
-     * Return a description of this subject
-     *
-     * @return string
-     */
-    public function getDescription()
-    {
-        return $this->description;
     }
 
     /**

--- a/lib/Benchmark/SubjectBuilder.php
+++ b/lib/Benchmark/SubjectBuilder.php
@@ -87,7 +87,6 @@ class SubjectBuilder
                 $parameters,
                 $meta['iterations'],
                 $meta['revs'],
-                $meta['description'],
                 $meta['processIsolation'],
                 $meta['group']
             );

--- a/lib/Report/Dom/PhpBenchXpath.php
+++ b/lib/Report/Dom/PhpBenchXpath.php
@@ -25,6 +25,7 @@ class PhpBenchXpath extends \DOMXpath
             'PhpBench\Report\Dom\functions\max',
             'PhpBench\Report\Dom\functions\median',
             'PhpBench\Report\Dom\functions\parameters_to_json',
+            'PhpBench\Report\Dom\functions\class_name',
         ));
     }
 

--- a/lib/Report/Dom/xpath_functions.php
+++ b/lib/Report/Dom/xpath_functions.php
@@ -43,3 +43,10 @@ function parameters_to_json($values)
 
     return json_encode($array);
 }
+
+function class_name($classFqn)
+{
+    $parts = explode('\\', $classFqn);
+    end($parts);
+    return current($parts);
+}

--- a/lib/Report/Generator/ConsoleTableGenerator.php
+++ b/lib/Report/Generator/ConsoleTableGenerator.php
@@ -45,12 +45,12 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
             'title' => null,
             'description' => null,
             'selector' => '//iteration',
-            'headers' => array('Subject', 'Group', 'Params', 'Description', 'PID', 'Mem.', 'Mem. Diff', 'Revs', 'Iter.', 'Time', 'Rps', 'Deviation'),
+            'headers' => array('Benchmark', 'Subject', 'Group', 'Params', 'PID', 'Mem.', 'Mem. Diff', 'Revs', 'Iter.', 'Time', 'Rps', 'Deviation'),
             'cells' => array(
+                'benchmark' => 'string(php:bench(\'class_name\', string(ancestor-or-self::benchmark/@class)))',
                 'subject' => 'string(../../@name)',
                 'group' => 'string(../../group/@name)',
-                'params' => 'php:bench(\'parameters_to_json\', ../../parameter)',
-                'description' => 'string(../../@description)',
+                'params' => 'php:bench(\'parameters_to_json\', ancestor::subject/parameter)',
                 'pid' => 'number(./@pid)',
                 'memory' => 'number(.//@memory)',
                 'memory_diff' => 'number(.//@memory_diff)',
@@ -213,9 +213,10 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
             'aggregate' => array(
                 'extends' => 'full',
                 'selector' => '//iterations',
-                'headers' => array('Description', 'Params', 'Sum Revs.', 'Nb. Iters.', 'Av. Time', 'Av. RPS', 'Stability', 'Deviation'),
+                'headers' => array('Benchmark', 'Subject', 'Params', 'Sum Revs.', 'Nb. Iters.', 'Av. Time', 'Av. RPS', 'Stability', 'Deviation'),
                 'cells' => array(
-                    'description' => 'string(ancestor-or-self::subject/@description)',
+                    'benchmark' => 'string(php:bench(\'class_name\', string(ancestor-or-self::benchmark/@class)))',
+                    'subject' => 'string(ancestor-or-self::subject/@name)',
                     'params' => 'php:bench(\'parameters_to_json\', ancestor-or-self::subject/parameter)',
                     'revs' => 'number(sum(.//@revs))',
                     'iters' => 'number(count(descendant::iteration))',
@@ -229,7 +230,7 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
                 ),
                 'format' => array(
                     'revs' => '!number',
-                    'rps' => array('!number', '%s<comment>rps</comment>'),
+                    'rps' => array('%.2f', '%s<comment>rps</comment>'),
                     'time' => array('!number', '%s<comment>μs</comment>'),
                     'stability' => array('%.2f', '%s<comment>%%</comment>'),
                     'deviation' => array('%.2f', '!balance', '%s<comment>%%</comment>'),

--- a/lib/Result/Dumper/XmlDumper.php
+++ b/lib/Result/Dumper/XmlDumper.php
@@ -71,7 +71,6 @@ class XmlDumper
         $subjectEl = $dom->createElement('subject');
         $subjectEl->setAttribute('identifier', $subjectResult->getIdentifier());
         $subjectEl->setAttribute('name', $subjectResult->getName());
-        $subjectEl->setAttribute('description', $subjectResult->getDescription());
 
         $parameters = $subjectResult->getParameters();
         $this->appendParameters($subjectEl, $parameters);

--- a/lib/Result/Loader/XmlLoader.php
+++ b/lib/Result/Loader/XmlLoader.php
@@ -57,11 +57,10 @@ class XmlLoader
         foreach ($xpath->query('./subject', $benchmarkEl) as $subjectEl) {
             $identifier = $subjectEl->getAttribute('identifier');
             $name = $subjectEl->getAttribute('name');
-            $description = $subjectEl->getAttribute('description');
             $iterationsResults = $this->getIterationsResults($xpath, $subjectEl);
             $groups = $this->getGroups($xpath, $subjectEl);
             $parameters = $this->getParametersForNode($xpath, $subjectEl);
-            $subjectResults[] = new SubjectResult($identifier, $name, $description, $groups, $parameters, $iterationsResults);
+            $subjectResults[] = new SubjectResult($identifier, $name, $groups, $parameters, $iterationsResults);
         }
 
         return $subjectResults;

--- a/lib/Result/SubjectResult.php
+++ b/lib/Result/SubjectResult.php
@@ -15,17 +15,15 @@ class SubjectResult
 {
     private $identifier;
     private $name;
-    private $description;
     private $groups;
     private $iterationsResults;
     private $parameters;
 
-    public function __construct($identifier, $name, $description, array $groups, array $parameters, array $iterationsResults)
+    public function __construct($identifier, $name, array $groups, array $parameters, array $iterationsResults)
     {
         $this->identifier = $identifier;
         $this->iterationsResults = $iterationsResults;
         $this->name = $name;
-        $this->description = $description;
         $this->groups = $groups;
         $this->parameters = $parameters;
     }
@@ -33,11 +31,6 @@ class SubjectResult
     public function getName()
     {
         return $this->name;
-    }
-
-    public function getDescription()
-    {
-        return $this->description;
     }
 
     public function getIterationsResults()

--- a/tests/Functional/Console/Command/ReportCommandTest.php
+++ b/tests/Functional/Console/Command/ReportCommandTest.php
@@ -24,7 +24,7 @@ class ReportCommandTest extends BaseCommandTestCase
         ));
         $this->assertEquals(0, $tester->getStatusCode());
         $display = $tester->getDisplay();
-        $this->assertContains('Parameterized bench', $display);
+        $this->assertContains('benchParameterized', $display);
     }
 
     /**

--- a/tests/Functional/Console/Command/RunCommandTest.php
+++ b/tests/Functional/Console/Command/RunCommandTest.php
@@ -55,7 +55,7 @@ class RunCommandTest extends BaseCommandTestCase
         ));
         $this->assertEquals(0, $tester->getStatusCode());
         $display = $tester->getDisplay();
-        $this->assertContains('Parameterized bench mark', $display);
+        $this->assertContains('bench', $display);
     }
 
     /**
@@ -82,7 +82,7 @@ class RunCommandTest extends BaseCommandTestCase
         ));
         $this->assertEquals(0, $tester->getStatusCode());
         $display = $tester->getDisplay();
-        $this->assertContains('Parameterized bench mark', $display);
+        $this->assertContains('benchParameterized', $display);
     }
 
     /**
@@ -99,7 +99,7 @@ class RunCommandTest extends BaseCommandTestCase
         ));
         $this->assertEquals(0, $tester->getStatusCode());
         $display = $tester->getDisplay();
-        $this->assertContains('Parameterized bench mark', $display);
+        $this->assertContains('benchParameterized', $display);
     }
 
     /**
@@ -116,7 +116,7 @@ class RunCommandTest extends BaseCommandTestCase
         ));
         $this->assertEquals(0, $tester->getStatusCode());
         $display = $tester->getDisplay();
-        $this->assertContains('Parameterized bench mark', $display);
+        $this->assertContains('benchParameterized', $display);
     }
 
     /**

--- a/tests/Functional/benchmarks/BenchmarkBench.php
+++ b/tests/Functional/benchmarks/BenchmarkBench.php
@@ -27,9 +27,6 @@ class BenchmarkBench implements Benchmark
         self::$tearDownCalled = true;
     }
 
-    /**
-     * @description randomBench
-     */
     public function benchRandom(Iteration $iteration)
     {
         usleep(rand(0, 50000));
@@ -38,7 +35,6 @@ class BenchmarkBench implements Benchmark
     /**
      * @iterations 3
      * @revs 1000
-     * @description Do nothing three times
      * @group do_nothing
      */
     public function benchDoNothing(Iteration $iteration)
@@ -48,7 +44,6 @@ class BenchmarkBench implements Benchmark
     /**
      * @paramProvider provideParamsOne
      * @paramProvider provideParamsTwo
-     * @description Parameterized bench mark
      * @group parameterized
      * @iterations 1
      */

--- a/tests/Functional/benchmarks/IsolatedBench.php
+++ b/tests/Functional/benchmarks/IsolatedBench.php
@@ -14,7 +14,6 @@ use PhpBench\Benchmark;
 class IsolatedBench implements Benchmark
 {
     /**
-     * @description 5 iterations in isolation
      * @iterations 5
      */
     public function benchIterationIsolation()
@@ -25,7 +24,6 @@ class IsolatedBench implements Benchmark
     }
 
     /**
-     * @description Set of 5 iterations in isolation
      * @iterations 5
      */
     public function benchIterationsIsolation()

--- a/tests/Functional/benchmarks/IsolatedParametersBench.php
+++ b/tests/Functional/benchmarks/IsolatedParametersBench.php
@@ -15,7 +15,6 @@ use PhpBench\Benchmark;
 class IsolatedParameterBench implements Benchmark
 {
     /**
-     * @description This subject is executed in process isolation
      * @group process
      * @iterations 5
      * @processIsolation iteration

--- a/tests/Functional/benchmarks/IsolatedRevsBench.php
+++ b/tests/Functional/benchmarks/IsolatedRevsBench.php
@@ -14,7 +14,6 @@ use PhpBench\Benchmark;
 class IsolatedRevsBench implements Benchmark
 {
     /**
-     * @description 2 sets of revolitions
      * @revs 10
      * @revs 100
      */

--- a/tests/Functional/report.xml
+++ b/tests/Functional/report.xml
@@ -2,7 +2,7 @@
 <phpbench version="0.1" date="2015-05-25T09:24:11+02:00">
   <suite>
     <benchmark class="BenchmarkBench">
-      <subject name="benchRandom" description="randomBench">
+      <subject name="benchRandom">
         <iterations>
           <iteration pid="1234" index="0" revs="1" time="19253" memory="288" memory_diff="288" memory_inc="3050824" memory_diff_inc="31192"/>
         </iterations>
@@ -14,7 +14,7 @@
           <iteration pid="1234" index="2" revs="1" time="8" memory="576" memory_diff="192" memory_inc="3080544" memory_diff_inc="1336"/>
         </iterations>
       </subject>
-      <subject name="benchParameterized" description="Parameterized bench mark">
+      <subject name="benchParameterized">
         <iterations>
           <parameter name="length" value="1"/>
           <parameter name="strategy" value="left"/>
@@ -38,7 +38,7 @@
       </subject>
     </benchmark>
     <benchmark class="IsolatedBench">
-      <subject name="benchIterationIsolation" description="5 iterations in isolation">
+      <subject name="benchIterationIsolation">
         <iterations>
           <iteration pid="1234" index="0" revs="1" time="91" memory="248" memory_diff="248" memory_inc="3096448" memory_diff_inc="2840"/>
           <iteration pid="1234" index="1" revs="1" time="37" memory="440" memory_diff="192" memory_inc="3097768" memory_diff_inc="1320"/>
@@ -47,7 +47,7 @@
           <iteration pid="1234" index="4" revs="1" time="29" memory="1016" memory_diff="192" memory_inc="3101776" memory_diff_inc="1336"/>
         </iterations>
       </subject>
-      <subject name="benchIterationsIsolation" description="Set of 5 iterations in isolation">
+      <subject name="benchIterationsIsolation">
         <iterations>
           <iteration pid="1234" index="0" revs="1" time="34" memory="248" memory_diff="248" memory_inc="3104272" memory_diff_inc="2840"/>
           <iteration pid="1234" index="1" revs="1" time="30" memory="440" memory_diff="192" memory_inc="3105592" memory_diff_inc="1320"/>
@@ -58,7 +58,7 @@
       </subject>
     </benchmark>
     <benchmark class="IsolatedParameterBench">
-      <subject name="benchIterationIsolation" description="randomBench">
+      <subject name="benchIterationIsolation">
         <iterations>
           <parameter name="hello" value="Look &quot;I am using double quotes&quot;"/>
           <parameter name="goodbye" value="Look 'I am use $dollars&quot;"/>

--- a/tests/Unit/Benchmark/ParserTest.php
+++ b/tests/Unit/Benchmark/ParserTest.php
@@ -38,7 +38,6 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             array(
                 <<<EOT
 /**
-* @description Hello
 * @beforeMethod beforeMe
 * @beforeMethod afterBeforeMe
 * @paramProvider provideParam
@@ -50,8 +49,6 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 */
 EOT
                 ,
-                array(
-                    'description' => 'Hello',
                     'iterations' => 3,
                     'beforeMethod' => array('beforeMe', 'afterBeforeMe'),
                     'paramProvider' => array('provideParam'),
@@ -67,7 +64,6 @@ EOT
 EOT
                 ,
                 array(
-                    'description' => '',
                     'beforeMethod' => array(),
                     'paramProvider' => array(),
                     'iterations' => 1,
@@ -106,7 +102,6 @@ EOT
         return array(
             array(
                 array(
-                    'description' => 'Hello',
                     'iterations' => 3,
                     'beforeMethod' => array('beforeMe', 'afterBeforeMe'),
                     'paramProvider' => array('provideParam'),
@@ -116,7 +111,6 @@ EOT
                 ),
                 <<<EOT
 /**
-* @description Hallo
 * @beforeMethod again
 * @paramProvider notherParam
 * @iterations 3
@@ -127,7 +121,6 @@ EOT
 EOT
                 ,
                 array(
-                    'description' => 'Hallo',
                     'iterations' => 3,
                     'beforeMethod' => array('beforeMe', 'afterBeforeMe', 'again'),
                     'paramProvider' => array('provideParam', 'notherParam'),
@@ -138,7 +131,6 @@ EOT
             ),
             array(
                 array(
-                    'description' => 'Hello',
                     'iterations' => 3,
                     'beforeMethod' => array('beforeMe', 'afterBeforeMe'),
                     'paramProvider' => array('provideParam'),
@@ -153,7 +145,6 @@ EOT
 EOT
                 ,
                 array(
-                    'description' => 'Hello',
                     'iterations' => 4,
                     'beforeMethod' => array('beforeMe', 'afterBeforeMe'),
                     'paramProvider' => array('provideParam'),
@@ -164,7 +155,6 @@ EOT
             ),
             array(
                 array(
-                    'description' => 'Hello',
                     'iterations' => 3,
                     'beforeMethod' => array('beforeMe', 'afterBeforeMe'),
                     'paramProvider' => array('provideParam'),
@@ -173,7 +163,6 @@ EOT
                 ),
                 '/** */',
                 array(
-                    'description' => 'Hello',
                     'iterations' => 3,
                     'beforeMethod' => array('beforeMe', 'afterBeforeMe'),
                     'paramProvider' => array('provideParam'),
@@ -186,7 +175,7 @@ EOT
     }
 
     /**
-     * It should throw an exception if more than one description annotation is present.
+     * It should throw an exception if more than one process isolation annotation is present.
      *
      * @expectedException \InvalidArgumentException
      */
@@ -194,8 +183,8 @@ EOT
     {
         $doc = <<<EOT
 /**
- * @description One
- * @description Two
+ * @processIsolation iteration
+ * @processIsolation iterations
  */
 EOT;
         $this->parser->parseDoc($doc);
@@ -227,7 +216,6 @@ EOT;
     {
         $doc = <<<EOT
 /**
-* @description Hello
 * @processIsolation iterationasd
 */
 EOT

--- a/tests/Unit/Benchmark/ParserTest.php
+++ b/tests/Unit/Benchmark/ParserTest.php
@@ -48,7 +48,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 * @group base
 */
 EOT
-                ,
+                , array(
                     'iterations' => 3,
                     'beforeMethod' => array('beforeMe', 'afterBeforeMe'),
                     'paramProvider' => array('provideParam'),

--- a/tests/Unit/Benchmark/RunnerTest.php
+++ b/tests/Unit/Benchmark/RunnerTest.php
@@ -52,7 +52,6 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         $this->subject->getNbIterations()->willReturn($iterations);
         $this->subject->getMethodName()->willReturn('benchFoo');
         $this->subject->getBeforeMethods()->willReturn(array('beforeFoo'));
-        $this->subject->getDescription()->willReturn('Hello world');
         $this->subject->getIdentifier()->willReturn(1);
         $this->subject->getParameters()->willReturn(array());
         $this->subject->getGroups()->willReturn(array());
@@ -127,7 +126,6 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         $this->subject->getIdentifier()->willReturn(1);
         $this->subject->getParameters()->willReturn(array());
         $this->subject->getMethodName()->willReturn('benchFoo');
-        $this->subject->getDescription()->willReturn('benchFoo');
         $this->subject->getGroups()->willReturn(array());
         $this->subject->getNbIterations()->willReturn(0);
         $this->subject->getProcessIsolation()->willReturn(false);
@@ -155,7 +153,6 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         $this->subject->getIdentifier()->willReturn(1);
         $this->subject->getParameters()->willReturn(array());
         $this->subject->getMethodName()->willReturn('benchFoo');
-        $this->subject->getDescription()->willReturn('benchFoo');
         $this->subject->getGroups()->willReturn(array());
         $this->subject->getNbIterations()->willReturn(0);
         $this->subject->getProcessIsolation()->willReturn(false);

--- a/tests/Unit/Benchmark/SubjectBuilderTest.php
+++ b/tests/Unit/Benchmark/SubjectBuilderTest.php
@@ -40,7 +40,6 @@ class SubjectBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('one', 'two'), $subject->getParameters());
         $this->assertEquals(3, $subject->getNbIterations());
         $this->assertInternalType('int', $subject->getNbIterations());
-        $this->assertEquals('Run a select query', $subject->getDescription());
     }
 
     /**

--- a/tests/Unit/Benchmark/subject-builder-test/SubjectBuilderCase.php
+++ b/tests/Unit/Benchmark/subject-builder-test/SubjectBuilderCase.php
@@ -21,7 +21,6 @@ class SubjectBuilderCase implements Benchmark
      * @beforeMethod beforeSelectSql
      * @paramProvider provideNumbers
      * @iterations 3
-     * @description Run a select query
      */
     public function benchSelectSql(BenchIteration $iteration)
     {
@@ -30,7 +29,6 @@ class SubjectBuilderCase implements Benchmark
     /**
      * @beforeMethod setupSelectSql
      * @iterations 3
-     * @description Run a select query
      */
     public function benchTraverseSomething(BenchIteration $iteration)
     {

--- a/tests/Unit/Report/Generator/ConsoleTableGeneratorTest.php
+++ b/tests/Unit/Report/Generator/ConsoleTableGeneratorTest.php
@@ -132,7 +132,7 @@ class ConsoleTableGeneratorTest extends \PHPUnit_Framework_TestCase
             ),
             array($iterations)
         );
-        $benchmark = new BenchmarkResult('Benchmark\Class', 'Hallo', array($subject));
+        $benchmark = new BenchmarkResult('Benchmark\Class', array($subject));
         $suite = new SuiteResult(array($benchmark));
 
         return $suite;

--- a/tests/Unit/Report/Generator/ConsoleTableGeneratorTest.php
+++ b/tests/Unit/Report/Generator/ConsoleTableGeneratorTest.php
@@ -121,7 +121,6 @@ class ConsoleTableGeneratorTest extends \PHPUnit_Framework_TestCase
         $subject = new SubjectResult(
             1,
             'mySubject',
-            'My Subject\'s description',
             array('one', 'two'),
             array(
                 'foo' => 'bar',

--- a/tests/Unit/Report/Generator/ConsoleTableGeneratorTest.php
+++ b/tests/Unit/Report/Generator/ConsoleTableGeneratorTest.php
@@ -133,7 +133,7 @@ class ConsoleTableGeneratorTest extends \PHPUnit_Framework_TestCase
             ),
             array($iterations)
         );
-        $benchmark = new BenchmarkResult('Benchmark\Class', array($subject));
+        $benchmark = new BenchmarkResult('Benchmark\Class', 'Hallo', array($subject));
         $suite = new SuiteResult(array($benchmark));
 
         return $suite;

--- a/tests/Unit/Result/Dumper/XmlDumperTest.php
+++ b/tests/Unit/Result/Dumper/XmlDumperTest.php
@@ -33,7 +33,7 @@ class XmlDumperTest extends \PHPUnit_Framework_TestCase
         $expected = <<<EOT
   <suite>
     <benchmark class="Benchmark\Class">
-      <subject identifier="1" name="mySubject" description="My Subject's description">
+      <subject identifier="1" name="mySubject">
         <parameter name="foo" value="bar"/>
         <parameter name="array" multiple="1">
           <parameter name="0" value="one"/>
@@ -70,7 +70,6 @@ EOT;
         $subject = new SubjectResult(
             1,
             'mySubject',
-            'My Subject\'s description',
             array('one', 'two'),
             array(
                 'foo' => 'bar',

--- a/tests/Unit/Result/Loader/benchdump.xml
+++ b/tests/Unit/Result/Loader/benchdump.xml
@@ -1,6 +1,6 @@
 <suite>
 <benchmark class="Benchmark\Class">
-  <subject name="mySubject" description="My Subject's description">
+  <subject name="mySubject">
     <iterations>
       <parameter foo="bar"/>
       <iteration time="100"/>


### PR DESCRIPTION
Consider removeing the "description" annotation from subjects and rely only on the classname and subject name to infer what benchmarks relate to.