### PR TITLE
Only parse the first class token

### DIFF
--- a/lib/Benchmark/Remote/Payload.php
+++ b/lib/Benchmark/Remote/Payload.php
@@ -123,7 +123,7 @@ class Payload
         if (null === $result) {
             throw new \RuntimeException(sprintf(
                 'Could not decode return value from script from template "%s" (should be a JSON encoded string): %s',
-                $template,
+                $this->template,
                 $output
             ));
         }

--- a/lib/Benchmark/Remote/Reflector.php
+++ b/lib/Benchmark/Remote/Reflector.php
@@ -143,13 +143,16 @@ class Reflector
                     for ($j = $i + 1;$j < count($tokens);$j++) {
                         if ($tokens[$j] === '{') {
                             $class = $tokens[$i + 2][1];
+
+                            // only parse the first class token
+                            break 2;
                         }
                     }
                 }
             }
         };
 
-        if (!$class) {
+        if (!trim($class)) {
             return;
         }
 

--- a/tests/Unit/Benchmark/Remote/ReflectorTest.php
+++ b/tests/Unit/Benchmark/Remote/ReflectorTest.php
@@ -94,6 +94,10 @@ class ReflectorTest extends \PHPUnit_Framework_TestCase
      */
     public function testMultipleClassKeywords()
     {
+        if (version_compare(phpversion(), '5.5', '<')) {
+            $this->markTestSkipped();
+        }
+
         $fname = __DIR__ . '/reflector/ClassWithClassKeywords.php';
         $classHierarchy = $this->reflector->reflect($fname);
         $reflection = $classHierarchy->getTop();

--- a/tests/Unit/Benchmark/Remote/ReflectorTest.php
+++ b/tests/Unit/Benchmark/Remote/ReflectorTest.php
@@ -87,4 +87,16 @@ class ReflectorTest extends \PHPUnit_Framework_TestCase
             ),
         ), $parameterSets);
     }
+
+    /**
+     * It should parse a class which has multiple class keywords and return the first
+     * declared class.
+     */
+    public function testMultipleClassKeywords()
+    {
+        $fname = __DIR__ . '/reflector/ClassWithClassKeywords.php';
+        $classHierarchy = $this->reflector->reflect($fname);
+        $reflection = $classHierarchy->getTop();
+        $this->assertEquals('\Test\ClassWithClassKeywords', $reflection->class);
+    }
 }

--- a/tests/Unit/Benchmark/Remote/reflector/ClassWithClassKeywords.php
+++ b/tests/Unit/Benchmark/Remote/reflector/ClassWithClassKeywords.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Test;
+
+/**
+ * @revs(10000)
+ * @iterations(5)
+ */
+class ClassWithClassKeywords
+{
+    protected $class = \Test\B::class;
+
+    public function benchIsSubclassOf()
+    {
+        is_subclass_of($this->class, \Test\A::class);
+    }
+
+    public function benchReflectionClass()
+    {
+        $c = new \ReflectionClass($this->class);
+        $c->isSubclassOf(\Test\A::class);
+    }
+}
+
+class A
+{
+}


### PR DESCRIPTION
Currently the Reflector class parses all the T_CLASS tokens, in addition to this returning the last declared class this will also include `Foobar::class` instances and return an empty string.

This fix will use the first instance of the `T_CLASS` token.

Fixes #174 