### PR TITLE
Verbose logger

### DIFF
--- a/docs/benchmark-runner.rst
+++ b/docs/benchmark-runner.rst
@@ -105,6 +105,12 @@ specified using the ``--progress`` option:
 
     $ phpbench run /path/to/HashBench.php --progress=classdots
 
+The built-in progress loggers are:
+
+- ``dots``: The default logger, shows one dot per subject (like PHPUnit).
+- ``classdots``: Shows the benchmark class, and then a dot for each subject.
+- ``verbose``: Verbose output.
+
 Configuration File
 ------------------
 

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -24,6 +24,7 @@ use PhpBench\Console\Command\RunCommand;
 use PhpBench\Container;
 use PhpBench\ExtensionInterface;
 use PhpBench\ProgressLogger\DotsProgressLogger;
+use PhpBench\ProgressLogger\VerboseProgressLogger;
 use PhpBench\ProgressLoggerRegistry;
 use PhpBench\Report\Generator\CompositeGenerator;
 use PhpBench\Report\Generator\ConsoleTabularCustomGenerator;
@@ -171,6 +172,10 @@ class CoreExtension implements ExtensionInterface
         $container->register('progress_logger.classdots', function (Container $container) {
             return new DotsProgressLogger(true);
         }, array('progress_logger' => array('name' => 'classdots')));
+
+        $container->register('progress_logger.verbose', function (Container $container) {
+            return new VerboseProgressLogger(true);
+        }, array('progress_logger' => array('name' => 'verbose')));
     }
 
     private function registerReportGenerators(Container $container)

--- a/lib/ProgressLogger/VerboseProgressLogger.php
+++ b/lib/ProgressLogger/VerboseProgressLogger.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the PHP Bench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\ProgressLogger;
+
+use PhpBench\Benchmark\Benchmark;
+use PhpBench\Benchmark\Subject;
+use PhpBench\ProgressLoggerInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class VerboseProgressLogger implements ProgressLoggerInterface
+{
+    private $output;
+
+    public function setOutput(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    public function benchmarkStart(Benchmark $benchmark)
+    {
+        $this->output->writeln(sprintf('<comment>%s</comment>', $benchmark->getClassFqn()));
+    }
+
+    public function benchmarkEnd(Benchmark $benchmark)
+    {
+    }
+
+    public function subjectStart(Subject $subject)
+    {
+        $this->output->write('  <info>>> </info>' . $subject->getMethodName());
+    }
+
+    public function subjectEnd(Subject $subject)
+    {
+        $this->output->writeln(' [<info>OK</info>]');
+    }
+}

--- a/tests/Functional/Console/Command/RunCommandTest.php
+++ b/tests/Functional/Console/Command/RunCommandTest.php
@@ -226,6 +226,19 @@ class RunCommandTest extends BaseCommandTestCase
     }
 
     /**
+     * It can have the verbose progress logger specified.
+     */
+    public function testVerboseProgressLogger()
+    {
+        $tester = $this->runCommand('run', array(
+            '--progress' => 'verbose',
+            'path' => __DIR__ . '/../../benchmarks/BenchmarkBench.php',
+        ));
+        $display = $tester->getDisplay();
+        $this->assertContains('BenchmarkBench', $display);
+    }
+
+    /**
      * It should run specified groups.
      */
     public function testGroups()


### PR DESCRIPTION
Adds new verbose logger:

````
PhpBench 0.5. Running benchmarks.
Using configuration file: examples/phpbench.json

\HashingBenchmark
  >> benchMd5 [OK]
  >> benchSha256 [OK]
  >> benchSha1 [OK]
\StringSplitting
  >> benchStrStrSubstr [OK]
  >> benchPregMatch [OK]
  >> benchExplode [OK]
\CostOfReflectionBench
  >> benchMethodSet [OK]
  >> benchPublicProperty [OK]
  >> benchPublicReflection [OK]
  >> benchPrivateReflection [OK]
  >> benchNewClass [OK]
  >> benchReflectionNewInstance [OK]
\CostOfCalling
  >> benchCallWithoutParams [OK]
  >> benchCallWithParams [OK]
\PhpBench\Tests\Functional\benchmarks\ArrayKeysBench
  >> benchArrayKeyExists [OK]
  >> benchIsset [OK]
  >> benchInArray [OK]

Done (17 subjects, 146 iterations) in 8.26s
````