### PR TITLE
Skip Annotation

### DIFF
--- a/docs/writing-benchmarks.rst
+++ b/docs/writing-benchmarks.rst
@@ -268,4 +268,23 @@ You can assign benchmark subjects to groups using the ``@Groups`` annotation.
 
 The group can then be targetted using the command line interface.
 
+Skiping Subjects
+-----------------
+
+You can skip subjects by using the ``@Skip`` annotation:
+
+.. code-block:: php
+
+    <?php
+
+    class HashBench extends Foobar
+    {
+        /**
+         * @Skip()
+         */
+        public function testFoobar()
+        {
+        }
+    }
+
 .. _cartesian product: https://en.wikipedia.org/wiki/Cartesian_product

--- a/examples/ArrayKeysBench.php
+++ b/examples/ArrayKeysBench.php
@@ -15,9 +15,10 @@ namespace PhpBench\Tests\Functional\benchmarks;
  * This example benchmarks array_key_exists vs. isset vs. in_array.
  *
  * @BeforeMethods({"init"})
- * @Revs(10000)
+ * @Revs(1000)
  * @Iterations(4)
  * @Groups({"array_keys"})
+ * @ParamProviders({"provideNbElements"})
  */
 class ArrayKeysBench
 {
@@ -25,9 +26,9 @@ class ArrayKeysBench
     private $values;
     private $index = 0;
 
-    public function init()
+    public function init($params)
     {
-        $this->array = array_fill(0, 50000, 'this is a test');
+        $this->array = array_fill(0, $params['nb_elements'], 'this is a test');
         $this->values = array_combine(array_keys($this->array), array_keys($this->array));
     }
 
@@ -44,5 +45,23 @@ class ArrayKeysBench
     public function benchInArray()
     {
         in_array($this->index++, $this->values);
+    }
+
+    public function provideNbElements()
+    {
+        return array(
+            array(
+                'nb_elements' => 10,
+            ),
+            array(
+                'nb_elements' => 100,
+            ),
+            array(
+                'nb_elements' => 1000,
+            ),
+            array(
+                'nb_elements' => 10000,
+            ),
+        );
     }
 }

--- a/examples/phpbench.json
+++ b/examples/phpbench.json
@@ -37,7 +37,7 @@
         "array_keys": {
             "generator": "table_custom",
             "title": "Comparison of array location functions",
-            "description": "This benchmark creates an array with 50,000 elements. \nEach subject checks the existence of the key with the index of the current revolution. (or in the case of in_arrey, for the value).\nDeviation is calculated per revolution",
+            "description": "This benchmark creates an array with checks the performance of array location functions with variable numbers of elements. Deviation is relative to the number of elements.",
             "file": "reports/array_keys.json"
         },
         "string_splitting": {

--- a/examples/reports/array_keys.json
+++ b/examples/reports/array_keys.json
@@ -24,12 +24,12 @@
                 {
                     "name": "time",
                     "class": "time",
-                    "expr": "average(.//iteration[@revs='{{ row.item }}']/@time)"
+                    "expr": "sum(./variant[parameter[@name='nb_elements']/@value = {{ row.item }}]/iteration/@time) div sum(./variant[parameter[@name='nb_elements']/@value = {{ row.item }}]/iteration/@revs)"
                 },
                 {
                     "name": "deviation",
                     "class": "deviation",
-                    "expr": "deviation(min(//cell[@name='time']), number(./cell[@name='time'])) div number(./cell[@name='elements'])",
+                    "expr": "deviation(min(//row[cell[@name='elements'] = {{ row.item }}]/cell[@name='time']), number(./cell[@name='time']))",
                     "pass": 1
                 }
             ],

--- a/lib/Benchmark/Metadata/AbstractMetadata.php
+++ b/lib/Benchmark/Metadata/AbstractMetadata.php
@@ -52,6 +52,11 @@ abstract class AbstractMetadata
     private $class;
 
     /**
+     * @var bool
+     */
+    private $skip;
+
+    /**
      * @param mixed $class
      */
     public function __construct($class)
@@ -129,5 +134,15 @@ abstract class AbstractMetadata
     public function setRevs($revs)
     {
         $this->revs = $revs;
+    }
+
+    public function getSkip()
+    {
+        return $this->skip;
+    }
+
+    public function setSkip($skip)
+    {
+        $this->skip = $skip;
     }
 }

