### PR TITLE
Polymorphic Executor

### DIFF
--- a/lib/Benchmark/Executor/template/microtime.template
+++ b/lib/Benchmark/Executor/template/microtime.template
@@ -1,0 +1,63 @@
+<?php
+
+namespace PhpBench;
+
+// disable garbage collection
+gc_disable();
+
+$class = '{{ class }}';
+$file = '{{ file }}';
+$subject = '{{ subject }}';
+$revolutions = {{ revolutions }};
+$beforeMethods = {{ beforeMethods }};
+$afterMethods = {{ afterMethods }};
+$bootstrap = '{{ bootstrap }}';
+$parameters = {{ parameters }};
+
+if ($bootstrap) {
+    require_once($bootstrap);
+}
+
+require_once($file);
+
+$benchmark = new $class();
+
+foreach ($beforeMethods as $beforeMethod) {
+    $benchmark->$beforeMethod($parameters);
+}
+
+// run the benchmarks: note that passing arguments to the method slightly increases
+// the calltime, so we explicitly do one thing or the other depending on if parameters
+// are provided.
+if ($parameters) {
+    $startMemory = memory_get_usage();
+    $startTime = microtime(true);
+
+    for ($i = 0; $i < $revolutions; $i++) {
+        $benchmark->$subject($parameters);
+    }
+
+    $endTime = microtime(true);
+    $endMemory = memory_get_usage();
+} else {
+    $startMemory = memory_get_usage();
+    $startTime = microtime(true);
+
+    for ($i = 0; $i < $revolutions; $i++) {
+        $benchmark->$subject();
+    }
+
+    $endTime = microtime(true);
+    $endMemory = memory_get_usage();
+}
+
+foreach ($afterMethods as $afterMethod) {
+    $benchmark->$afterMethod($parameters);
+}
+
+echo json_encode(array(
+    'memory' => $endMemory - $startMemory,
+    'time' => ($endTime * 1000000) - ($startTime * 1000000),
+));
+
+exit(0);

--- a/lib/Benchmark/ExecutorInterface.php
+++ b/lib/Benchmark/ExecutorInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Benchmark;
+
+use PhpBench\Config\ConfigurableInterface;
+
+/**
+ * Executors are responsible for executing the benchmark class
+ * and returning the timing metrics, and optionally the memory and profling
+ * data.
+ */
+interface ExecutorInterface extends ConfigurableInterface
+{
+    /**
+     * Execute the benchmark and return metrics.
+     *
+     * @param Iteration $iteration
+     * @param array $options
+     *
+     * @return IterationResult
+     */
+    public function execute(Iteration $iteration, array $options = array());
+}

--- a/lib/Benchmark/Iteration.php
+++ b/lib/Benchmark/Iteration.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Benchmark;
+
+use PhpBench\Benchmark\Metadata\SubjectMetadata;
+
+/**
+ * Represents the data required to execute a single iteration.
+ */
+class Iteration
+{
+    private $subject;
+    private $revolutions;
+    private $parameters = array();
+    private $index;
+
+    public function __construct(
+        $index,
+        SubjectMetadata $subject,
+        $revolutions,
+        array $parameters
+    ) {
+        $this->index = $index;
+        $this->subject = $subject;
+        $this->revolutions = $revolutions;
+        $this->parameters = $parameters;
+    }
+
+    public function getSubject()
+    {
+        return $this->subject;
+    }
+
+    public function getRevolutions()
+    {
+        return $this->revolutions;
+    }
+
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+}

--- a/lib/Benchmark/IterationResult.php
+++ b/lib/Benchmark/IterationResult.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Benchmark;
+
+/**
+ * Represents the result of a single iteration executed by an executor.
+ */
+class IterationResult
+{
+    /**
+     * @var int
+     */
+    private $time;
+
+    /**
+     * @var int
+     */
+    private $memory;
+
+    /**
+     * @param mixed $time Time taken to execute the iteration in microseconds.
+     * @param mixed $memory Memory used by iteration in bytes.
+     */
+    public function __construct($time, $memory)
+    {
+        $this->time = $time;
+        $this->memory = $memory;
+    }
+
+    public function getTime()
+    {
+        return $this->time;
+    }
+
+    public function getMemory()
+    {
+        return $this->memory;
+    }
+}

--- a/lib/Config/ConfigurableInterface.php
+++ b/lib/Config/ConfigurableInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Config;
+
+interface ConfigurableInterface
+{
+    /**
+     * Return a JSON schema which should be used to validate the configuration.
+     * Return an empty array() if you want to allow anything.
+     *
+     * @param OptionsResolver $options
+     */
+    public function getSchema();
+
+    /***
+     * Return the default configuration. This configuration will be prepended
+     * to all subsequent reports and should be used to provide default values.
+     *
+     * @return array
+     */
+
+    public function getDefaultConfig();
+}

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -12,7 +12,7 @@
 namespace PhpBench\Extension;
 
 use PhpBench\Benchmark\CollectionBuilder;
-use PhpBench\Benchmark\Executor;
+use PhpBench\Benchmark\Executor\MicrotimeExecutor;
 use PhpBench\Benchmark\Metadata\Driver\AnnotationDriver;
 use PhpBench\Benchmark\Metadata\Factory;
 use PhpBench\Benchmark\Remote\Launcher;
