### PR TITLE
Changed "subject" to "filter", fixes #123

### DIFF
--- a/docs/benchmark-runner.rst
+++ b/docs/benchmark-runner.rst
@@ -19,12 +19,12 @@ To run a single benchmark class, specify a specific file:
 
     $ phpbench run /path/to/HashBench.php
 
-To run a single method of a single benchmark class, add the ``--subject``
+To run a single method of a single benchmark class, use the ``--filter``
 option:
 
 .. code-block:: bash
 
-    $ phpbench run /path/to/HashBench.php --subject=benchMd5
+    $ phpbench run /path/to/HashBench.php --filter=benchMd5
 
 Groups can be specified using the ``--group`` option:
 
@@ -36,6 +36,21 @@ Groups can be specified using the ``--group`` option:
 
     Both ``--subject`` and ``--group`` options may be specified multiple
     times.
+
+.. _filtering:
+
+Filtering
+---------
+
+The ``--filter`` option accepts a regex without the delimiters and matches
+against a string such as ``HashBench::benchMd5``, so all of the following are
+valid:
+
+.. code-block:: bash
+
+    $ phpbench run /path/to --filter=benchFoo
+    $ phpbench run /path/to --filter=HashBench::benchFoo
+    $ phpbench run /path/to --filter=Hash.*
 
 .. _overriding_iterations_and_revolutions:
 

--- a/examples/CostOfCallingBench.php
+++ b/examples/CostOfCallingBench.php
@@ -16,6 +16,8 @@
  */
 class CostOfCalling
 {
+    private $reflectionMethod;
+
     public function benchCallWithoutParams()
     {
         $this->doSomething();
@@ -26,11 +28,49 @@ class CostOfCalling
         $this->doSomethingWithParams(1, 2, 3, 4);
     }
 
-    private function doSomething()
+    public function benchUserFuncWithoutParams()
+    {
+        call_user_func(array($this, 'doSomething'));
+    }
+
+    public function benchUserFuncParams()
+    {
+        call_user_func(array($this, 'doSomething'), 1, 2, 3, 4);
+    }
+
+    /**
+     * @BeforeMethods({"initReflection"})
+     */
+    public function benchReflectionCall()
+    {
+        $this->reflectionMethod->invoke($this);
+    }
+
+    public function initReflection()
+    {
+        $reflection = new ReflectionClass($this);
+        $this->reflectionMethod = $reflection->getMethod('doSomething');
+    }
+
+    /**
+     * @BeforeMethods({"initReflectionWithParams"})
+     */
+    public function benchReflectionCallWithParams()
+    {
+        $this->reflectionMethod->invokeArgs($this, array(1, 2, 3, 4));
+    }
+
+    public function initReflectionWithParams()
+    {
+        $reflection = new ReflectionClass($this);
+        $this->reflectionMethod = $reflection->getMethod('doSomethingWithParams');
+    }
+
+    public function doSomething()
     {
     }
 
-    private function doSomethingWithParams($one, $two, $three, $four)
+    public function doSomethingWithParams($one, $two, $three, $four)
     {
     }
 }

--- a/lib/Benchmark/CollectionBuilder.php
+++ b/lib/Benchmark/CollectionBuilder.php
@@ -48,7 +48,7 @@ class CollectionBuilder
      * @param array $subjectFilter
      * @param array $groupFilter
      */
