### PR TITLE
Iteration rejection and retry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "symfony/console": "^2.4",
         "symfony/finder": "^2.4",
         "symfony/process": "^2.1",
-        "phpbench/tabular": "^0.2",
+        "phpbench/tabular": "^0.2.0",
         "seld/jsonlint": "^1.0",
         "justinrainbow/json-schema": "^1.0",
         "doctrine/annotations": "^1.2.7",

--- a/docs/benchmark-runner.rst
+++ b/docs/benchmark-runner.rst
@@ -86,6 +86,30 @@ configure reports.
 
 The ``--report`` option can be specified multiple times.
 
+.. _retry_threshold:
+
+Retry Threshold
+---------------
+
+PHPBench is able to dramatically improve the stability of your benchmarks by
+retrying the iteration set until all the deviations in time between iterations
+fit within a given margin of error.
+
+You can set this as follows:
+
+.. code-block:: bash
+
+    $ phpbench run /path/to/HashBench.php --retry-threshold=5
+
+The retry threshold is the margin of error as a percentage which is allowed
+between deviations.  Generally the lower this value, the higher the stability,
+but the longer it will take for a set of iterations to be resolved.
+
+By default the retry threshold is disabled.
+
+You may also set the retry threshold in the
+:ref:`configuration <configuration_retry_threshold>`.
+
 Changing the Output Medium
 --------------------------
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -76,6 +76,19 @@ Specify which progress logger to use:
         "progress": "dots"
     }
 
+.. _configuration_retry_threshold:
+
+Retry Threshold
+---------------
+
+Set the :ref:`retry_threshold`:
+
+.. code-block:: javascript
+
+    {
+        "retry_threshold": 5
+    }
+
 Reports
 -------
 

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -131,14 +131,14 @@ And you should see some output similar to the following:
     .
     Done (1 subjects, 1 iterations) in 0.22s
 
-    +-------------------+--------------+-------+--------+------+--------------+----------+--------+-----------+
-    | benchmark         | subject      | group | params | revs | iter         | time     | memory | deviation |
-    +-------------------+--------------+-------+--------+------+--------------+----------+--------+-----------+
-    | TimeConsumerBench | benchConsume |       | []     | 1    | 0            | 226.00μs | 3,416b | 0.00%     |
-    |                   |              |       |        |      |              |          |        |           |
-    |                   |              |       |        |      | stability >> | 100.00%  |        |           |
-    |                   |              |       |        |      | average >>   | 226.00μs | 3,416b |           |
-    +-------------------+--------------+-------+--------+------+--------------+----------+--------+-----------+
+    +-------------------+--------------+-------+--------+------+--------------+------+----------+--------+-----------+
+    | benchmark         | subject      | group | params | revs | iter         | rej  | time     | memory | deviation |
+    +-------------------+--------------+-------+--------+------+--------------+------+----------+--------+-----------+
+    | TimeConsumerBench | benchConsume |       | []     | 1    | 0            | 0    | 226.00μs | 3,416b | 0.00%     |
+    |                   |              |       |        |      |              |      |          |        |           |
+    |                   |              |       |        |      | stability >> |      | 100.00%  |        |           |
+    |                   |              |       |        |      | average >>   | 0.00 | 226.00μs | 3,416b |           |
+    +-------------------+--------------+-------+--------+------+--------------+------+----------+--------+-----------+
 
 You may have guessed that the code was only executed once (as indicated by the
 ``revs`` column). To achieve a better measurement we should increase the
@@ -205,6 +205,36 @@ rather than ``default``:
 
     $ php vendor/bin/phpbench run benchmarks/TimeConsumerBench.php --report=aggregate
 
+Increase Stability
+------------------
+
+You will be able to see the column "stability" in the aggregate report. This
+is a percentage where 100% means that all the iterations had exactly the same
+time, the lower the percentage the less you can trust the results.
+
+To increase stability you can use the ``--retry-threshold`` to automatically
+:ref:`repeat the iterations <retry_threshold>` until they fit within a given
+margin of error:
+
+.. code-block:: bash
+
+    $ php vendor/bin/phpbench run benchmarks/TimeConsumerBench.php --report=aggregate --retry-threshold=5
+
+.. warning::
+
+    Lower values for ``retry-threshold``, depending on the stability of your
+    system,  generally lead to increased total benchmarking time.
+
+You may get a better view of what is going on by using the ``verbose``
+progress logger:
+
+.. code-block:: bash
+
+    $ php vendor/bin/phpbench run benchmarks/TimeConsumerBench.php --report=aggregate --retry-threshold=5 --progress=verbose
+
+Customize Reports
+-----------------
+
 PHPBench also allows you to customize reports on the command line, try the
 following:
 
@@ -216,6 +246,9 @@ Above we configure a new report which extends the ``default`` report that we
 have already used, but we exclude the ``benchmark`` and ``subject`` columns.
 A full list of all the options for the default reports can be found in the
 :doc:`report-generators` chapter.
+
+Configuration
+-------------
 
 Now to finish off, lets add the path and new report to the configuration file:
 

--- a/docs/reports.rst
+++ b/docs/reports.rst
@@ -11,14 +11,14 @@ in the form of a table:
 
 .. code-block:: bash
 
-    +-------------------+--------------+-------+--------+------+--------------+----------+--------+-----------+
-    | benchmark         | subject      | group | params | revs | iter         | time     | memory | deviation |
-    +-------------------+--------------+-------+--------+------+--------------+----------+--------+-----------+
-    | TimeConsumerBench | benchConsume |       | []     | 1    | 0            | 226.00μs | 3,416b | 0.00%     |
-    |                   |              |       |        |      |              |          |        |           |
-    |                   |              |       |        |      | stability >> | 100.00%  |        |           |
-    |                   |              |       |        |      | average >>   | 226.00μs | 3,416b |           |
-    +-------------------+--------------+-------+--------+------+--------------+----------+--------+-----------+
+    +-------------------+--------------+-------+--------+------+--------------+------+----------+--------+-----------+
+    | benchmark         | subject      | group | params | revs | iter         | rej  | time     | memory | deviation |
+    +-------------------+--------------+-------+--------+------+--------------+------+----------+--------+-----------+
+    | TimeConsumerBench | benchConsume |       | []     | 1    | 0            | 0    | 226.00μs | 3,416b | 0.00%     |
+    |                   |              |       |        |      |              |      |          |        |           |
+    |                   |              |       |        |      | stability >> |      | 100.00%  |        |           |
+    |                   |              |       |        |      | average >>   | 0.00 | 226.00μs | 3,416b |           |
+    +-------------------+--------------+-------+--------+------+--------------+------+----------+--------+-----------+
 
 Generator: :ref:`generator_table`.
 
@@ -30,6 +30,7 @@ Columns:
 - **params**: Any :ref:`parameters` which were passed to the benchmark.
 - **revs**: Number of :ref:`revolutions`.
 - **iter**: The :ref:`iteration <iterations>` index.
