### PR TITLE
Changing to ansible-like iterators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
 
 script: 
   - phpunit
-  - php bin/phpbench run --config=examples/phpbench.json --dump-file=dump.xml
+  - php bin/phpbench run --config=examples/phpbench.json --dump-file=dump.xml --report=all
   - cat dump.xml
 
 matrix:

--- a/examples/phpbench.json
+++ b/examples/phpbench.json
@@ -3,32 +3,44 @@
     "path": "./",
     "reports": {
         "cost_of_setting": {
-            "extends": "console_aggregate",
+            "extends": "aggregate",
             "title": "Cost of Setting",
             "description": "Comparison of different ways of setting properties",
-            "selector": "//subject[group/@name='cost_of_setting']//iterations"
+            "sort": ["time"],
+            "params": {"selector": "//subject[group/@name='cost_of_setting']//iterations"}
         },
         "cost_of_instantiation": {
-            "extends": "console_aggregate",
+            "extends": "aggregate",
             "title": "Cost of Instantiation",
             "description": "Compares instantiating a class directly against instantiating via. Reflection",
-            "selector": "//subject[group/@name='cost_of_instantiation']//iterations"
+            "sort": ["time"],
+            "params": {"selector": "//subject[group/@name='cost_of_instantiation']//iterations"}
         },
-        "array_keys_100": {
-            "extends": "console_aggregate",
+        "array_keys": {
+            "generator": "console_table",
             "title": "Comparison of array location functions",
             "description": "This benchmark creates an array with 50,000 elements. Each subject checks the existence of the key with the index of the current revolution. (or in the case of in_arrey, for the value). 100 revolutions",
-            "selector": "//subject[group/@name='array_keys']//iterations[iteration[@revs=100]]"
-        },
-        "array_keys_10000": {
-            "extends": "console_simple",
-            "title": "Comparison of array location functions",
-            "description": "This benchmark creates an array with 50,000 elements. Each subject checks the existence of the key with the index of the current revolution. (or in the case of in_arrey, for the value). 1000 revolutions",
-            "selector": "//subject[group/@name='array_keys']//iterations/iteration[@revs=10000]"
+            "rows": [
+                {
+                    "cells": {
+                        "subject": "string(ancestor::subject/@name)",
+                        "elements": "string('{{ row.item }}')",
+                        "time": "string(php:bench('avg', ./iteration[@revs='{{ row.item }}']/@time))",
+                        "iters": "number(count(.//iteration))",
+                        "revs": "number(sum(.//iteration/@revs))",
+                        "deviation": {
+                            "expr": "number(php:bench('deviation', number(php:bench('min', //cell[@name=\"time\"])), number(./cell[@name=\"time\"])))",
+                            "post_process": true
+                        }
+                    },
+                    "with_query": "//subject[group/@name='array_keys']//iterations",
+                    "with_items": ["10", "100", "1000"]
+                }
+            ]
         },
         "all": {
             "generator": "composite",
-            "reports": ["cost_of_setting", "cost_of_instantiation", "array_keys_100", "array_keys_10000"]
+            "reports": ["cost_of_setting", "cost_of_instantiation", "array_keys"]
         }
     }
 }

