### PR TITLE
Added skip annotation

### DIFF
--- a/docs/writing-benchmarks.rst
+++ b/docs/writing-benchmarks.rst
@@ -259,4 +259,30 @@ You can assign benchmark subjects to groups using the ``@group`` annotation.
 
 The group can then be targetted using the command line interface.
 
+Skipping Subjects
+-----------------
+
+Sometimes it may be desirable to skip a subject. This may happen if you are
+overriding a method which does not apply to the subject you are benchmarking.
+
+To skip a subject add the ``@skip`` annotation:
+
+.. code-block:: php
+
+    <?php
+
+    class HashBench extends FooBench
+    {
+        // ... 
+
+        /**
+         * @skip
+         */
+        public function benchSomething()
+        {
+        }
+
+        // ... 
+    }
+
 .. _cartesian product: https://en.wikipedia.org/wiki/Cartesian_product

--- a/examples/phpbench.json
+++ b/examples/phpbench.json
@@ -1,7 +1,6 @@
 {
     "bootstrap": "../vendor/autoload.php",
     "path": "./",
-    "progress_logger_name": "verbose",
     "outputs": {
         "console_example": {
             "renderer": "console",

--- a/examples/phpbench.json
+++ b/examples/phpbench.json
@@ -1,6 +1,7 @@
 {
     "bootstrap": "../vendor/autoload.php",
     "path": "./",
+    "progress_logger_name": "verbose",
     "outputs": {
         "console_example": {
             "renderer": "console",

--- a/lib/Benchmark/BenchmarkBuilder.php
+++ b/lib/Benchmark/BenchmarkBuilder.php
@@ -41,6 +41,7 @@ class BenchmarkBuilder
         );
 
         $classMeta = $this->parser->parseDoc($classInfo['comment']);
+        var_dump($classInfo['methods']);
         foreach ($classInfo['methods'] as $methodName => $methodInfo) {
             $subject = $this->buildSubject($benchmark, $methodName, $methodInfo, $classMeta, $subjectFilter, $groupFilter);
 
@@ -67,6 +68,10 @@ class BenchmarkBuilder
         }
 
         $subjectMeta = $this->parser->parseDoc($methodInfo['comment'], $classMeta);
+
+        if ($subjectMeta['skip'] == true) {
+            return;
+        }
 
         if ($groupFilter && 0 === count(array_intersect($groupFilter, $subjectMeta['group']))) {
             return;

--- a/lib/Benchmark/BenchmarkBuilder.php
+++ b/lib/Benchmark/BenchmarkBuilder.php
@@ -41,7 +41,6 @@ class BenchmarkBuilder
         );
 
         $classMeta = $this->parser->parseDoc($classInfo['comment']);
-        var_dump($classInfo['methods']);
         foreach ($classInfo['methods'] as $methodName => $methodInfo) {
             $subject = $this->buildSubject($benchmark, $methodName, $methodInfo, $classMeta, $subjectFilter, $groupFilter);
 

--- a/lib/Benchmark/Parser.php
+++ b/lib/Benchmark/Parser.php
@@ -24,6 +24,7 @@ class Parser
             'iterations' => array(),
             'group' => array(),
             'revs' => array(),
+            'skip' => false,
         );
 
         // singular annotations
@@ -41,6 +42,11 @@ class Parser
         }
 
         foreach ($lines as $line) {
+            if (preg_match('{@skip.*$}', $line)) {
+                $meta['skip'] = true;
+                continue;
+            }
+
             if (!preg_match('{@([a-zA-Z0-9]+)\s+(.*)$}', $line, $matches)) {
                 continue;
             }

--- a/tests/Unit/Benchmark/BenchmarkBuilderTest.php
+++ b/tests/Unit/Benchmark/BenchmarkBuilderTest.php
@@ -15,7 +15,8 @@ use PhpBench\Benchmark\BenchmarkBuilder;
 use Prophecy\Argument;
 
 /**
- * NOTE: This test case is horrible. It and the code should be refactored.
+ * NOTE: This test case (and probably the code it tests) is sub-optimal and
+ * could be refactored.
  */
 class BenchmarkBuilderTest extends \PHPUnit_Framework_TestCase
 {
@@ -131,7 +132,7 @@ class BenchmarkBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should ignore subjects with the "skip" metadata
+     * It should ignore subjects with the "skip" metadata.
      */
     public function testSkip()
     {
@@ -276,7 +277,7 @@ class BenchmarkBuilderTest extends \PHPUnit_Framework_TestCase
             'paramProvider' => array(),
             'iterations' => 1,
             'revs' => array(1),
-            'skip' => false
+            'skip' => false,
         ), $metadata);
     }
 }

--- a/tests/Unit/Benchmark/ParserTest.php
+++ b/tests/Unit/Benchmark/ParserTest.php
@@ -29,7 +29,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     public function testParseMethodDoc($docComment, $expected)
     {
         $result = $this->parser->parseDoc($docComment);
-        $this->assertEquals($result, $expected);
+        $this->assertEquals($expected, $result);
     }
 
     public function provideParseMethodDoc()
@@ -47,6 +47,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 * @revs 1000
 * @revs 10
 * @group base
+* @skip
 */
 EOT
                 , array(
@@ -56,6 +57,23 @@ EOT
                     'paramProvider' => array('provideParam'),
                     'revs' => array(1000, 10),
                     'group' => array('base'),
+                    'skip' => true,
+                ),
+            ),
+            array(
+                <<<EOT
+/**
+* @skip Not implemented
+*/
+EOT
+                , array(
+                    'iterations' => 1,
+                    'beforeMethod' => array(),
+                    'afterMethod' => array(),
+                    'paramProvider' => array(),
+                    'revs' => array(),
+                    'group' => array(),
+                    'skip' => true,
                 ),
             ),
             array(
@@ -71,6 +89,7 @@ EOT
                     'iterations' => 1,
                     'revs' => array(),
                     'group' => array(),
+                    'skip' => false,
                 ),
             ),
         );
@@ -109,6 +128,7 @@ EOT
                     'paramProvider' => array('provideParam'),
                     'revs' => array(1000, 10),
                     'group' => array('boo'),
+                    'skip' => false,
                 ),
                 <<<EOT
 /**
@@ -127,6 +147,7 @@ EOT
                     'paramProvider' => array('provideParam', 'notherParam'),
                     'revs' => array(1000, 10, 5),
                     'group' => array('boo', 'five'),
+                    'skip' => false,
                 ),
             ),
             array(
@@ -137,6 +158,7 @@ EOT
                     'paramProvider' => array('provideParam'),
                     'revs' => array(1000, 10),
                     'group' => array('boo'),
+                    'skip' => false,
                 ),
                 <<<EOT
 /**
@@ -151,6 +173,7 @@ EOT
                     'paramProvider' => array('provideParam'),
                     'revs' => array(1000, 10),
                     'group' => array('boo'),
+                    'skip' => false,
                 ),
             ),
             array(
@@ -160,6 +183,7 @@ EOT
                     'afterMethod' => array(),
                     'paramProvider' => array('provideParam'),
                     'revs' => array(1000, 10),
+                    'skip' => false,
                 ),
                 '/** */',
                 array(
@@ -169,6 +193,7 @@ EOT
                     'paramProvider' => array('provideParam'),
                     'revs' => array(1000, 10),
                     'group' => array(),
+                    'skip' => false,
                 ),
             ),
         );


### PR DESCRIPTION
Allows methods/subjects to be skipped - useful if the method is an inherited method / abstract method.