+- **rej**: Number of rejected iterations (see :ref:`retry_threshold`).
 - **time**: Time taken to execute a single iteration in microseconds_
 - **memory**: Memory used, in bytes.
 - **deviation**: Deviation from the mean as a percentage (when multiple
@@ -49,11 +50,11 @@ row for each subject:
 
 .. code-block:: bash
 
-    +-------------------+--------------+-------+--------+------+-------+------------+--------+-----------+-----------+
-    | benchmark         | subject      | group | params | revs | iters | time       | memory | deviation | stability |
-    +-------------------+--------------+-------+--------+------+-------+------------+--------+-----------+-----------+
-    | TimeConsumerBench | benchConsume |       | []     | 1    | 1     | 227.0000μs | 3,416b | 0.00%     | 100.00%   |
-    +-------------------+--------------+-------+--------+------+-------+------------+--------+-----------+-----------+
+    +-------------------+--------------+-------+--------+------+-------+-----+------------+--------+-----------+-----------+
+    | benchmark         | subject      | group | params | revs | iters | rej | time       | memory | deviation | stability |
+    +-------------------+--------------+-------+--------+------+-------+-----+------------+--------+-----------+-----------+
+    | TimeConsumerBench | benchConsume |       | []     | 1    | 1     | 0   | 227.0000μs | 3,416b | 0.00%     | 100.00%   |
+    +-------------------+--------------+-------+--------+------+-------+-----+-------+--------+-----------+-----------+
 
 Generator: :ref:`generator_table`.
 
@@ -65,6 +66,7 @@ Columns:
 - **params**: Any :ref:`parameters` which were passed to the benchmark.
 - **revs**: Sum of the number of :ref:`revolutions` for all iterations.
 - **iters**: Number of :ref:`iterations <iterations>` performed.
+- **rej**: Number of rejected iterations (see :ref:`retry_threshold`).
 - **time**: Average time taken for each iteration.
 - **memory**: Average memory used.
 - **deviation**: Deviation from the mean as a percentage (when multiple

--- a/docs/writing-benchmarks.rst
+++ b/docs/writing-benchmarks.rst
@@ -84,8 +84,8 @@ Revolutions can also be overridden from the :ref:`command line
 
 .. _iterations:
 
-Improving Stability: Iterations
--------------------------------
+Verifying and Improving Stability: Iterations
+---------------------------------------------
 
 Iterations represent the number of times we will perform the benchmark
 (including all the revolutions). Contrary to revolutions, a time reading will
@@ -116,6 +116,10 @@ Iterations can be specified using the ``@Iterations`` annotation:
 
 Iterations can also be overridden from the :ref:`command line
 <overriding_iterations_and_revolutions>`.
+
+You can instruct PHPBench to continuously run the iterations until the
+deviation of each iteration fits within a given margin of error by using the
+``--retry-threshold``. See :ref:`retry_threshold` for more information.
 
 Estabilishing State: Before and After
 -------------------------------------

--- a/examples/phpbench.json
+++ b/examples/phpbench.json
@@ -2,6 +2,7 @@
     "bootstrap": "../vendor/autoload.php",
     "path": "./",
     "progress": "verbose",
+    "retry_threshold": 10,
     "outputs": {
         "console_example": {
             "renderer": "console",

--- a/lib/Benchmark/ExecutorInterface.php
+++ b/lib/Benchmark/ExecutorInterface.php
@@ -21,7 +21,7 @@ use PhpBench\Config\ConfigurableInterface;
 interface ExecutorInterface extends ConfigurableInterface
 {
     /**
-     * Execute the benchmark and return metrics.
+     * Execute the benchmark and return the result.
      *
      * @param Iteration $iteration
      * @param array $options

--- a/lib/Benchmark/Iteration.php
+++ b/lib/Benchmark/Iteration.php
@@ -23,6 +23,16 @@ class Iteration
     private $parameters = array();
     private $index;
 
+    private $result;
+    private $deviation;
+    private $rejectionCount = 0;
+
+    /**
+     * @param int $index
+     * @param SubjectMetadata $subject
+     * @param int $revolutions
+     * @param array $parameters
+     */
     public function __construct(
         $index,
         SubjectMetadata $subject,
@@ -35,18 +45,114 @@ class Iteration
         $this->parameters = $parameters;
     }
 
+    /**
+     * Return the index of this iteration.
+     *
+     * @return int
+     */
+    public function getIndex()
+    {
+        return $this->index;
+    }
+
+    /**
+     * Get the subject metadata for this iteration.
+     *
+     * @return SubjectMetadata
+     */
     public function getSubject()
     {
         return $this->subject;
     }
 
+    /**
+     * Get the number of revolutions for this iteration.
+     *
+     * @return int
+     */
     public function getRevolutions()
     {
         return $this->revolutions;
     }
 
+    /**
+     * Get the parameter set for this iteration.
+     *
+     * @return array
+     */
     public function getParameters()
     {
         return $this->parameters;
+    }
+
+    /**
+     * Assosciate the result of the iteration with the iteration.
+     *
+     * @param int
+     */
+    public function setResult(IterationResult $result)
+    {
+        $this->result = $result;
+    }
+
+    /**
+     * Return the result.
+     *
+     * Throw an exception if the result has not yet been set.
+     *
+     * @throws \RuntimeException
+     *
+     * @return IterationResult
+     */
+    public function getResult()
+    {
+        if (!$this->result) {
+            throw new \RuntimeException(
+                'The iteration result has not been set yet.'
+            );
+        }
+
+        return $this->result;
+    }
+
+    /**
+     * Return the deviation from the mean for this iteration.
+     *
+     * @return float
+     */
+    public function getDeviation()
+    {
+        return $this->deviation;
+    }
+
+    /**
+     * Set the deviation of this iteration from other iterations in the same
+     * set.
+     *
+     * NOTE: Should be called by the IterationCollection
+     *
+     * @param int
+     */
+    public function setDeviation($deviation)
+    {
+        $this->deviation = $deviation;
+    }
+
+    /**
+     * Increase the reject count.
+     */
+    public function incrementRejectionCount()
+    {
+        $this->rejectionCount++;
+    }
+
+    /**
+     * Return the number of times that this iteration was rejected.
+     *
+     * @return int
+     */
+    public function getRejectionCount()
+    {
+        return $this->rejectionCount;
     }
 }

--- a/lib/Benchmark/IterationCollection.php
+++ b/lib/Benchmark/IterationCollection.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Benchmark;
+
+/**
+ * Stores Iterations and calculates the deviations and rejection
+ * status for each based on the given rejection threshold.
+ */
+class IterationCollection implements \IteratorAggregate
+{
+    /**
+     * @var Iteration[]
+     */
+    private $iterations = array();
+
+    /**
+     * @var Iteration[]
+     */
+    private $rejects = array();
+
+    /**
+     * @var float
+     */
+    private $rejectionThreshold;
+
+    /**
+     * @param float $rejectionThreshold
+     */
+    public function __construct($rejectionThreshold = null)
+    {
+        $this->rejectionThreshold = $rejectionThreshold;
+    }
+
+    /**
+     * Replace the iterations in the collection with the given iterations.
+     *
+     * @param Iteration[] $iterations
+     */
+    public function replace(array $iterations)
+    {
+        $this->iterations = $iterations;
+    }
+
+    /**
+     * Add an iteration.
+     *
+     * @param Iteration $iteration
+     */
+    public function add(Iteration $iteration)
+    {
+        $this->iterations[] = $iteration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->iterations);
+    }
+
+    /**
+     * Calculate and set the deviation from the mean time for each iteration. If
+     * the deviation is greater than the rejection threshold, then mark the iteration as
+     * rejected.
+     */
+    public function computeDeviations()
+    {
+        $this->rejects = array();
+        $average = $total = null;
+
+        if (0 === count($this->iterations)) {
+            return;
+        }
+
+        foreach ($this->iterations as $iteration) {
+            $total += $iteration->getResult()->getTime();
+        }
+        $average = $total / count($this->iterations);
+
+        foreach ($this->iterations as $iteration) {
+            // deviation is the percentage different of the value from the average of the set. We
+            // use abs() to always obtain a positive number.
+            $deviation = abs(100 / $average * ($iteration->getResult()->getTime() - $average));
+            $iteration->setDeviation($deviation);
+
+            if (null !== $this->rejectionThreshold) {
+                if ($deviation >= $this->rejectionThreshold) {
+                    $this->rejects[] = $iteration;
+                }
+            }
+        }
+    }
+
+    /**
+     * Return the number of rejected iterations.
+     *
+     * @return int
+     */
+    public function getRejectCount()
+    {
+        return count($this->rejects);
+    }
+
+    /**
+     * Return all rejected iterations.
+     *
+     * @return Iteration[]
+     */
+    public function getRejects()
+    {
+        return $this->rejects;
+    }
+}

--- a/lib/Console/Command/RunCommand.php
+++ b/lib/Console/Command/RunCommand.php
@@ -65,12 +65,13 @@ EOT
         $this->addArgument('path', InputArgument::OPTIONAL, 'Path to benchmark(s)');
         $this->addOption('subject', array(), InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Subject to run (can be specified multiple times)');
         $this->addOption('group', array(), InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Group to run (can be specified multiple times)');
-        $this->addOption('dump-file', 'df', InputOption::VALUE_OPTIONAL, 'Dump XML result to named file');
+        $this->addOption('dump-file', 'd', InputOption::VALUE_OPTIONAL, 'Dump XML result to named file');
         $this->addOption('dump', null, InputOption::VALUE_NONE, 'Dump XML result to stdout and suppress all other output');
         $this->addOption('parameters', null, InputOption::VALUE_REQUIRED, 'Override parameters to use in (all) benchmarks');
         $this->addOption('iterations', null, InputOption::VALUE_REQUIRED, 'Override number of iteratios to run in (all) benchmarks');
         $this->addOption('revs', null, InputOption::VALUE_REQUIRED, 'Override number of revs (revolutions) on (all) benchmarks');
         $this->addOption('progress', 'l', InputOption::VALUE_REQUIRED, 'Progress logger to use, one of <comment>dots</comment>, <comment>classdots</comment>');
+        $this->addOption('retry-threshold', 'r', InputOption::VALUE_REQUIRED, 'Set target allowable deviation', null);
 
         // this option is parsed before the container is compiled.
         $this->addOption('bootstrap', 'b', InputOption::VALUE_REQUIRED, 'Set or override the bootstrap file.');
@@ -92,6 +93,7 @@ EOT
         $dumpfile = $input->getOption('dump-file');
         $progressLoggerName = $input->getOption('progress') ?: $this->progressLoggerName;
         $inputPath = $input->getArgument('path');
+        $retryThreshold = $input->getOption('retry-threshold');
 
         $path = $inputPath ?: $this->benchPath;
 
@@ -129,7 +131,7 @@ EOT
 
         $consoleOutput->writeln('');
         $startTime = microtime(true);
-        $suiteResult = $this->executeBenchmarks($path, $subjects, $groups, $parameters, $iterations, $revs, $configPath, $progressLogger);
+        $suiteResult = $this->executeBenchmarks($path, $subjects, $groups, $parameters, $iterations, $revs, $configPath, $retryThreshold, $progressLogger);
         $consoleOutput->writeln('');
 
         $consoleOutput->writeln(sprintf(
@@ -163,6 +165,7 @@ EOT
         $iterations,
         $revs,
         $configPath,
+        $retryThreshold,
         LoggerInterface $progressLogger = null
     ) {
         if ($progressLogger) {
@@ -191,6 +194,10 @@ EOT
 
         if ($groups) {
             $this->runner->setGroups($groups);
+        }
+
+        if ($retryThreshold) {
+            $this->runner->setRetryThreshold($retryThreshold);
         }
 
         return $this->runner->runAll($path);

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -79,6 +79,7 @@ class CoreExtension implements ExtensionInterface
             'outputs' => array(),
             'config_path' => null,
             'progress' => 'dots',
+            'retry_threshold' => null,
         ));
     }
 
@@ -116,6 +117,7 @@ class CoreExtension implements ExtensionInterface
             return new Runner(
                 $container->get('benchmark.collection_builder'),
                 $container->get('benchmark.executor'),
+                $container->getParameter('retry_threshold'),
                 $container->getParameter('config_path')
             );
         });

--- a/lib/Progress/Logger/DotsLogger.php
+++ b/lib/Progress/Logger/DotsLogger.php
@@ -11,6 +11,7 @@
 
 namespace PhpBench\Progress\Logger;
 
+use PhpBench\Benchmark\Iteration;
 use PhpBench\Benchmark\Metadata\BenchmarkMetadata;
 use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Progress\LoggerInterface;
@@ -20,6 +21,8 @@ class DotsLogger implements LoggerInterface
 {
     private $output;
     private $showBench;
+
+    private $buffer;
 
     public function __construct($showBench = false)
     {
@@ -56,6 +59,35 @@ class DotsLogger implements LoggerInterface
 
     public function subjectEnd(SubjectMetadata $subject)
     {
-        $this->output->write('.');
+        $this->buffer .= '.';
+        $this->output->write(sprintf(
+            "\x0D%s ",
+            $this->buffer
+        ));
+    }
+
+    public function iterationStart(Iteration $iteration)
+    {
+        $state = $iteration->getIndex() % 4;
+        $states = array(
+            0 => '|',
+            1 => '/',
+            2 => '-',
+            3 => '\\',
+        );
+
+        $this->output->write(sprintf(
+            "\x0D%s%s",
+            $this->buffer,
+            $states[$state]
+        ));
+    }
+
+    public function iterationEnd(Iteration $iteration)
+    {
+    }
+
+    public function retryStart($rejectionCount)
+    {
     }
 }

--- a/lib/Progress/Logger/NullLogger.php
+++ b/lib/Progress/Logger/NullLogger.php
@@ -11,6 +11,7 @@
 
 namespace PhpBench\Progress\Logger;
 
+use PhpBench\Benchmark\Iteration;
 use PhpBench\Benchmark\Metadata\BenchmarkMetadata;
 use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Progress\LoggerInterface;
@@ -35,6 +36,18 @@ class NullLogger implements LoggerInterface
     }
 
     public function subjectEnd(SubjectMetadata $subject)
+    {
+    }
+
+    public function iterationStart(Iteration $iteration)
+    {
+    }
+
+    public function iterationEnd(Iteration $iteration)
+    {
+    }
+
+    public function retryStart($rejectionCount)
     {
     }
 }

--- a/lib/Progress/Logger/VerboseLogger.php
+++ b/lib/Progress/Logger/VerboseLogger.php
@@ -11,6 +11,7 @@
 
 namespace PhpBench\Progress\Logger;
 
+use PhpBench\Benchmark\Iteration;
 use PhpBench\Benchmark\Metadata\BenchmarkMetadata;
 use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Progress\LoggerInterface;
@@ -19,6 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class VerboseLogger implements LoggerInterface
 {
     private $output;
+    private $lastSubject;
 
     public function setOutput(OutputInterface $output)
     {
@@ -36,11 +38,36 @@ class VerboseLogger implements LoggerInterface
 
     public function subjectStart(SubjectMetadata $subject)
     {
-        $this->output->write('  <info>>> </info>' . $subject->getName());
+        $this->lastSubject = $this->lastRetry = sprintf('  <info>>> </info>%s:', $subject->getName());
+        $this->output->write($this->lastSubject);
     }
 
     public function subjectEnd(SubjectMetadata $subject)
     {
         $this->output->writeln(' [<info>OK</info>]');
+    }
+
+    public function iterationStart(Iteration $iteration)
+    {
+        static $count;
+        $this->output->write($this->lastIteration = sprintf(
+            "\x0D%s I%s ",
+            $this->lastRetry,
+            $iteration->getIndex()
+        ));
+        $count++;
+    }
+
+    public function iterationEnd(Iteration $iteration)
+    {
+    }
+
+    public function retryStart($rejectionCount)
+    {
+        $this->output->write($this->lastRetry = sprintf(
+            "\x0D%s %dR",
+            $this->lastSubject,
+            $rejectionCount
+        ));
     }
 }

--- a/lib/Progress/LoggerInterface.php
+++ b/lib/Progress/LoggerInterface.php
@@ -11,19 +11,59 @@
 
 namespace PhpBench\Progress;
 
+use PhpBench\Benchmark\Iteration;
 use PhpBench\Benchmark\Metadata\BenchmarkMetadata;
 use PhpBench\Benchmark\Metadata\SubjectMetadata;
-use Symfony\Component\Console\Output\OutputInterface;
+use PhpBench\Console\OutputAwareInterface;
 
-interface LoggerInterface
+interface LoggerInterface extends OutputAwareInterface
 {
+    /**
+     * Log the end of a benchmark.
+     *
+     * @param BenchmarkMetadata $benchmark
+     */
     public function benchmarkEnd(BenchmarkMetadata $benchmark);
 
+    /**
+     * Log the start of a benchmark.
+     *
+     * @param BenchmarkMetadata $benchmark
+     */
     public function benchmarkStart(BenchmarkMetadata $benchmark);
 
-    public function subjectEnd(SubjectMetadata $case);
+    /**
+     * Log the end of a benchmarking subject.
+     *
+     * @param SubjectMetadata $case
+     */
+    public function subjectEnd(SubjectMetadata $subject);
 
-    public function subjectStart(SubjectMetadata $case);
+    /**
+     * Log the end of a benchmarking subject.
+     *
+     * @param SubjectMetadata $case
+     */
+    public function subjectStart(SubjectMetadata $subject);
 
-    public function setOutput(OutputInterface $output);
+    /**
+     * Log the end of an iteration.
+     *
+     * @param Iteration $iteration
+     */
+    public function iterationEnd(Iteration $iteration);
+
+    /**
+     * Log the start of an iteration.
+     *
+     * @param Iteration $iteration
+     */
+    public function iterationStart(Iteration $iteration);
+
+    /**
+     * Log the number of retries to be made.
+     *
+     * @param int $rejectionCount
+     */
+    public function retryStart($rejectionCount);
 }

--- a/lib/Report/Generator/tabular/aggregate.json
+++ b/lib/Report/Generator/tabular/aggregate.json
@@ -30,8 +30,12 @@
                     "expr": "sum(descendant-or-self::iteration/@revs)"
                 },
                 {
-                    "name": "iters",
+                    "name": "its",
                     "expr": "count(descendant-or-self::iteration)"
+                },
+                {
+                    "name": "rej",
+                    "expr": "sum(descendant-or-self::iteration/@rejection-count)"
                 },
                 {
                     "name": "time",

--- a/lib/Report/Generator/tabular/classes.json
+++ b/lib/Report/Generator/tabular/classes.json
@@ -5,8 +5,7 @@
         ],
         "deviation": [
             [ "number", { "decimal_places": 2 }],
-            [ "printf", { "format": "%s%%" } ],
-            [ "balance" ]
+            [ "printf", { "format": "%s%%" } ]
         ],
         "memory": [
             [ "number" ],
@@ -19,6 +18,9 @@
         "time": [
             [ "number", { "decimal_places": 4 }],
             [ "printf", { "format": "%s\u03bcs" }]
+        ],
+        "number": [
+            [ "number", { "decimal_places": 2 }]
         ]
     }
 }

--- a/lib/Report/Generator/tabular/iteration.json
+++ b/lib/Report/Generator/tabular/iteration.json
@@ -34,6 +34,10 @@
                     "expr": "count(descendant-or-self::iteration/preceding-sibling::*)"
                 },
                 {
+                    "name": "rej",
+                    "expr": "string(descendant-or-self::iteration/@rejection-count)"
+                },
+                {
                     "name": "time",
                     "class": "time",
                     "expr": "number(descendant-or-self::iteration/@time) div number(sum(descendant-or-self::iteration/@revs))"
@@ -46,7 +50,7 @@
                 {
                     "name": "deviation",
                     "class": "deviation",
-                    "expr": "deviation(average(//iteration/@time), number(descendant-or-self::iteration/@time))"
+                    "expr": "number(descendant-or-self::iteration/@deviation)"
                 }
             ],
             "with_query": "{{ param.selector }}"
@@ -74,12 +78,16 @@
                         {
                             "col": "time", 
                             "class": "time"
+                        },
+                        {
+                            "col": "rej", 
+                            "class": "number"
                         }
                     ]
                 }
             ],
             "group": "footer",
-            "with_items": [ "average" ]
+            "with_items": [ "average", "sum" ]
         },
         {
             "cells": [

--- a/tests/Functional/Report/Generator/TabularGeneratorTest.php
+++ b/tests/Functional/Report/Generator/TabularGeneratorTest.php
@@ -213,8 +213,8 @@ class TabularGeneratorTest extends GeneratorTestCase
                     <parameter name="one" value="two" />
                     <parameter name="three" value="four" />
                 </parameter>
-                <iteration time="100" memory="100" revs="1" />
-                <iteration time="75" memory="100" revs="1" />
+                <iteration time="100" memory="100" revs="1" deviation="1" rejection-count="0"/>
+                <iteration time="75" memory="100" revs="1" deviation="2" rejection-count="0"/>
            </variant>
         </subject>
     </benchmark>

--- a/tests/System/RunTest.php
+++ b/tests/System/RunTest.php
@@ -298,4 +298,16 @@ class RunTest extends SystemTestCase
             array('markdown'),
         );
     }
+
+    /**
+     * It should set the retry threshold.
+     */
+    public function testRetryThreshold()
+    {
+        $process = $this->phpbench(
+            'run benchmarks/set1/BenchmarkBench.php --retry-threshold=50'
+        );
+
+        $this->assertExitCode(0, $process);
+    }
 }

--- a/tests/System/output/html.html
+++ b/tests/System/output/html.html
@@ -1,9 +1,3 @@
-      <div class="header">
-        <h1>PHPBench Benchmark Results</h1>
-      </div>
-      <div class="body">
-        <h2/>
-        <p/>
         <table>
           <thead>
             <tr>
@@ -13,6 +7,7 @@
               <th>params</th>
               <th>revs</th>
               <th>iter</th>
+              <th>rej</th>
               <th>time</th>
               <th>memory</th>
               <th>deviation</th>
@@ -26,253 +21,373 @@
               <td>[]</td>
               <td>1</td>
               <td>0</td>
-              <td>19,253.0000μs</td>
-              <td>288b</td>
-              <td>+2,145.65%</td>
-            </tr>
-            <tr>
-              <td>BenchmarkBench</td>
-              <td>benchDoNothing</td>
-              <td/>
-              <td>[]</td>
-              <td>1</td>
               <td>0</td>
-              <td>12.0000μs</td>
-              <td>192b</td>
-              <td>-98.6</td>
-            </tr>
-            <tr>
-              <td>BenchmarkBench</td>
-              <td>benchDoNothing</td>
-              <td/>
-              <td>[]</td>
-              <td>1</td>
-              <td>1</td>
-              <td>8.0000μs</td>
-              <td>384b</td>
-              <td>-99.07</td>
-            </tr>
-            <tr>
-              <td>BenchmarkBench</td>
-              <td>benchDoNothing</td>
-              <td/>
-              <td>[]</td>
-              <td>1</td>
-              <td>2</td>
-              <td>8.0000μs</td>
+              <td>41,634.0000μs</td>
               <td>576b</td>
-              <td>-99.07</td>
+              <td>0.00%</td>
             </tr>
             <tr>
               <td>BenchmarkBench</td>
-              <td>benchParameterized</td>
-              <td/>
+              <td>benchDoNothing</td>
+              <td>do_nothing</td>
               <td>[]</td>
-              <td>1</td>
-              <td>2</td>
-              <td>9.0000μs</td>
-              <td>192b</td>
-              <td>-98.95</td>
+              <td>10000</td>
+              <td>0</td>
+              <td>0</td>
+              <td>1.7757μs</td>
+              <td>560b</td>
+              <td>70.67%</td>
             </tr>
             <tr>
               <td>BenchmarkBench</td>
-              <td>benchParameterized</td>
-              <td/>
+              <td>benchDoNothing</td>
+              <td>do_nothing</td>
               <td>[]</td>
-              <td>1</td>
-              <td>2</td>
-              <td>8.0000μs</td>
-              <td>384b</td>
-              <td>-99.07</td>
-            </tr>
-            <tr>
-              <td>BenchmarkBench</td>
-              <td>benchParameterized</td>
-              <td/>
-              <td>[]</td>
-              <td>1</td>
-              <td>2</td>
-              <td>8.0000μs</td>
-              <td>576b</td>
-              <td>-99.07</td>
-            </tr>
-            <tr>
-              <td>BenchmarkBench</td>
-              <td>benchParameterized</td>
-              <td/>
-              <td>[]</td>
-              <td>1</td>
-              <td>2</td>
-              <td>8.0000μs</td>
-              <td>768b</td>
-              <td>-99.07</td>
-            </tr>
-            <tr>
-              <td>IsolatedBench</td>
-              <td>benchIterationIsolation</td>
-              <td/>
-              <td>[]</td>
+              <td>10000</td>
               <td>1</td>
               <td>0</td>
-              <td>91.0000μs</td>
-              <td>248b</td>
-              <td>-89.39</td>
+              <td>1.3282μs</td>
+              <td>560b</td>
+              <td>27.66%</td>
             </tr>
             <tr>
-              <td>IsolatedBench</td>
-              <td>benchIterationIsolation</td>
-              <td/>
+              <td>BenchmarkBench</td>
+              <td>benchDoNothing</td>
+              <td>do_nothing</td>
               <td>[]</td>
-              <td>1</td>
-              <td>1</td>
-              <td>37.0000μs</td>
-              <td>440b</td>
-              <td>-95.68</td>
-            </tr>
-            <tr>
-              <td>IsolatedBench</td>
-              <td>benchIterationIsolation</td>
-              <td/>
-              <td>[]</td>
-              <td>1</td>
+              <td>10000</td>
               <td>2</td>
-              <td>31.0000μs</td>
-              <td>632b</td>
-              <td>-96.38</td>
-            </tr>
-            <tr>
-              <td>IsolatedBench</td>
-              <td>benchIterationIsolation</td>
-              <td/>
-              <td>[]</td>
-              <td>1</td>
-              <td>3</td>
-              <td>29.0000μs</td>
-              <td>824b</td>
-              <td>-96.62</td>
-            </tr>
-            <tr>
-              <td>IsolatedBench</td>
-              <td>benchIterationIsolation</td>
-              <td/>
-              <td>[]</td>
-              <td>1</td>
-              <td>4</td>
-              <td>29.0000μs</td>
-              <td>1,016b</td>
-              <td>-96.62</td>
-            </tr>
-            <tr>
-              <td>IsolatedBench</td>
-              <td>benchIterationsIsolation</td>
-              <td/>
-              <td>[]</td>
-              <td>1</td>
               <td>0</td>
-              <td>34.0000μs</td>
-              <td>248b</td>
-              <td>-96.03</td>
+              <td>1.2570μs</td>
+              <td>560b</td>
+              <td>20.82%</td>
             </tr>
             <tr>
-              <td>IsolatedBench</td>
-              <td>benchIterationsIsolation</td>
-              <td/>
+              <td>BenchmarkBench</td>
+              <td>benchDoNothing</td>
+              <td>do_nothing</td>
               <td>[]</td>
-              <td>1</td>
-              <td>1</td>
-              <td>30.0000μs</td>
-              <td>440b</td>
-              <td>-96.5</td>
+              <td>10000</td>
+              <td>3</td>
+              <td>0</td>
+              <td>0.9412μs</td>
+              <td>560b</td>
+              <td>9.54%</td>
             </tr>
             <tr>
-              <td>IsolatedBench</td>
-              <td>benchIterationsIsolation</td>
-              <td/>
+              <td>BenchmarkBench</td>
+              <td>benchDoNothing</td>
+              <td>do_nothing</td>
               <td>[]</td>
+              <td>10000</td>
+              <td>4</td>
+              <td>0</td>
+              <td>0.8391μs</td>
+              <td>560b</td>
+              <td>19.35%</td>
+            </tr>
+            <tr>
+              <td>BenchmarkBench</td>
+              <td>benchDoNothing</td>
+              <td>do_nothing</td>
+              <td>[]</td>
+              <td>10000</td>
+              <td>5</td>
+              <td>0</td>
+              <td>0.8895μs</td>
+              <td>560b</td>
+              <td>14.51%</td>
+            </tr>
+            <tr>
+              <td>BenchmarkBench</td>
+              <td>benchDoNothing</td>
+              <td>do_nothing</td>
+              <td>[]</td>
+              <td>10000</td>
+              <td>6</td>
+              <td>0</td>
+              <td>0.8493μs</td>
+              <td>560b</td>
+              <td>18.37%</td>
+            </tr>
+            <tr>
+              <td>BenchmarkBench</td>
+              <td>benchDoNothing</td>
+              <td>do_nothing</td>
+              <td>[]</td>
+              <td>10000</td>
+              <td>7</td>
+              <td>0</td>
+              <td>0.8270μs</td>
+              <td>560b</td>
+              <td>20.51%</td>
+            </tr>
+            <tr>
+              <td>BenchmarkBench</td>
+              <td>benchDoNothing</td>
+              <td>do_nothing</td>
+              <td>[]</td>
+              <td>10000</td>
+              <td>8</td>
+              <td>0</td>
+              <td>0.8271μs</td>
+              <td>560b</td>
+              <td>20.50%</td>
+            </tr>
+            <tr>
+              <td>BenchmarkBench</td>
+              <td>benchDoNothing</td>
+              <td>do_nothing</td>
+              <td>[]</td>
+              <td>10000</td>
+              <td>9</td>
+              <td>0</td>
+              <td>0.8701μs</td>
+              <td>560b</td>
+              <td>16.37%</td>
+            </tr>
+            <tr>
+              <td>BenchmarkBench</td>
+              <td>benchParameterized</td>
+              <td>parameterized</td>
+              <td>{"length":"1","strategy":"left"}</td>
               <td>1</td>
               <td>2</td>
-              <td>29.0000μs</td>
-              <td>632b</td>
-              <td>-96.62</td>
+              <td>0</td>
+              <td>6.0000μs</td>
+              <td>552b</td>
+              <td>0.00%</td>
             </tr>
             <tr>
-              <td>IsolatedBench</td>
-              <td>benchIterationsIsolation</td>
-              <td/>
-              <td>[]</td>
-              <td>1</td>
-              <td>3</td>
-              <td>28.0000μs</td>
-              <td>824b</td>
-              <td>-96.73</td>
-            </tr>
-            <tr>
-              <td>IsolatedBench</td>
-              <td>benchIterationsIsolation</td>
-              <td/>
-              <td>[]</td>
-              <td>1</td>
-              <td>4</td>
-              <td>29.0000μs</td>
-              <td>1,016b</td>
-              <td>-96.62</td>
-            </tr>
-            <tr>
-              <td>IsolatedParameterBench</td>
-              <td>benchIterationIsolation</td>
-              <td/>
-              <td>[]</td>
+              <td>BenchmarkBench</td>
+              <td>benchParameterized</td>
+              <td>parameterized</td>
+              <td>{"length":"2","strategy":"left"}</td>
               <td>1</td>
               <td>2</td>
-              <td>10.0000μs</td>
-              <td>256b</td>
-              <td>-98.83</td>
+              <td>0</td>
+              <td>6.0000μs</td>
+              <td>552b</td>
+              <td>0.00%</td>
             </tr>
             <tr>
-              <td>IsolatedParameterBench</td>
-              <td>benchIterationIsolation</td>
-              <td/>
-              <td>[]</td>
+              <td>BenchmarkBench</td>
+              <td>benchParameterized</td>
+              <td>parameterized</td>
+              <td>{"length":"1","strategy":"right"}</td>
               <td>1</td>
-              <td>3</td>
-              <td>8.0000μs</td>
-              <td>256b</td>
-              <td>-99.07</td>
+              <td>2</td>
+              <td>0</td>
+              <td>6.0000μs</td>
+              <td>552b</td>
+              <td>0.00%</td>
             </tr>
             <tr>
-              <td>IsolatedParameterBench</td>
-              <td>benchIterationIsolation</td>
-              <td/>
-              <td>[]</td>
+              <td>BenchmarkBench</td>
+              <td>benchParameterized</td>
+              <td>parameterized</td>
+              <td>{"length":"2","strategy":"right"}</td>
               <td>1</td>
-              <td>4</td>
+              <td>2</td>
+              <td>0</td>
               <td>7.0000μs</td>
-              <td>256b</td>
-              <td>-99.18</td>
+              <td>552b</td>
+              <td>0.00%</td>
+            </tr>
+            <tr>
+              <td>IsolatedBench</td>
+              <td>benchIterationIsolation</td>
+              <td/>
+              <td>[]</td>
+              <td>1</td>
+              <td>0</td>
+              <td>0</td>
+              <td>45.0000μs</td>
+              <td>896b</td>
+              <td>2.74%</td>
+            </tr>
+            <tr>
+              <td>IsolatedBench</td>
+              <td>benchIterationIsolation</td>
+              <td/>
+              <td>[]</td>
+              <td>1</td>
+              <td>1</td>
+              <td>0</td>
+              <td>45.0000μs</td>
+              <td>896b</td>
+              <td>2.74%</td>
+            </tr>
+            <tr>
+              <td>IsolatedBench</td>
+              <td>benchIterationIsolation</td>
+              <td/>
+              <td>[]</td>
+              <td>1</td>
+              <td>2</td>
+              <td>0</td>
+              <td>42.0000μs</td>
+              <td>896b</td>
+              <td>4.11%</td>
+            </tr>
+            <tr>
+              <td>IsolatedBench</td>
+              <td>benchIterationIsolation</td>
+              <td/>
+              <td>[]</td>
+              <td>1</td>
+              <td>3</td>
+              <td>0</td>
+              <td>45.0000μs</td>
+              <td>896b</td>
+              <td>2.74%</td>
+            </tr>
+            <tr>
+              <td>IsolatedBench</td>
+              <td>benchIterationIsolation</td>
+              <td/>
+              <td>[]</td>
+              <td>1</td>
+              <td>4</td>
+              <td>0</td>
+              <td>42.0000μs</td>
+              <td>896b</td>
+              <td>4.11%</td>
+            </tr>
+            <tr>
+              <td>IsolatedBench</td>
+              <td>benchIterationsIsolation</td>
+              <td/>
+              <td>[]</td>
+              <td>1</td>
+              <td>0</td>
+              <td>0</td>
+              <td>43.0000μs</td>
+              <td>896b</td>
+              <td>0.46%</td>
+            </tr>
+            <tr>
+              <td>IsolatedBench</td>
+              <td>benchIterationsIsolation</td>
+              <td/>
+              <td>[]</td>
+              <td>1</td>
+              <td>1</td>
+              <td>0</td>
+              <td>45.0000μs</td>
+              <td>896b</td>
+              <td>4.17%</td>
+            </tr>
+            <tr>
+              <td>IsolatedBench</td>
+              <td>benchIterationsIsolation</td>
+              <td/>
+              <td>[]</td>
+              <td>1</td>
+              <td>2</td>
+              <td>0</td>
+              <td>43.0000μs</td>
+              <td>896b</td>
+              <td>0.46%</td>
+            </tr>
+            <tr>
+              <td>IsolatedBench</td>
+              <td>benchIterationsIsolation</td>
+              <td/>
+              <td>[]</td>
+              <td>1</td>
+              <td>3</td>
+              <td>0</td>
+              <td>43.0000μs</td>
+              <td>896b</td>
+              <td>0.46%</td>
+            </tr>
+            <tr>
+              <td>IsolatedBench</td>
+              <td>benchIterationsIsolation</td>
+              <td/>
+              <td>[]</td>
+              <td>1</td>
+              <td>4</td>
+              <td>0</td>
+              <td>42.0000μs</td>
+              <td>896b</td>
+              <td>2.78%</td>
             </tr>
             <tr>
               <td>IsolatedParameterBench</td>
               <td>benchIterationIsolation</td>
-              <td/>
-              <td>[]</td>
+              <td>process</td>
+              <td>{"hello":"Look \"I am using double quotes\"","goodbye":"Look 'I am use $dollars\""}</td>
+              <td>1</td>
+              <td>2</td>
+              <td>0</td>
+              <td>7.0000μs</td>
+              <td>544b</td>
+              <td>9.38%</td>
+            </tr>
+            <tr>
+              <td>IsolatedParameterBench</td>
+              <td>benchIterationIsolation</td>
+              <td>process</td>
+              <td>{"hello":"Look \"I am using double quotes\"","goodbye":"Look 'I am use $dollars\""}</td>
+              <td>1</td>
+              <td>3</td>
+              <td>0</td>
+              <td>6.0000μs</td>
+              <td>544b</td>
+              <td>6.25%</td>
+            </tr>
+            <tr>
+              <td>IsolatedParameterBench</td>
+              <td>benchIterationIsolation</td>
+              <td>process</td>
+              <td>{"hello":"Look \"I am using double quotes\"","goodbye":"Look 'I am use $dollars\""}</td>
+              <td>1</td>
+              <td>4</td>
+              <td>0</td>
+              <td>6.0000μs</td>
+              <td>544b</td>
+              <td>6.25%</td>
+            </tr>
+            <tr>
+              <td>IsolatedParameterBench</td>
+              <td>benchIterationIsolation</td>
+              <td>process</td>
+              <td>{"hello":"Look \"I am using double quotes\"","goodbye":"Look 'I am use $dollars\""}</td>
               <td>1</td>
               <td>5</td>
-              <td>7.0000μs</td>
-              <td>256b</td>
-              <td>-99.18</td>
+              <td>0</td>
+              <td>6.0000μs</td>
+              <td>544b</td>
+              <td>6.25%</td>
             </tr>
             <tr>
               <td>IsolatedParameterBench</td>
               <td>benchIterationIsolation</td>
-              <td/>
-              <td>[]</td>
+              <td>process</td>
+              <td>{"hello":"Look \"I am using double quotes\"","goodbye":"Look 'I am use $dollars\""}</td>
               <td>1</td>
               <td>6</td>
-              <td>6.0000μs</td>
-              <td>256b</td>
-              <td>-99.3</td>
+              <td>0</td>
+              <td>7.0000μs</td>
+              <td>544b</td>
+              <td>9.38%</td>
             </tr>
             <tr>
+              <td>IsolatedRevsBench</td>
+              <td>benchIterationIsolation</td>
+              <td/>
+              <td>[]</td>
+              <td>100</td>
+              <td>0</td>
+              <td>0</td>
+              <td>10.8500μs</td>
+              <td>896b</td>
+              <td>0.00%</td>
+            </tr>
+            <tr>
+              <td/>
               <td/>
               <td/>
               <td/>
@@ -290,7 +405,8 @@
               <td/>
               <td/>
               <td>stability</td>
-              <td>-320683.33%</td>
+              <td/>
+              <td>-693700.00%</td>
               <td/>
               <td/>
             </tr>
@@ -301,10 +417,22 @@
               <td/>
               <td/>
               <td>average</td>
-              <td>857.3478μs</td>
-              <td>477b</td>
+              <td>0.00</td>
+              <td>1,359.5888μs</td>
+              <td>676b</td>
+              <td/>
+            </tr>
+            <tr>
+              <td/>
+              <td/>
+              <td/>
+              <td/>
+              <td/>
+              <td>sum</td>
+              <td>0.00</td>
+              <td>42,147.2542μs</td>
+              <td>20,960b</td>
               <td/>
             </tr>
           </tbody>
         </table>
-      </div>

--- a/tests/System/output/markdown.md
+++ b/tests/System/output/markdown.md
@@ -1,33 +1,42 @@
 PHPBench Benchmark Results
 ==========================
 
-benchmark | subject | group | params | revs | iter | time | memory | deviation
- --- | --- | --- | --- | --- | --- | --- | --- | --- 
-BenchmarkBench | benchRandom |  | [] | 1 | 0 | 19,253.0000μs | 288b | +2,145.65%
-BenchmarkBench | benchDoNothing |  | [] | 1 | 0 | 12.0000μs | 192b | -98.6
-BenchmarkBench | benchDoNothing |  | [] | 1 | 1 | 8.0000μs | 384b | -99.07
-BenchmarkBench | benchDoNothing |  | [] | 1 | 2 | 8.0000μs | 576b | -99.07
-BenchmarkBench | benchParameterized |  | [] | 1 | 2 | 9.0000μs | 192b | -98.95
-BenchmarkBench | benchParameterized |  | [] | 1 | 2 | 8.0000μs | 384b | -99.07
-BenchmarkBench | benchParameterized |  | [] | 1 | 2 | 8.0000μs | 576b | -99.07
-BenchmarkBench | benchParameterized |  | [] | 1 | 2 | 8.0000μs | 768b | -99.07
-IsolatedBench | benchIterationIsolation |  | [] | 1 | 0 | 91.0000μs | 248b | -89.39
-IsolatedBench | benchIterationIsolation |  | [] | 1 | 1 | 37.0000μs | 440b | -95.68
-IsolatedBench | benchIterationIsolation |  | [] | 1 | 2 | 31.0000μs | 632b | -96.38
-IsolatedBench | benchIterationIsolation |  | [] | 1 | 3 | 29.0000μs | 824b | -96.62
-IsolatedBench | benchIterationIsolation |  | [] | 1 | 4 | 29.0000μs | 1,016b | -96.62
-IsolatedBench | benchIterationsIsolation |  | [] | 1 | 0 | 34.0000μs | 248b | -96.03
-IsolatedBench | benchIterationsIsolation |  | [] | 1 | 1 | 30.0000μs | 440b | -96.5
-IsolatedBench | benchIterationsIsolation |  | [] | 1 | 2 | 29.0000μs | 632b | -96.62
-IsolatedBench | benchIterationsIsolation |  | [] | 1 | 3 | 28.0000μs | 824b | -96.73
-IsolatedBench | benchIterationsIsolation |  | [] | 1 | 4 | 29.0000μs | 1,016b | -96.62
-IsolatedParameterBench | benchIterationIsolation |  | [] | 1 | 2 | 10.0000μs | 256b | -98.83
-IsolatedParameterBench | benchIterationIsolation |  | [] | 1 | 3 | 8.0000μs | 256b | -99.07
-IsolatedParameterBench | benchIterationIsolation |  | [] | 1 | 4 | 7.0000μs | 256b | -99.18
-IsolatedParameterBench | benchIterationIsolation |  | [] | 1 | 5 | 7.0000μs | 256b | -99.18
-IsolatedParameterBench | benchIterationIsolation |  | [] | 1 | 6 | 6.0000μs | 256b | -99.3
- |  |  |  |  |  |  |  | 
- |  |  |  |  | stability | -320683.33% |  | 
- |  |  |  |  | average | 857.3478μs | 477b | 
+benchmark | subject | group | params | revs | iter | rej | time | memory | deviation
+ --- | --- | --- | --- | --- | --- | --- | --- | --- | --- 
+BenchmarkBench | benchRandom |  | [] | 1 | 0 | 0 | 41,634.0000μs | 576b | 0.00%
+BenchmarkBench | benchDoNothing | do_nothing | [] | 10000 | 0 | 0 | 1.7757μs | 560b | 70.67%
+BenchmarkBench | benchDoNothing | do_nothing | [] | 10000 | 1 | 0 | 1.3282μs | 560b | 27.66%
+BenchmarkBench | benchDoNothing | do_nothing | [] | 10000 | 2 | 0 | 1.2570μs | 560b | 20.82%
+BenchmarkBench | benchDoNothing | do_nothing | [] | 10000 | 3 | 0 | 0.9412μs | 560b | 9.54%
+BenchmarkBench | benchDoNothing | do_nothing | [] | 10000 | 4 | 0 | 0.8391μs | 560b | 19.35%
+BenchmarkBench | benchDoNothing | do_nothing | [] | 10000 | 5 | 0 | 0.8895μs | 560b | 14.51%
+BenchmarkBench | benchDoNothing | do_nothing | [] | 10000 | 6 | 0 | 0.8493μs | 560b | 18.37%
+BenchmarkBench | benchDoNothing | do_nothing | [] | 10000 | 7 | 0 | 0.8270μs | 560b | 20.51%
+BenchmarkBench | benchDoNothing | do_nothing | [] | 10000 | 8 | 0 | 0.8271μs | 560b | 20.50%
+BenchmarkBench | benchDoNothing | do_nothing | [] | 10000 | 9 | 0 | 0.8701μs | 560b | 16.37%
+BenchmarkBench | benchParameterized | parameterized | {"length":"1","strategy":"left"} | 1 | 2 | 0 | 6.0000μs | 552b | 0.00%
+BenchmarkBench | benchParameterized | parameterized | {"length":"2","strategy":"left"} | 1 | 2 | 0 | 6.0000μs | 552b | 0.00%
+BenchmarkBench | benchParameterized | parameterized | {"length":"1","strategy":"right"} | 1 | 2 | 0 | 6.0000μs | 552b | 0.00%
+BenchmarkBench | benchParameterized | parameterized | {"length":"2","strategy":"right"} | 1 | 2 | 0 | 7.0000μs | 552b | 0.00%
+IsolatedBench | benchIterationIsolation |  | [] | 1 | 0 | 0 | 45.0000μs | 896b | 2.74%
+IsolatedBench | benchIterationIsolation |  | [] | 1 | 1 | 0 | 45.0000μs | 896b | 2.74%
+IsolatedBench | benchIterationIsolation |  | [] | 1 | 2 | 0 | 42.0000μs | 896b | 4.11%
+IsolatedBench | benchIterationIsolation |  | [] | 1 | 3 | 0 | 45.0000μs | 896b | 2.74%
+IsolatedBench | benchIterationIsolation |  | [] | 1 | 4 | 0 | 42.0000μs | 896b | 4.11%
+IsolatedBench | benchIterationsIsolation |  | [] | 1 | 0 | 0 | 43.0000μs | 896b | 0.46%
+IsolatedBench | benchIterationsIsolation |  | [] | 1 | 1 | 0 | 45.0000μs | 896b | 4.17%
+IsolatedBench | benchIterationsIsolation |  | [] | 1 | 2 | 0 | 43.0000μs | 896b | 0.46%
+IsolatedBench | benchIterationsIsolation |  | [] | 1 | 3 | 0 | 43.0000μs | 896b | 0.46%
+IsolatedBench | benchIterationsIsolation |  | [] | 1 | 4 | 0 | 42.0000μs | 896b | 2.78%
+IsolatedParameterBench | benchIterationIsolation | process | {"hello":"Look \"I am using double quotes\"","goodbye":"Look 'I am use $dollars\""} | 1 | 2 | 0 | 7.0000μs | 544b | 9.38%
+IsolatedParameterBench | benchIterationIsolation | process | {"hello":"Look \"I am using double quotes\"","goodbye":"Look 'I am use $dollars\""} | 1 | 3 | 0 | 6.0000μs | 544b | 6.25%
+IsolatedParameterBench | benchIterationIsolation | process | {"hello":"Look \"I am using double quotes\"","goodbye":"Look 'I am use $dollars\""} | 1 | 4 | 0 | 6.0000μs | 544b | 6.25%
+IsolatedParameterBench | benchIterationIsolation | process | {"hello":"Look \"I am using double quotes\"","goodbye":"Look 'I am use $dollars\""} | 1 | 5 | 0 | 6.0000μs | 544b | 6.25%
+IsolatedParameterBench | benchIterationIsolation | process | {"hello":"Look \"I am using double quotes\"","goodbye":"Look 'I am use $dollars\""} | 1 | 6 | 0 | 7.0000μs | 544b | 9.38%
+IsolatedRevsBench | benchIterationIsolation |  | [] | 100 | 0 | 0 | 10.8500μs | 896b | 0.00%
+ |  |  |  |  |  |  |  |  | 
+ |  |  |  |  | stability |  | -693700.00% |  | 
+ |  |  |  |  | average | 0.00 | 1,359.5888μs | 676b | 
+ |  |  |  |  | sum | 0.00 | 42,147.2542μs | 20,960b | 
 
 

--- a/tests/System/report.xml
+++ b/tests/System/report.xml
@@ -1,74 +1,89 @@
 <?xml version="1.0"?>
-<phpbench version="0.1" date="2015-05-25T09:24:11+02:00">
-  <suite>
-    <benchmark class="BenchmarkBench">
-      <subject name="benchRandom">
-        <iterations>
-          <iteration pid="1234" index="0" revs="1" time="19253" memory="288" memory_diff="288" memory_inc="3050824" memory_diff_inc="31192"/>
-        </iterations>
-      </subject>
-      <subject name="benchDoNothing" description="Do nothing three times">
-        <iterations>
-          <iteration pid="1234" index="0" revs="1" time="12" memory="192" memory_diff="192" memory_inc="3077888" memory_diff_inc="2784"/>
-          <iteration pid="1234" index="1" revs="1" time="8" memory="384" memory_diff="192" memory_inc="3079208" memory_diff_inc="1320"/>
-          <iteration pid="1234" index="2" revs="1" time="8" memory="576" memory_diff="192" memory_inc="3080544" memory_diff_inc="1336"/>
-        </iterations>
-      </subject>
-      <subject name="benchParameterized">
-        <iterations>
-          <parameter name="length" value="1"/>
-          <parameter name="strategy" value="left"/>
-          <iteration pid="1234" index="0" revs="1" time="9" memory="192" memory_diff="192" memory_inc="3085832" memory_diff_inc="5712"/>
-        </iterations>
-        <iterations>
-          <parameter name="length" value="2"/>
-          <parameter name="strategy" value="left"/>
-          <iteration pid="1234" index="0" revs="1" time="8" memory="384" memory_diff="192" memory_inc="3087976" memory_diff_inc="2144"/>
-        </iterations>
-        <iterations>
-          <parameter name="length" value="1"/>
-          <parameter name="strategy" value="right"/>
-          <iteration pid="1234" index="0" revs="1" time="8" memory="576" memory_diff="192" memory_inc="3090136" memory_diff_inc="2160"/>
-        </iterations>
-        <iterations>
-          <parameter name="length" value="2"/>
-          <parameter name="strategy" value="right"/>
-          <iteration pid="1234" index="0" revs="1" time="8" memory="768" memory_diff="192" memory_inc="3092296" memory_diff_inc="2160"/>
-        </iterations>
-      </subject>
-    </benchmark>
-    <benchmark class="IsolatedBench">
-      <subject name="benchIterationIsolation">
-        <iterations>
-          <iteration pid="1234" index="0" revs="1" time="91" memory="248" memory_diff="248" memory_inc="3096448" memory_diff_inc="2840"/>
-          <iteration pid="1234" index="1" revs="1" time="37" memory="440" memory_diff="192" memory_inc="3097768" memory_diff_inc="1320"/>
-          <iteration pid="1234" index="2" revs="1" time="31" memory="632" memory_diff="192" memory_inc="3099104" memory_diff_inc="1336"/>
-          <iteration pid="1234" index="3" revs="1" time="29" memory="824" memory_diff="192" memory_inc="3100440" memory_diff_inc="1336"/>
-          <iteration pid="1234" index="4" revs="1" time="29" memory="1016" memory_diff="192" memory_inc="3101776" memory_diff_inc="1336"/>
-        </iterations>
-      </subject>
-      <subject name="benchIterationsIsolation">
-        <iterations>
-          <iteration pid="1234" index="0" revs="1" time="34" memory="248" memory_diff="248" memory_inc="3104272" memory_diff_inc="2840"/>
-          <iteration pid="1234" index="1" revs="1" time="30" memory="440" memory_diff="192" memory_inc="3105592" memory_diff_inc="1320"/>
-          <iteration pid="1234" index="2" revs="1" time="29" memory="632" memory_diff="192" memory_inc="3106928" memory_diff_inc="1336"/>
-          <iteration pid="1234" index="3" revs="1" time="28" memory="824" memory_diff="192" memory_inc="3108288" memory_diff_inc="1360"/>
-          <iteration pid="1234" index="4" revs="1" time="29" memory="1016" memory_diff="192" memory_inc="3109624" memory_diff_inc="1336"/>
-        </iterations>
-      </subject>
-    </benchmark>
-    <benchmark class="IsolatedParameterBench">
-      <subject name="benchIterationIsolation">
-        <iterations>
-          <parameter name="hello" value="Look &quot;I am using double quotes&quot;"/>
-          <parameter name="goodbye" value="Look 'I am use $dollars&quot;"/>
-          <iteration pid="1234" index="0" revs="1" time="10" memory="256" memory_diff="256" memory_inc="3039688" memory_diff_inc="31096"/>
-          <iteration pid="1234" index="0" revs="1" time="8" memory="256" memory_diff="256" memory_inc="3039688" memory_diff_inc="31096"/>
-          <iteration pid="1234" index="0" revs="1" time="7" memory="256" memory_diff="256" memory_inc="3039688" memory_diff_inc="31096"/>
-          <iteration pid="1234" index="0" revs="1" time="7" memory="256" memory_diff="256" memory_inc="3039688" memory_diff_inc="31096"/>
-          <iteration pid="1234" index="0" revs="1" time="6" memory="256" memory_diff="256" memory_inc="3039688" memory_diff_inc="31096"/>
-        </iterations>
-      </subject>
-    </benchmark>
-  </suite>
+<phpbench version="0.6">
+  <benchmark class="\BenchmarkBench">
+    <subject name="benchRandom">
+      <variant>
+        <iteration revs="1" time="41634" memory="576" deviation="0" rejection-count="0"/>
+      </variant>
+    </subject>
+    <subject name="benchDoNothing">
+      <group name="do_nothing"/>
+      <variant>
+        <iteration revs="10000" time="17757" memory="560" deviation="70.671459602853" rejection-count="0"/>
+        <iteration revs="10000" time="13282" memory="560" deviation="27.659983468215" rejection-count="0"/>
+        <iteration revs="10000" time="12570" memory="560" deviation="20.81659329886" rejection-count="0"/>
+        <iteration revs="10000" time="9412" memory="560" deviation="9.5365333230811" rejection-count="0"/>
+        <iteration revs="10000" time="8391" memory="560" deviation="19.349877933911" rejection-count="0"/>
+        <iteration revs="10000" time="8895" memory="560" deviation="14.505680398301" rejection-count="0"/>
+        <iteration revs="10000" time="8493" memory="560" deviation="18.369504623133" rejection-count="0"/>
+        <iteration revs="10000" time="8270" memory="560" deviation="20.51286980258" rejection-count="0"/>
+        <iteration revs="10000" time="8271" memory="560" deviation="20.503258299533" rejection-count="0"/>
+        <iteration revs="10000" time="8701" memory="560" deviation="16.370311989389" rejection-count="0"/>
+      </variant>
+    </subject>
+    <subject name="benchParameterized">
+      <group name="parameterized"/>
+      <variant>
+        <parameter name="length" value="1"/>
+        <parameter name="strategy" value="left"/>
+        <iteration revs="1" time="6" memory="552" deviation="0" rejection-count="0"/>
+      </variant>
+      <variant>
+        <parameter name="length" value="2"/>
+        <parameter name="strategy" value="left"/>
+        <iteration revs="1" time="6" memory="552" deviation="0" rejection-count="0"/>
+      </variant>
+      <variant>
+        <parameter name="length" value="1"/>
+        <parameter name="strategy" value="right"/>
+        <iteration revs="1" time="6" memory="552" deviation="0" rejection-count="0"/>
+      </variant>
+      <variant>
+        <parameter name="length" value="2"/>
+        <parameter name="strategy" value="right"/>
+        <iteration revs="1" time="7" memory="552" deviation="0" rejection-count="0"/>
+      </variant>
+    </subject>
+  </benchmark>
+  <benchmark class="\IsolatedBench">
+    <subject name="benchIterationIsolation">
+      <variant>
+        <iteration revs="1" time="45" memory="896" deviation="2.7397260273973" rejection-count="0"/>
+        <iteration revs="1" time="45" memory="896" deviation="2.7397260273973" rejection-count="0"/>
+        <iteration revs="1" time="42" memory="896" deviation="4.1095890410959" rejection-count="0"/>
+        <iteration revs="1" time="45" memory="896" deviation="2.7397260273973" rejection-count="0"/>
+        <iteration revs="1" time="42" memory="896" deviation="4.1095890410959" rejection-count="0"/>
+      </variant>
+    </subject>
+    <subject name="benchIterationsIsolation">
+      <variant>
+        <iteration revs="1" time="43" memory="896" deviation="0.46296296296297" rejection-count="0"/>
+        <iteration revs="1" time="45" memory="896" deviation="4.1666666666667" rejection-count="0"/>
+        <iteration revs="1" time="43" memory="896" deviation="0.46296296296297" rejection-count="0"/>
+        <iteration revs="1" time="43" memory="896" deviation="0.46296296296297" rejection-count="0"/>
+        <iteration revs="1" time="42" memory="896" deviation="2.7777777777778" rejection-count="0"/>
+      </variant>
+    </subject>
+  </benchmark>
+  <benchmark class="\IsolatedParameterBench">
+    <subject name="benchIterationIsolation">
+      <group name="process"/>
+      <variant>
+        <parameter name="hello" value="Look &quot;I am using double quotes&quot;"/>
+        <parameter name="goodbye" value="Look 'I am use $dollars&quot;"/>
+        <iteration revs="1" time="7" memory="544" deviation="9.375" rejection-count="0"/>
+        <iteration revs="1" time="6" memory="544" deviation="6.25" rejection-count="0"/>
+        <iteration revs="1" time="6" memory="544" deviation="6.25" rejection-count="0"/>
+        <iteration revs="1" time="6" memory="544" deviation="6.25" rejection-count="0"/>
+        <iteration revs="1" time="7" memory="544" deviation="9.375" rejection-count="0"/>
+      </variant>
+    </subject>
+  </benchmark>
+  <benchmark class="\IsolatedRevsBench">
+    <subject name="benchIterationIsolation">
+      <variant>
+        <iteration revs="100" time="1085" memory="896" deviation="0" rejection-count="0"/>
+      </variant>
+    </subject>
+  </benchmark>
 </phpbench>

--- a/tests/Unit/Benchmark/IterationCollectionTest.php
+++ b/tests/Unit/Benchmark/IterationCollectionTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Tests\Unit\Benchmark;
+
+use PhpBench\Benchmark\IterationCollection;
+use PhpBench\Benchmark\IterationResult;
+
+class IterationCollectionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * It should be iterable
+     * It sohuld be countable.
+     */
+    public function testIteration()
+    {
+        $iterations = new IterationCollection();
+        $iterations->replace(array(
+            $this->createIteration(4),
+            $this->createIteration(4),
+            $this->createIteration(6),
+            $this->createIteration(8),
+        ));
+
+        $this->assertCount(4, $iterations);
+
+        foreach ($iterations as $iteration) {
+            $this->assertInstanceOf('PhpBench\Benchmark\Iteration', $iteration);
+        }
+    }
+
+    /**
+     * It should calculate the deviation of each iteration from the average.
+     */
+    public function testComputeDeviation()
+    {
+        $iterations = new IterationCollection();
+        $iterations->replace(array(
+            $this->createIteration(4, 50),
+            $this->createIteration(8, 0),
+            $this->createIteration(4, 50),
+            $this->createIteration(16, 100),
+        ));
+
+        $iterations->computeDeviations();
+    }
+
+    /**
+     * It should not crash if compute deviations is called with zero iterations in the collection.
+     */
+    public function testComputeDeviationZeroIterations()
+    {
+        $iterations = new IterationCollection();
+        $iterations->computeDeviations();
+    }
+
+    /**
+     * It should mark iterations as rejected if they deviate too far from the mean.
+     */
+    public function testReject()
+    {
+        $iterations = new IterationCollection(50);
+        $iterations->replace(array(
+            $iter1 = $this->createIteration(4, 50),
+            $iter2 = $this->createIteration(8, 0),
+            $iter3 = $this->createIteration(4, 50),
+            $iter4 = $this->createIteration(16, 100),
+        ));
+
+        $iterations->computeDeviations();
+
+        $this->assertCount(3, $iterations->getRejects());
+        $this->assertContains($iter1, $iterations->getRejects());
+        $this->assertContains($iter3, $iterations->getRejects());
+        $this->assertContains($iter4, $iterations->getRejects());
+        $this->assertNotContains($iter2, $iterations->getRejects());
+    }
+
+    private function createIteration($time, $expectedDeviation = null)
+    {
+        $iteration = $this->prophesize('PhpBench\Benchmark\Iteration');
+        $iteration->getResult()->willReturn(new IterationResult($time, null));
+
+        if (null !== $expectedDeviation) {
+            $iteration->setDeviation($expectedDeviation)->shouldBeCalled();
+        }
+
+        return $iteration->reveal();
+    }
+}

--- a/tests/Unit/Benchmark/IterationTest.php
+++ b/tests/Unit/Benchmark/IterationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Tests\Unit\Benchmark;
+
+use PhpBench\Benchmark\Iteration;
+use PhpBench\Benchmark\IterationResult;
+
+class IterationTest extends \PHPUnit_Framework_TestCase
+{
+    private $iteration;
+    private $subject;
+
+    public function setUp()
+    {
+        $this->subject = $this->prophesize('PhpBench\Benchmark\Metadata\SubjectMetadata');
+        $this->iteration = new Iteration(
+            0,
+            $this->subject->reveal(),
+            5,
+            array()
+        );
+    }
+
+    /**
+     * It should throw an exception something tries to retrieve the result before it has been set.
+     *
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage iteration result
+     */
+    public function testGetResultNotSet()
+    {
+        $this->iteration->getResult();
+    }
+
+    /**
+     * It should be possible to set and override the iteration result.
+     */
+    public function testSetResult()
+    {
+        $result = new IterationResult(10, 10);
+        $this->iteration->setResult($result);
+        $this->iteration->setResult($result);
+        $this->assertSame($result, $this->iteration->getResult());
+    }
+}

--- a/tests/Unit/Benchmark/RunnerTest.php
+++ b/tests/Unit/Benchmark/RunnerTest.php
@@ -31,6 +31,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         $this->runner = new Runner(
             $this->collectionBuilder->reveal(),
             $this->executor->reveal(),
+            null,
             null
         );
     }
@@ -67,7 +68,9 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         $this->benchmark->getClass()->willReturn('Benchmark');
 
         if (!$exception) {
-            $this->executor->execute(Argument::type('PhpBench\Benchmark\Iteration'))->shouldBeCalledTimes(count($revs) * $iterations)->willReturn(new IterationResult(10, 10));
+            $this->executor->execute(Argument::type('PhpBench\Benchmark\Iteration'))
+                ->shouldBeCalledTimes(count($revs) * $iterations)
+                ->willReturn(new IterationResult(10, 10));
         }
 
         $result = $this->runner->runAll(__DIR__);
@@ -96,7 +99,7 @@ EOT
   <benchmark class="Benchmark">
     <subject name="benchFoo">
       <variant>
-        <iteration revs="1" time="10" memory="10"/>
+        <iteration revs="1" time="10" memory="10" deviation="0" rejection-count="0"/>
       </variant>
     </subject>
   </benchmark>
@@ -110,8 +113,8 @@ EOT
   <benchmark class="Benchmark">
     <subject name="benchFoo">
       <variant>
-        <iteration revs="1" time="10" memory="10"/>
-        <iteration revs="3" time="10" memory="10"/>
+        <iteration revs="1" time="10" memory="10" deviation="0" rejection-count="0"/>
+        <iteration revs="3" time="10" memory="10" deviation="0" rejection-count="0"/>
       </variant>
     </subject>
   </benchmark>
@@ -125,14 +128,14 @@ EOT
   <benchmark class="Benchmark">
     <subject name="benchFoo">
       <variant>
-        <iteration revs="1" time="10" memory="10"/>
-        <iteration revs="3" time="10" memory="10"/>
-        <iteration revs="1" time="10" memory="10"/>
-        <iteration revs="3" time="10" memory="10"/>
-        <iteration revs="1" time="10" memory="10"/>
-        <iteration revs="3" time="10" memory="10"/>
-        <iteration revs="1" time="10" memory="10"/>
-        <iteration revs="3" time="10" memory="10"/>
+        <iteration revs="1" time="10" memory="10" deviation="0" rejection-count="0"/>
+        <iteration revs="3" time="10" memory="10" deviation="0" rejection-count="0"/>
+        <iteration revs="1" time="10" memory="10" deviation="0" rejection-count="0"/>
+        <iteration revs="3" time="10" memory="10" deviation="0" rejection-count="0"/>
+        <iteration revs="1" time="10" memory="10" deviation="0" rejection-count="0"/>
+        <iteration revs="3" time="10" memory="10" deviation="0" rejection-count="0"/>
+        <iteration revs="1" time="10" memory="10" deviation="0" rejection-count="0"/>
+        <iteration revs="3" time="10" memory="10" deviation="0" rejection-count="0"/>
       </variant>
     </subject>
   </benchmark>
@@ -148,7 +151,7 @@ EOT
       <variant>
         <parameter name="one" value="two"/>
         <parameter name="three" value="four"/>
-        <iteration revs="1" time="10" memory="10"/>
+        <iteration revs="1" time="10" memory="10" deviation="0" rejection-count="0"/>
       </variant>
     </subject>
   </benchmark>
@@ -164,7 +167,7 @@ EOT
       <variant>
         <parameter name="0" value="one"/>
         <parameter name="1" value="two"/>
-        <iteration revs="1" time="10" memory="10"/>
+        <iteration revs="1" time="10" memory="10" deviation="0" rejection-count="0"/>
       </variant>
     </subject>
   </benchmark>
@@ -181,7 +184,7 @@ EOT
         <parameter name="one" type="collection">
           <parameter name="three" value="four"/>
         </parameter>
-        <iteration revs="1" time="10" memory="10"/>
+        <iteration revs="1" time="10" memory="10" deviation="0" rejection-count="0"/>
       </variant>
     </subject>
   </benchmark>
@@ -227,6 +230,17 @@ EOT
             , PhpBench::VERSION)),
             trim($result->saveXml())
         );
+    }
+
+    /**
+     * It should throw an exception if the retry threshold is not numeric.
+     *
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage numeric
+     */
+    public function testRetryNotNumeric()
+    {
+        $this->runner->setRetryThreshold('asd');
     }
 
     private function configureSubject($subject, array $options)


### PR DESCRIPTION
This PR introduces a new feature. Currently, if the system is unstable and there are anomalous timings, it is necessary to rerun the benchmarks until a suitable stability is reached.

This PR will introduce "Reject and Retry" on each iteration set. If an iteration deviates from the mean by more than a given value (e.g. 5%) then it is marked as being "rejected". Rejected iterations are then executed again and the deviations recalculated. This process will repeat until the requisite target stability is met.

This will enable more accurate timings at the expense of benchmarking time.