### PR TITLE
Pretty print params

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "symfony/console": "^2.4",
         "symfony/finder": "^2.4",
         "symfony/process": "^2.1",
-        "phpbench/tabular": "^0.2.0",
+        "phpbench/tabular": "^0.2.3",
         "seld/jsonlint": "^1.0",
         "justinrainbow/json-schema": "^1.0",
         "doctrine/annotations": "^1.2.7",

--- a/examples/ArrayKeysBench.php
+++ b/examples/ArrayKeysBench.php
@@ -11,6 +11,8 @@
 
 namespace PhpBench\Tests\Functional\benchmarks;
 
+require_once __DIR__ . '/BaseBench.php';
+
 /**
  * This example benchmarks array_key_exists vs. isset vs. in_array.
  *

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -38,8 +38,10 @@ use PhpBench\Tabular\Definition\Loader;
 use PhpBench\Tabular\Dom\XPathResolver;
 use PhpBench\Tabular\Formatter;
 use PhpBench\Tabular\Formatter\Format\BalanceFormat;
+use PhpBench\Tabular\Formatter\Format\JSONFormat;
 use PhpBench\Tabular\Formatter\Format\NumberFormat;
 use PhpBench\Tabular\Formatter\Format\PrintfFormat;
+use PhpBench\Tabular\Formatter\Format\TruncateFormat;
 use PhpBench\Tabular\Formatter\Registry\ArrayRegistry;
 use PhpBench\Tabular\TableBuilder;
 use PhpBench\Tabular\Tabular;
@@ -263,6 +265,8 @@ class CoreExtension implements ExtensionInterface
             $registry->register('printf', new PrintfFormat());
             $registry->register('balance', new BalanceFormat());
             $registry->register('number', new NumberFormat());
+            $registry->register('truncate', new TruncateFormat());
+            $registry->register('json_format', new JSONFormat());
 
             return $registry;
         });

--- a/lib/Report/Generator/AbstractTabularGenerator.php
+++ b/lib/Report/Generator/AbstractTabularGenerator.php
@@ -44,6 +44,12 @@ abstract class AbstractTabularGenerator implements GeneratorInterface, OutputAwa
             $this->output->writeln($document->saveXML());
         }
 
+        if (isset($config['pretty_params']) && true === $config['pretty_params']) {
+            $definition['classes']['params'] = array(
+                array('json_format', array()),
+            );
+        }
+
         $tableDom = $this->tabular->tabulate($document, $definition, $parameters);
 
         if ($config['exclude']) {

--- a/lib/Report/Generator/TabularGenerator.php
+++ b/lib/Report/Generator/TabularGenerator.php
@@ -56,6 +56,9 @@ class TabularGenerator extends AbstractTabularGenerator
                         array('type' => 'null'),
                     ),
                 ),
+                'pretty_params' => array(
+                    'type' => 'boolean',
+                ),
                 'aggregate' => array(
                     'type' => 'boolean',
                 ),

--- a/lib/Report/Generator/tabular/aggregate.json
+++ b/lib/Report/Generator/tabular/aggregate.json
@@ -22,6 +22,7 @@
                     "expr": "string(join_node_values(',', ancestor-or-self::subject/group/@name))"
                 },
                 {
+                    "class": "params",
                     "name": "params",
                     "expr": "parameters_to_json(ancestor-or-self::variant/parameter)"
                 },

--- a/lib/Report/Generator/tabular/classes.json
+++ b/lib/Report/Generator/tabular/classes.json
@@ -21,6 +21,8 @@
         ],
         "number": [
             [ "number", { "decimal_places": 2 }]
+        ],
+        "params": [
         ]
     }
 }

--- a/lib/Report/Generator/tabular/iteration.json
+++ b/lib/Report/Generator/tabular/iteration.json
@@ -22,6 +22,7 @@
                     "expr": "string(join_node_values(',', ancestor-or-self::subject/group/@name))"
                 },
                 {
+                    "class": "params",
                     "name": "params",
                     "expr": "parameters_to_json(ancestor-or-self::variant/parameter)"
                 },

--- a/tests/Functional/Report/Generator/TabularGeneratorTest.php
+++ b/tests/Functional/Report/Generator/TabularGeneratorTest.php
@@ -192,6 +192,38 @@ class TabularGeneratorTest extends GeneratorTestCase
         ), $values);
     }
 
+    /**
+     * It should pretty print parameters.
+     */
+    public function testPrettyParams()
+    {
+        $dom = $this->generate(
+            $this->getSuiteDocument(),
+            array(
+                'pretty_params' => true,
+            )
+        );
+
+        $value = null;
+        foreach ($dom->xpath()->query('//group[@name="body"]/row[1]/cell[@name="params"]') as $cellEl) {
+            $value = $cellEl->nodeValue;
+        }
+        $this->assertEquals(<<<EOT
+{
+    "foo": "bar",
+    "array": [
+        "one",
+        "two"
+    ],
+    "assoc_array": {
+        "one": "two",
+        "three": "four"
+    }
+}
+EOT
+        , $value);
+    }
+
     private function getSuiteDocument()
     {
         $suite = new SuiteDocument();


### PR DESCRIPTION
This PR introduces a new option to pretty print the parameters in the console report:

When using the `pretty_params` option:

False:

````
+-------------------------------------------------------------------------------------+------+-----+-----+----------+--------+-----------+-----------+
| params                                                                              | revs | its | rej | time     | memory | deviation | stability |
+-------------------------------------------------------------------------------------+------+-----+-----+----------+--------+-----------+-----------+
| {"hello":"Look \"I am using double quotes\"","goodbye":"Look 'I am use $dollars\""} | 5    | 5   | 0   | 7.4000μs | 544b   | 0.00%     | 20.00%    |
+-------------------------------------------------------------------------------------+------+-----+-----+----------+--------+-----------+-----------+
````

True:

````
+---------------------------------------------------+------+-----+-----+----------+--------+-----------+-----------+
| params                                            | revs | its | rej | time     | memory | deviation | stability |
+---------------------------------------------------+------+-----+-----+----------+--------+-----------+-----------+
| {                                                 | 5    | 5   | 0   | 5.4000μs | 544b   | 0.00%     | 80.00%    |
|     "hello": "Look \"I am using double quotes\"", |      |     |     |          |        |           |           |
|     "goodbye": "Look 'I am use $dollars\""        |      |     |     |          |        |           |           |
| }                                                 |      |     |     |          |        |           |           |
+---------------------------------------------------+------+-----+-----+----------+--------+-----------+-----------+
````