-    public function buildCollection($path, array $subjectFilter = array(), array $groupFilter = array())
+    public function buildCollection($path, array $filters = array(), array $groupFilter = array())
     {
         if (!file_exists($path)) {
             throw new \InvalidArgumentException(sprintf(
@@ -85,8 +85,8 @@ class CollectionBuilder
                 $benchmarkMetadata->filterSubjectGroups($groupFilter);
             }
 
-            if ($subjectFilter) {
-                $benchmarkMetadata->filterSubjectNames($subjectFilter);
+            if ($filters) {
+                $benchmarkMetadata->filterSubjectNames($filters);
             }
 
             if (false === $benchmarkMetadata->hasSubjects()) {

--- a/lib/Benchmark/Metadata/BenchmarkMetadata.php
+++ b/lib/Benchmark/Metadata/BenchmarkMetadata.php
@@ -88,10 +88,22 @@ class BenchmarkMetadata extends AbstractMetadata
      *
      * @param array $subjectNames
      */
-    public function filterSubjectNames(array $subjectNames)
+    public function filterSubjectNames(array $filters)
     {
         foreach (array_keys($this->subjectMetadatas) as $subjectName) {
-            if (!in_array($subjectName, $subjectNames)) {
+            $unset = true;
+
+            foreach ($filters as $filter) {
+                if (preg_match(
+                    sprintf('{^.*?%s.*?$}', $filter),
+                    sprintf('%s::%s', $this->getClass(), $subjectName)
+                )) {
+                    $unset = false;
+                    break;
+                }
+            }
+
+            if (true === $unset) {
                 unset($this->subjectMetadatas[$subjectName]);
             }
         }

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -29,7 +29,7 @@ class Runner
     private $executorOverride;
     private $configPath;
     private $parametersOverride;
-    private $subjectsOverride = array();
+    private $filters = array();
     private $groups = array();
     private $executor;
     private $retryThreshold = null;
@@ -57,9 +57,9 @@ class Runner
      *
      * @param string[] $subjects
      */
-    public function overrideSubjects(array $subjects)
+    public function setFilters(array $filters)
     {
-        $this->subjectsOverride = $subjects;
+        $this->filters = $filters;
     }
 
     /**
@@ -159,7 +159,7 @@ class Runner
         $suiteEl = $dom->createElement('phpbench');
         $suiteEl->setAttribute('version', PhpBench::VERSION);
 
-        $collection = $this->collectionBuilder->buildCollection($path, $this->subjectsOverride, $this->groups);
+        $collection = $this->collectionBuilder->buildCollection($path, $this->filters, $this->groups);
 
         /* @var BenchmarkMetadata */
         foreach ($collection->getBenchmarks() as $benchmark) {

--- a/lib/Console/Command/RunCommand.php
+++ b/lib/Console/Command/RunCommand.php
@@ -63,7 +63,7 @@ All bench marks under the given path will be executed recursively.
 EOT
         );
         $this->addArgument('path', InputArgument::OPTIONAL, 'Path to benchmark(s)');
-        $this->addOption('subject', array(), InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Subject to run (can be specified multiple times)');
+        $this->addOption('filter', array(), InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore all benchmarks not matching this filter (can be a regex)');
         $this->addOption('group', array(), InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Group to run (can be specified multiple times)');
         $this->addOption('dump-file', 'd', InputOption::VALUE_OPTIONAL, 'Dump XML result to named file');
         $this->addOption('dump', null, InputOption::VALUE_NONE, 'Dump XML result to stdout and suppress all other output');
@@ -88,7 +88,7 @@ EOT
         $iterations = $input->getOption('iterations');
         $revs = $input->getOption('revs');
         $configPath = $input->getOption('config');
-        $subjects = $input->getOption('subject');
+        $filters = $input->getOption('filter');
         $groups = $input->getOption('group');
         $dumpfile = $input->getOption('dump-file');
         $progressLoggerName = $input->getOption('progress') ?: $this->progressLoggerName;
@@ -131,7 +131,7 @@ EOT
 
         $consoleOutput->writeln('');
         $startTime = microtime(true);
-        $suiteResult = $this->executeBenchmarks($path, $subjects, $groups, $parameters, $iterations, $revs, $configPath, $retryThreshold, $progressLogger);
+        $suiteResult = $this->executeBenchmarks($path, $filters, $groups, $parameters, $iterations, $revs, $configPath, $retryThreshold, $progressLogger);
         $consoleOutput->writeln('');
 
         $consoleOutput->writeln(sprintf(
@@ -159,7 +159,7 @@ EOT
 
     private function executeBenchmarks(
         $path,
-        array $subjects,
+        array $filters,
         array $groups,
         $parameters,
         $iterations,
@@ -184,8 +184,8 @@ EOT
             $this->runner->overrideRevs($revs);
         }
 
-        if ($subjects) {
-            $this->runner->overrideSubjects($subjects);
+        if ($filters) {
+            $this->runner->setFilters($filters);
         }
 
         if ($parameters) {

--- a/tests/System/RunTest.php
+++ b/tests/System/RunTest.php
@@ -171,7 +171,7 @@ class RunTest extends SystemTestCase
     public function testOverrideIterations()
     {
         $process = $this->phpbench(
-            'run --subject=benchRandom --dump --iterations=10 benchmarks/set1/BenchmarkBench.php'
+            'run --filter=benchRandom --dump --iterations=10 benchmarks/set1/BenchmarkBench.php'
         );
 
         $this->assertExitCode(0, $process);

--- a/tests/Unit/Benchmark/Metadata/BenchmarkMetadataTest.php
+++ b/tests/Unit/Benchmark/Metadata/BenchmarkMetadataTest.php
@@ -45,7 +45,7 @@ class BenchmarkMetadataTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should filter subjects based on a given whitelist.
+     * It should filter subjects based on a given filter.
      */
     public function testFilter()
     {
@@ -54,6 +54,24 @@ class BenchmarkMetadataTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $this->metadata->getSubjectMetadatas());
         $this->metadata->filterSubjectNames(array('subjectSeventySeven'));
         $this->assertCount(0, $this->metadata->getSubjectMetadatas());
+    }
+
+    /**
+     * It should filter on the class name.
+     */
+    public function testFilterClassName()
+    {
+        $this->metadata->filterSubjectNames(array('Class::subjectOne*'));
+        $this->assertCount(1, $this->metadata->getSubjectMetadatas());
+    }
+
+    /**
+     * It should filter using a regex.
+     */
+    public function testFilterRegex()
+    {
+        $this->metadata->filterSubjectNames(array('.*One*'));
+        $this->assertCount(1, $this->metadata->getSubjectMetadatas());
     }
 
     /**


### PR DESCRIPTION
Renamed `subject` option to `filter` and made it act as a regex upon the fully expanded name (including the FQN of the class). Closes #123