@@ -119,7 +119,7 @@ class CoreExtension implements ExtensionInterface
         });
 
         $container->register('benchmark.executor', function (Container $container) {
-            return new Executor(
+            return new MicrotimeExecutor(
                 $container->get('benchmark.remote.launcher')
             );
         });

--- a/tests/Unit/Benchmark/Executor/microtimetest/ExecutorBench.php
+++ b/tests/Unit/Benchmark/Executor/microtimetest/ExecutorBench.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpBench\Tests\Unit\Benchmark\executortest;
+namespace PhpBench\Tests\Unit\Benchmark\Executor\microtimetest;
 
 class ExecutorBench
 {

--- a/tests/Unit/Benchmark/RunnerTest.php
+++ b/tests/Unit/Benchmark/RunnerTest.php
@@ -12,8 +12,10 @@
 namespace PhpBench\Tests\Benchmark;
 
 use PhpBench\Benchmark\Iteration;
+use PhpBench\Benchmark\IterationResult;
 use PhpBench\Benchmark\Runner;
 use PhpBench\PhpBench;
+use Prophecy\Argument;
 
 class RunnerTest extends \PHPUnit_Framework_TestCase
 {
@@ -23,7 +25,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         $this->collection = $this->prophesize('PhpBench\Benchmark\Collection');
         $this->subject = $this->prophesize('PhpBench\Benchmark\Metadata\SubjectMetadata');
         $this->collectionBuilder->buildCollection(__DIR__, array(), array())->willReturn($this->collection);
-        $this->executor = $this->prophesize('PhpBench\Benchmark\Executor');
+        $this->executor = $this->prophesize('PhpBench\Benchmark\ExecutorInterface');
         $this->benchmark = $this->prophesize('PhpBench\Benchmark\Metadata\BenchmarkMetadata');
 
         $this->runner = new Runner(
@@ -46,6 +48,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         if ($exception) {
             $this->setExpectedException($exception[0], $exception[1]);
         }
+
         $this->collection->getBenchmarks()->willReturn(array(
             $this->benchmark,
         ));
@@ -64,9 +67,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         $this->benchmark->getClass()->willReturn('Benchmark');
 
         if (!$exception) {
-            foreach ($revs as $revCount) {
-                $this->executor->execute($this->subject->reveal(), $revCount, $parameters)->shouldBeCalledTimes($iterations);
-            }
+            $this->executor->execute(Argument::type('PhpBench\Benchmark\Iteration'))->shouldBeCalledTimes(count($revs) * $iterations)->willReturn(new IterationResult(10, 10));
         }
 
         $result = $this->runner->runAll(__DIR__);
@@ -95,7 +96,7 @@ EOT
   <benchmark class="Benchmark">
     <subject name="benchFoo">
       <variant>
-        <iteration revs="1" time="" memory=""/>
+        <iteration revs="1" time="10" memory="10"/>
       </variant>
     </subject>
   </benchmark>
@@ -109,8 +110,8 @@ EOT
   <benchmark class="Benchmark">
     <subject name="benchFoo">
       <variant>
-        <iteration revs="1" time="" memory=""/>
-        <iteration revs="3" time="" memory=""/>
+        <iteration revs="1" time="10" memory="10"/>
+        <iteration revs="3" time="10" memory="10"/>
       </variant>
     </subject>
   </benchmark>
@@ -124,14 +125,14 @@ EOT
   <benchmark class="Benchmark">
     <subject name="benchFoo">
       <variant>
-        <iteration revs="1" time="" memory=""/>
-        <iteration revs="3" time="" memory=""/>
-        <iteration revs="1" time="" memory=""/>
-        <iteration revs="3" time="" memory=""/>
-        <iteration revs="1" time="" memory=""/>
-        <iteration revs="3" time="" memory=""/>
-        <iteration revs="1" time="" memory=""/>
-        <iteration revs="3" time="" memory=""/>
+        <iteration revs="1" time="10" memory="10"/>
+        <iteration revs="3" time="10" memory="10"/>
+        <iteration revs="1" time="10" memory="10"/>
+        <iteration revs="3" time="10" memory="10"/>
+        <iteration revs="1" time="10" memory="10"/>
+        <iteration revs="3" time="10" memory="10"/>
+        <iteration revs="1" time="10" memory="10"/>
+        <iteration revs="3" time="10" memory="10"/>
       </variant>
     </subject>
   </benchmark>
@@ -147,7 +148,7 @@ EOT
       <variant>
         <parameter name="one" value="two"/>
         <parameter name="three" value="four"/>
-        <iteration revs="1" time="" memory=""/>
+        <iteration revs="1" time="10" memory="10"/>
       </variant>
     </subject>
   </benchmark>
@@ -163,7 +164,7 @@ EOT
       <variant>
         <parameter name="0" value="one"/>
         <parameter name="1" value="two"/>
-        <iteration revs="1" time="" memory=""/>
+        <iteration revs="1" time="10" memory="10"/>
       </variant>
     </subject>
   </benchmark>
@@ -180,7 +181,7 @@ EOT
         <parameter name="one" type="collection">
           <parameter name="three" value="four"/>
         </parameter>
-        <iteration revs="1" time="" memory=""/>
+        <iteration revs="1" time="10" memory="10"/>
       </variant>
     </subject>
   </benchmark>


### PR DESCRIPTION
This PR makes the Executor polymorphic. The executor is responsible for executing the benchmark subject and retrieving the statistics about it.

Abstracting this makes it possible to implement different executors, such as an XDebug executor, a Blackfire executor, or whatever. Eventually even executors for different languages (JavaExecutor, PythonExecutor - but these would require alternate metadata drivers).