--- a/lib/Benchmark/Metadata/Annotations/Skip.php
+++ b/lib/Benchmark/Metadata/Annotations/Skip.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Benchmark\Metadata\Annotations;
+
+/**
+ * @Annotation
+ * @Taget({"METHOD", "CLASS"})
+ */
+class Skip
+{
+}

--- a/lib/Benchmark/Metadata/Driver/AnnotationDriver.php
+++ b/lib/Benchmark/Metadata/Driver/AnnotationDriver.php
@@ -118,5 +118,9 @@ class AnnotationDriver implements DriverInterface
         if ($annotation instanceof Annotations\Revs) {
             $metadata->setRevs($annotation->getRevs());
         }
+
+        if ($annotation instanceof Annotations\Skip) {
+            $metadata->setSkip(true);
+        }
     }
 }

--- a/lib/Benchmark/Remote/ReflectionHierarchy.php
+++ b/lib/Benchmark/Remote/ReflectionHierarchy.php
@@ -78,7 +78,7 @@ class ReflectionHierarchy implements \IteratorAggregate
     /**
      * Return true if thare are no reflection classes here.
      *
-     * @return boolean
+     * @return bool
      */
     public function isEmpty()
     {

--- a/lib/Benchmark/Remote/Reflector.php
+++ b/lib/Benchmark/Remote/Reflector.php
@@ -118,7 +118,10 @@ class Reflector
                 break;
             }
 
-            $buffer .= fread($fp, 512);
+            // Read entire lines to prevent keyword truncation
+            for ($line = 0; $line <= 10; $line++) {
+                $buffer .= fgets($fp);
+            }
             $tokens = @token_get_all($buffer);
 
             if (strpos($buffer, '{') === false) {

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -146,20 +146,21 @@ class Runner
     private function run(BenchmarkMetadata $benchmark, \DOMElement $benchmarkEl)
     {
         foreach ($benchmark->getSubjectMetadatas() as $subject) {
-            $subjectEl = $benchmarkEl->ownerDocument->createElement('subject');
+            $subjectEl = $benchmarkEl->appendElement('subject');
             $subjectEl->setAttribute('name', $subject->getName());
 
+            if (true === $subject->getSkip()) {
+                continue;
+            }
+
             foreach ($subject->getGroups() as $group) {
-                $groupEl = $benchmarkEl->ownerDocument->createElement('group');
+                $groupEl = $benchmarkEl->appendElement('group');
                 $groupEl->setAttribute('name', $group);
-                $subjectEl->appendChild($groupEl);
             }
 
             $this->logger->subjectStart($subject);
             $this->runSubject($subject, $subjectEl);
             $this->logger->subjectEnd($subject);
-
-            $benchmarkEl->appendChild($subjectEl);
         }
     }
 

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -154,7 +154,7 @@ class Runner
             }
 
             foreach ($subject->getGroups() as $group) {
-                $groupEl = $benchmarkEl->appendElement('group');
+                $groupEl = $subjectEl->appendElement('group');
                 $groupEl->setAttribute('name', $group);
             }
 

--- a/lib/Report/Generator/tabular/aggregate.json
+++ b/lib/Report/Generator/tabular/aggregate.json
@@ -27,7 +27,7 @@
                 },
                 {
                     "name": "revs",
-                    "expr": "number(sum(descendant-or-self::iteration/@revs))"
+                    "expr": "sum(descendant-or-self::iteration/@revs)"
                 },
                 {
                     "name": "iters",
@@ -36,7 +36,7 @@
                 {
                     "name": "time",
                     "class": "time",
-                    "expr": "number(sum(descendant-or-self::iteration/@time)) div number(sum(descendant-or-self::iteration/@revs))"
+                    "expr": "sum(descendant-or-self::iteration/@time) div sum(descendant-or-self::iteration/@revs)"
                 },
                 {
                     "name": "memory",


### PR DESCRIPTION
This PR adds a `NotApplicable` annotation which indicates that the benchmark is not applicable to the implementation under test. Possible alternative to #149 

This feature has the added benefit that `N/A` subjects are visible in reports.