--- a/lib/Report/Dom/PhpBenchXpath.php
+++ b/lib/Report/Dom/PhpBenchXpath.php
@@ -34,6 +34,13 @@ class PhpBenchXpath extends \DOMXpath
      */
     public function evaluate($expr, \DOMNode $context = null, $registerNodeNs = null)
     {
+        if (!is_scalar($expr)) {
+            throw new \InvalidArgumentException(sprintf(
+                __METHOD__ . ' must be passed a scalar XPath expression, got: %s',
+                print_r($expr, true)
+            ));
+        }
+
         $expr = preg_replace(
             '{php:bench\(\'([a-z]+)}', 
             'php:function(\'PhpBench\\Report\\Dom\\functions\\\$1',

--- a/lib/Report/Generator/ConsoleTableGenerator.php
+++ b/lib/Report/Generator/ConsoleTableGenerator.php
@@ -44,7 +44,6 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
         $options->setDefaults(array(
             'title' => null,
             'description' => null,
-            'headers' => array('Benchmark', 'Subject', 'Group', 'Params', 'PID', 'Mem.', 'Mem. Diff', 'Revs', 'Iter.', 'Time', 'Rps', 'Deviation'),
             'rows' => array(
                 array(
                     'cells' => array(
@@ -114,7 +113,7 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
         }
 
         $table = $this->createTable();
-        $table->setHeaders($config['headers']);
+        $table->setHeaders(array_keys($row));
         $table->setRows($rows);
         $this->renderTable($table);
         $this->output->writeln('');
@@ -231,7 +230,6 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
         return array(
             'aggregate' => array(
                 'extends' => 'full',
-                'headers' => array('Benchmark', 'Subject', 'Params', 'Sum Revs.', 'Nb. Iters.', 'Av. Time', 'Av. RPS', 'Stability', 'Deviation'),
                 'rows' => array(
                     array(
                         'cells' => array(
@@ -262,7 +260,6 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
             ),
             'simple' => array(
                 'extends' => 'full',
-                'headers' => array('Subject', 'Sum Revs.', 'Iter', 'Time', 'Av. RPS', 'Deviation'),
                 'exclude' => array('benchmark', 'description"', 'memory', 'memory_diff', 'params', 'pid', 'group'),
             ),
             'full' => array(

--- a/lib/Report/Generator/ConsoleTableGenerator.php
+++ b/lib/Report/Generator/ConsoleTableGenerator.php
@@ -37,7 +37,7 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
     /**
      * @var \DOMNode[]
      */
-    private $postProcessElements;
+    private $postProcessElements = array();
 
     public function __construct(XmlDumper $xmlDumper = null, Formatter $formatter = null)
     {
@@ -384,6 +384,8 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
 
     /**
      * Render the table. For Symfony 2.4 support.
+     *
+     * @param mixed $table
      */
     private function renderTable($table)
     {
@@ -409,6 +411,7 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
      * @param string $expression
      * @param string $item
      * @param string $context
+     * @return string
      */
     private function replaceItem($expression, $item, $context)
     {
@@ -423,7 +426,6 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
      *
      * @param string $string
      * @param array $parameters
-     *
      * @return string
      */
     private function replaceParameters($string, array $parameters)

--- a/lib/Report/Generator/ConsoleTableGenerator.php
+++ b/lib/Report/Generator/ConsoleTableGenerator.php
@@ -15,6 +15,7 @@ use PhpBench\Report\Dom\PhpBenchXpath;
 use PhpBench\Report\Util;
 use PhpBench\Report\Tool\Sort;
 use PhpBench\Report\Tool\Formatter;
+use PhpBench\Report\Tool\Assert;
 
 class ConsoleTableGenerator implements OutputAware, ReportGenerator
 {
@@ -32,6 +33,11 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
      * @var Formatter
      */
     private $formatter;
+
+    /**
+     * @var \DOMNode[]
+     */
+    private $postProcessElements;
 
     public function __construct(XmlDumper $xmlDumper = null, Formatter $formatter = null)
     {
@@ -64,7 +70,6 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
                     'with_query' => '//iteration',
                 ),
             ),
-            'post_process' => array(),
             'format' => array(
                 'revs' => '!number',
                 'rps' => array('!number', '%s<comment>rps</comment>'),
@@ -118,6 +123,7 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
             Sort::sortRows($rows, $config['sort']);
         }
 
+        $row = null;
         foreach ($rows as &$row) {
             foreach ($row as $colName => &$value) {
                 if (isset($config['format'][$colName])) {
@@ -127,7 +133,7 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
         }
 
         $table = $this->createTable();
-        $table->setHeaders(array_keys($row));
+        $table->setHeaders(array_keys($row ?: array()));
         $table->setRows($rows);
         $this->renderTable($table);
         $this->output->writeln('');
@@ -148,6 +154,8 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
         $xpath = new PhpBenchXpath($resultDom);
 
         foreach ($config['rows'] as $rowConfig) {
+            Assert::hasOnlyKeys(array('cells', 'with_query', 'with_items'), $rowConfig, 'report config key "rows"');
+
             if (!isset($rowConfig['cells'])) {
                 throw new \InvalidArgumentException(sprintf(
                     'The "rows" key must contain an array of row configurations,  and each configuration must contain at least a "cells" key with an array of key to expression pairs, got: %s',
@@ -172,19 +180,22 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
                     $tableEl->appendChild($tableRowEl);
 
                     foreach ($rowConfig['cells'] as $colName => $cellExpr) {
+                        $cellConfig = array();
                         $cellItems = array(null);
 
                         if (is_array($cellExpr)) {
-                            if (!array_key_exists('expr', $cellExpr)) {
+                            $cellConfig = $cellExpr;
+                            Assert::hasOnlyKeys(array('post_process', 'expr', 'with_items'), $cellConfig, 'cell configuration');
+                            if (!array_key_exists('expr', $cellConfig)) {
                                 throw new \InvalidArgumentException(
                                     'Cell configuration must have at least an "expr" key containing an XPath expression'
                                 );
                             }
                             if (array_key_exists('with_items', $cellExpr)) {
-                                $cellItems = $cellExpr['with_items'];
+                                $cellItems = $cellConfig['with_items'];
                             }
 
-                            $cellExpr = $cellExpr['expr'];
+                            $cellExpr = $cellConfig['expr'];
                         }
 
                         foreach ($cellItems as $cellItem) {
@@ -197,7 +208,9 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
                             $tableCellEl->setAttribute('name', $name);
                             $tableRowEl->appendChild($tableCellEl);
 
-                            if (in_array($name, $config['post_process'])) {
+                            if (isset($cellConfig['post_process']) && true === $cellConfig['post_process']) {
+                                $this->postProcessElements[] = $tableCellEl;
+                                $tableCellEl->setAttribute('post-process', 1);
                                 $value = $expr;
                             } else {
                                 $value = $this->evaluateExpression($xpath, $expr, $contextEl);
@@ -228,24 +241,12 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
     {
         $rows = array();
         $tableXpath = new PhpBenchXpath($tableDom);
-        foreach ($tableXpath->query('//row') as $rowEl) {
-            foreach ($config['post_process'] as $cellName) {
-                $expression = './cell[@name="' . $cellName .'"]';
-                $cellEls = $tableXpath->query($expression, $rowEl);
-
-                if (false === $cellEls) {
-                    throw new \InvalidArgumentException(sprintf(
-                        'Could not find cell with name "%s" using expression "%s" when post processing table',
-                        $cellName,
-                        $expression
-                    ));
-                }
-
-                $cellEl = $cellEls->item(0);
-                $cellExpr = $cellEl->nodeValue;
-                $value = $this->evaluateExpression($tableXpath, $cellExpr, $rowEl);
-                $cellEl->nodeValue = $value;
-            }
+        foreach ($tableXpath->query('//row/cell[@post-process="1"]') as $cellEl) {
+            $cellExpr = $cellEl->nodeValue;
+            $rowEls = $tableXpath->query('./ancestor::row', $cellEl);
+            $rowEl = $rowEls->item(0);
+            $value = $this->evaluateExpression($tableXpath, $cellExpr, $rowEl);
+            $cellEl->nodeValue = $value;
         }
 
         $rows = array();
@@ -266,48 +267,11 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
         return $rows;
     }
 
-    public function getDefaultReports()
-    {
-        return array(
-            'aggregate' => array(
-                'extends' => 'full',
-                'rows' => array(
-                    array(
-                        'cells' => array(
-                            'benchmark' => 'string(php:bench(\'class_name\', string(ancestor-or-self::benchmark/@class)))',
-                            'subject' => 'string(ancestor-or-self::subject/@name)',
-                            'params' => 'php:bench(\'parameters_to_json\', ancestor-or-self::subject/parameter)',
-                            'revs' => 'number(sum(.//@revs))',
-                            'iters' => 'number(count(descendant::iteration))',
-                            'time' => 'number(php:bench(\'avg\', descendant::iteration/@time))',
-                            'rps' => '(1000000 div number(php:bench(\'avg\', descendant::iteration/@time)) * number(php:bench(\'avg\', (descendant::iteration/@revs))))',
-                            'stability' => '100 - php:bench(\'deviation\', number(php:bench(\'min\', descendant::iteration/@time)), number(php:bench(\'avg\', descendant::iteration/@time)))',
-                            'deviation' => 'number(php:bench(\'deviation\', number(php:bench(\'min\', //cell[@name="time"])), number(./cell[@name="time"])))',
-                        ),
-                        'with_query' => '//iterations',
-                    ),
-                ),
-                'post_process' => array(
-                    'deviation',
-                ),
-                'format' => array(
-                    'revs' => '!number',
-                    'rps' => array('%.2f', '%s<comment>rps</comment>'),
-                    'time' => array('!number', '%s<comment>μs</comment>'),
-                    'stability' => array('%.2f', '%s<comment>%%</comment>'),
-                    'deviation' => array('%.2f', '!balance', '%s<comment>%%</comment>'),
-                ),
-            ),
-            'simple' => array(
-                'extends' => 'full',
-                'exclude' => array('benchmark', 'description"', 'memory', 'memory_diff', 'params', 'pid', 'group'),
-            ),
-            'full' => array(
-                'generator' => 'console_table',
-            ),
-        );
-    }
-
+    /**
+     * Adds some output formatters.
+     *
+     * @param OutputFormatterInterface
+     */
     private function configureFormatters(OutputFormatterInterface $formatter)
     {
         $formatter->setStyle(
@@ -318,7 +282,18 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
         );
     }
 
-    private function evaluateExpression($xpath, $cellExpr, $contextEl)
+    /**
+     * Evaluate an XPath expression to a scalar value. If the value is FALSE then we assu,e
+     * that the XPath expression is invalid. Evaluating to `false` is not supported because that
+     * is what PHP returns if the expression is invalid.
+     *
+     * @param \DOMXpath $xpath
+     * @param string $cellExpr
+     * @param \DOMElement $contextEl
+     *
+     * @return scalar
+     */
+    private function evaluateExpression(\DOMXpath $xpath, $cellExpr, \DOMNode $contextEl)
     {
         $value = $xpath->evaluate($cellExpr, $contextEl);
 
@@ -340,6 +315,11 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
         return $value;
     }
 
+    /**
+     * Create the table class. For Symfony 2.4 support.
+     *
+     * @return object
+     */
     private function createTable()
     {
         if (class_exists('Symfony\Component\Console\Helper\Table')) {
@@ -348,6 +328,9 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
         return new \Symfony\Component\Console\Helper\TableHelper();   
     }
 
+    /**
+     * Render the table. For Symfony 2.4 support.
+     */
     private function renderTable($table)
     {
         if (class_exists('Symfony\Component\Console\Helper\Table')) {
@@ -357,11 +340,71 @@ class ConsoleTableGenerator implements OutputAware, ReportGenerator
         $table->render($this->output);
     }
 
+    /**
+     * Replace an item. Note that currently "items" must be simple
+     * string values.
+     *
+     * The "item" is the value for which should be substituted for the string "item"
+     * "context" would either be "row" or "cell".
+     *
+     * An item looks like `{{ row.item }}`.
+     *
+     * NOTE: In the future arrays could be supported, whereby the array key with dot notation
+     *       as: `{{ row.item.foobar }}`
+     *
+     * @param string $expression
+     * @param string $item
+     * @param string $context
+     */
     private function replaceItem($expression, $item, $context)
     {
         if (null === $item) {
             return $expression;
         }
         return preg_replace('/{{\s*?' . $context . '\.item\s*}}/', $item, $expression);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDefaultReports()
+    {
+        return array(
+            'aggregate' => array(
+                'extends' => 'full',
+                'rows' => array(
+                    array(
+                        'cells' => array(
+                            'benchmark' => 'string(php:bench(\'class_name\', string(ancestor-or-self::benchmark/@class)))',
+                            'subject' => 'string(ancestor-or-self::subject/@name)',
+                            'revs' => 'number(sum(.//@revs))',
+                            'iters' => 'number(count(descendant::iteration))',
+                            'time' => 'number(php:bench(\'avg\', descendant::iteration/@time))',
+                            'rps' => '(1000000 div number(php:bench(\'avg\', descendant::iteration/@time)) * number(php:bench(\'avg\', (descendant::iteration/@revs))))',
+                            'stability' => '100 - php:bench(\'deviation\', number(php:bench(\'min\', descendant::iteration/@time)), number(php:bench(\'avg\', descendant::iteration/@time)))',
+                            'deviation' => array(
+                                'expr' => 'number(php:bench(\'deviation\', number(php:bench(\'min\', //cell[@name="time"])), number(./cell[@name="time"])))',
+                                'post_process' => true,
+                            ),
+                        ),
+                        'with_query' => '//iterations',
+                    ),
+                ),
+                'format' => array(
+                    'revs' => '!number',
+                    'rps' => array('%.2f', '%s<comment>rps</comment>'),
+                    'time' => array('!number', '%s<comment>μs</comment>'),
+                    'stability' => array('%.2f', '%s<comment>%%</comment>'),
+                    'deviation' => array('%.2f', '!balance', '%s<comment>%%</comment>'),
+                ),
+            ),
+            'simple' => array(
+                'extends' => 'full',
+                'exclude' => array('benchmark', 'description"', 'memory', 'memory_diff', 'params', 'pid', 'group'),
+            ),
+            'full' => array(
+                'generator' => 'console_table',
+            ),
+        );
     }
 }

--- a/lib/Report/ReportManager.php
+++ b/lib/Report/ReportManager.php
@@ -191,7 +191,7 @@ class ReportManager
         if (isset($reportConfig['extends'])) {
             $extended = $this->getReport($reportConfig['extends']);
             unset($reportConfig['extends']);
-            $reportConfig = array_merge(
+            $reportConfig = array_replace_recursive(
                 $this->resolveReportConfig($extended),
                 $reportConfig
             );

--- a/lib/Report/Tool/Assert.php
+++ b/lib/Report/Tool/Assert.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace PhpBench\Report\Tool;
+
+class Assert
+{
+    /**
+     * Assert that an array has only the given keys.
+     *
+     * @param array $validKeys
+     */
+    public static function hasOnlyKeys(array $validKeys, array $array, $context)
+    {
+        $invalidKeys = array();
+        foreach (array_keys($array) as $key) {
+            if (!in_array($key, $validKeys)) {
+                $invalidKeys[] = $key;
+            }
+        }
+
+        if (!$invalidKeys) {
+            return;
+        }
+
+        throw new \InvalidArgumentException(sprintf(
+            'Invalid keys for %s: "%s". Valid keys are: "%s"',
+            $context, implode('", "', $invalidKeys), implode('", "', $validKeys)
+        ));
+    }
+}

--- a/tests/Unit/Report/Dom/PhpBenchXpathTest.php
+++ b/tests/Unit/Report/Dom/PhpBenchXpathTest.php
@@ -41,4 +41,14 @@ EOT
         $result = $this->xpath->evaluate('number(php:bench(\'avg\', //row/@value))');
         $this->assertEquals(3.75, $result);
     }
+
+    /**
+     * It should throw an exception if a non-scalar value is passed to evaluate
+     *
+     * @expectedException \InvalidArgumentException
+     */
+    public function testNonScalarEvaluate()
+    {
+        $this->xpath->evaluate(new \stdClass);
+    }
 }

--- a/tests/Unit/Report/Generator/ConsoleTableGeneratorTest.php
+++ b/tests/Unit/Report/Generator/ConsoleTableGeneratorTest.php
@@ -186,11 +186,13 @@ class ConsoleTableGeneratorTest extends \PHPUnit_Framework_TestCase
                 array(
                     'cells' => array(
                         'revs' => 'string(sum(.//@revs))',
-                        'time' => 'string(sum(//cell[@name="revs"]) * 4)',
+                        'time' => array(
+                            'expr' => 'string(sum(//cell[@name="revs"]) * 4)',
+                            'post_process' => true,
+                        ),
                     ),
                 ),
             ),
-            'post_process' => array('time'),
         );
 
         $this->generate($config);

--- a/tests/Unit/Report/Generator/ConsoleTableGeneratorTest.php
+++ b/tests/Unit/Report/Generator/ConsoleTableGeneratorTest.php
@@ -252,6 +252,19 @@ class ConsoleTableGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->generate($config);
     }
 
+    /**
+     * It should "render" the table even if it has no rows
+     */
+    public function testRenderNoOutput()
+    {
+        $config = array(
+            'rows' => array(
+            ),
+        );
+
+        $this->generate($config);
+    }
+
     private function generate($config)
     {
         $this->generator->configure($this->optionsResolver);

--- a/tests/Unit/Report/Generator/ConsoleTableGeneratorTest.php
+++ b/tests/Unit/Report/Generator/ConsoleTableGeneratorTest.php
@@ -71,6 +71,87 @@ class ConsoleTableGeneratorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * It should be able to add multiple individual rows
+     */
+    public function testGenerateMultipleRows()
+    {
+        $config = array(
+            'rows' => array(
+                array(
+                    'cells' => array(
+                        'hi' => 'string("hello")',
+                        'bye' => 'string("goodbye")',
+                    ),
+                ),
+                array(
+                    'cells' => array(
+                        'salut' => 'string("bonjour")',
+                        'ciao' => 'string("aurevoir")',
+                    ),
+                ),
+            )
+        );
+
+        $this->generate($config);
+        $output = $this->output->fetch();
+        $this->assertContains('hello', $output);
+        $this->assertContains('goodbye', $output);
+        $this->assertContains('salut', $output);
+        $this->assertContains('ciao', $output);
+    }
+
+    /**
+     * It should allow rows to be iterated with items
+     */
+    public function testIterateRowsWithParameters()
+    {
+        $config = array(
+            'rows' => array(
+                array(
+                    'cells' => array(
+                        'hi' => 'string("{{ row.item }}")',
+                        'ciao' => 'string("{{ row.item }}")',
+                    ),
+                    'with_items' => array('hello', 'bye'),
+                ),
+            )
+        );
+
+        $this->generate($config);
+        $output = $this->output->fetch();
+        $this->assertContains('hello', $output);
+        $this->assertContains('bye', $output);
+        $this->assertContains('hi', $output);
+        $this->assertContains('ciao', $output);
+    }
+
+    /**
+     * It should be able to iterate cells with items
+     */
+    public function testIterateCellsWithParameters()
+    {
+        $config = array(
+            'rows' => array(
+                array(
+                    'cells' => array(
+                        'hi' => 'string("Hello")',
+                        'ciao_{{ cell.item }}' => array(
+                            'expr' => 'string("{{ cell.item }}")',
+                            'with_items' => array('one', 'two', 'three'),
+                        ),
+                    ),
+                ),
+            )
+        );
+
+        $this->generate($config);
+        $output = $this->output->fetch();
+        $this->assertContains('ciao_one', $output);
+        $this->assertContains('ciao_two', $output);
+        $this->assertContains('ciao_three', $output);
+    }
+
+    /**
      * It should only iterate over the given selector
      */
     public function testGenerateWithSelector()

--- a/tests/Unit/Report/Tool/AssertTest.php
+++ b/tests/Unit/Report/Tool/AssertTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace PhpBench\Tests\Unit\Report\Tool;
+
+use PhpBench\Report\Tool\Assert;
+
+class AssertTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * It should assert if an array contains only the given keys
+     * It should do nothing if the array does only contain the given keys
+     */
+    public function testArrayOnlyKeys()
+    {
+        Assert::hasOnlyKeys(array(
+            'one', 'two'
+        ), array('one' => 'hello'), 'this context');
+    }
+
+    /**
+     * It should assert if an array contains only the given keys
+     * It should throw an exception if an array has keys which are not in the given set.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid keys for this context: "foobar". Valid keys are: "one", "two"
+     */
+    public function testArrayOnlyKeysFail()
+    {
+        Assert::hasOnlyKeys(array(
+            'one', 'two'
+        ), array('foobar' => 'hello'), 'this context');
+    }
+}


### PR DESCRIPTION
This PR aims to:

- Enable the definition of arbitrary rows
- Enable rows to be added dynamically (e.g. from the result of an XPath query or from a list of parameters
- Enable parameterable queries (e.g. `./iteration[parameter[@name="foo"]/@value = '{{ param }}'`)
- Enable cells to be created dynamically in the same way
- Enable cells to be formatted within their own configuration (and remove the `format` option).

````javascript
{
    "rows": {
        {
            "cells": {
                 "one": "./expr",
                 "two": {
                     "expr": "./expr",
                     "format": ["%s%%"]
                 },
                 "three_{{ item }}": {
                     "expr": "./expr[name="{{ item }}"]",
                     "with_items": ["10", "100", "1000"]
                 }
             },
             "with_query": "//selector"
        }
        {
            "cells": {
                 "one": "//total1",
                 "one": "//total2",
            }
        }
    }
}
````

The above would add a row for each `//selector` and then a single row containing the "totals".

The "two" column would have the given `printf` formatting assigned to it and the `three` column would expand to three cells: `three_10`, `three_100` and `three_1000`.


It also removes the `headers` option (for now) and the headers are instead inferred from the column names.

This idea is influenced by the ansible configuration grammer.
