### PR TITLE
Pass parameters as arguments

### DIFF
--- a/examples/ArrayKeysBench.php
+++ b/examples/ArrayKeysBench.php
@@ -26,23 +26,23 @@ class ArrayKeysBench
     private $values;
     private $index = 0;
 
-    public function init($params)
+    public function init($nbElements)
     {
-        $this->array = array_fill(0, $params['nb_elements'], 'this is a test');
+        $this->array = array_fill(0, $nbElements, 'this is a test');
         $this->values = array_combine(array_keys($this->array), array_keys($this->array));
     }
 
-    public function benchArrayKeyExists()
+    public function benchArrayKeyExists($nbElements)
     {
         array_key_exists($this->index++, $this->array);
     }
 
-    public function benchIsset()
+    public function benchIsset($nbElements)
     {
         isset($this->array[$this->index++]);
     }
 
-    public function benchInArray()
+    public function benchInArray($nbElements)
     {
         in_array($this->index++, $this->values);
     }
@@ -51,16 +51,16 @@ class ArrayKeysBench
     {
         return array(
             array(
-                'nb_elements' => 10,
+                'nbElements' => 10,
             ),
             array(
-                'nb_elements' => 100,
+                'nbElements' => 100,
             ),
             array(
-                'nb_elements' => 1000,
+                'nbElements' => 1000,
             ),
             array(
-                'nb_elements' => 10000,
+                'nbElements' => 10000,
             ),
         );
     }

--- a/examples/reports/array_keys.json
+++ b/examples/reports/array_keys.json
@@ -24,7 +24,7 @@
                 {
                     "name": "time",
                     "class": "time",
-                    "expr": "sum(./variant[parameter[@name='nb_elements']/@value = {{ row.item }}]/iteration/@time) div sum(./variant[parameter[@name='nb_elements']/@value = {{ row.item }}]/iteration/@revs)"
+                    "expr": "sum(./variant[parameter[@name='nbElements']/@value = {{ row.item }}]/iteration/@time) div sum(./variant[parameter[@name='nbElements']/@value = {{ row.item }}]/iteration/@revs)"
                 },
                 {
                     "name": "deviation",

--- a/lib/Benchmark/Executor/MicrotimeExecutor.php
+++ b/lib/Benchmark/Executor/MicrotimeExecutor.php
@@ -15,6 +15,7 @@ use PhpBench\Benchmark\ExecutorInterface;
 use PhpBench\Benchmark\Iteration;
 use PhpBench\Benchmark\IterationResult;
 use PhpBench\Benchmark\Remote\Launcher;
+use PhpBench\Benchmark\Metadata\SubjectMetadata;
 
 /**
  * This class generates a benchmarking script and places it in the systems
@@ -44,6 +45,11 @@ class MicrotimeExecutor implements ExecutorInterface
     public function execute(Iteration $iteration, array $options = array())
     {
         $subject = $iteration->getSubject();
+        $parameters = $this->resolveParameterOrder(
+            $subject,
+            $iteration->getParameters()
+        );
+
         $tokens = array(
             'class' => $subject->getBenchmarkMetadata()->getClass(),
             'file' => $subject->getBenchmarkMetadata()->getPath(),
@@ -51,7 +57,8 @@ class MicrotimeExecutor implements ExecutorInterface
             'revolutions' => $iteration->getRevolutions(),
             'beforeMethods' => var_export($subject->getBeforeMethods(), true),
             'afterMethods' => var_export($subject->getAfterMethods(), true),
-            'parameters' => var_export($iteration->getParameters(), true),
+            'parameters' => var_export($parameters, true),
+            'argString' => $this->getArgString(count($parameters))
         );
 
         $payload = $this->launcher->payload(__DIR__ . '/template/microtime.template', $tokens);
@@ -74,5 +81,78 @@ class MicrotimeExecutor implements ExecutorInterface
     public function getDefaultConfig()
     {
         return array();
+    }
+
+    private function resolveParameterOrder(SubjectMetadata $subject, array $parameters)
+    {
+        $isAssoc = false;
+        foreach (array_keys($parameters) as $key) {
+            if (is_string($key)) {
+                $isAssoc = true;
+                continue;
+            }
+
+            if (true === $isAssoc && is_numeric($key)) {
+                throw new \RuntimeException(sprintf(
+                    'Cannot mix numeric and string indexes in parameter set. Got: "%s"',
+                    implode('", "', array_keys($parameters))
+                ));
+            }
+        }
+
+        if ($isAssoc) {
+            $parameters = $this->mapAssocToArgs($subject, $parameters);
+        }
+
+        return $parameters;
+    }
+
+    private function mapAssocToArgs(SubjectMetadata $subject, array $parameters)
+    {
+        $args = $subject->getArguments();
+
+        if (count($args) && array_diff(array_keys($parameters), $args)) {
+            throw new \RuntimeException(sprintf(
+                'You have used an associative array for parameters. The argument names on the benchmarking ' . 
+                'subject "%s" must match the top level key names of the provided parameter set. Should be: "%s", current ' . 
+                'argument names: "%s"',
+                $subject->getName(),
+                implode('", "', array_keys($parameters)),
+                implode('", "', $args)
+            ));
+        }
+
+        if (count($args) && $diff = array_diff($args, array_keys($parameters))) {
+            throw new \RuntimeException(sprintf(
+                'Subject "%s" expects parameters: "%s", but did not get them.',
+                $subject->getName(),
+                implode('", "', $diff)
+            ));
+        }
+
+        $resolved = array();
+
+        foreach ($parameters as $key => $value) {
+            $argIndex = array_search($key, $args);
+
+            if (false === $argIndex) {
+                continue;
+            }
+
+            $resolved[$argIndex] = $value;
+        }
+
+        return $resolved;
+    }
+
+    private function getArgString($argCount)
+    {
+        $string = array();
+
+        for ($i = 0; $i < $argCount; $i++) {
+            $string[] = sprintf('$parameters[%s]', $i);
+        }
+
+        return implode(', ', $string);
     }
 }

--- a/lib/Benchmark/Executor/template/microtime.template
+++ b/lib/Benchmark/Executor/template/microtime.template
@@ -23,36 +23,21 @@ require_once($file);
 $benchmark = new $class();
 
 foreach ($beforeMethods as $beforeMethod) {
-    $benchmark->$beforeMethod($parameters);
+    $benchmark->$beforeMethod({{ argString }});
 }
 
-// run the benchmarks: note that passing arguments to the method slightly increases
-// the calltime, so we explicitly do one thing or the other depending on if parameters
-// are provided.
-if ($parameters) {
-    $startMemory = memory_get_usage();
-    $startTime = microtime(true);
+$startMemory = memory_get_usage();
+$startTime = microtime(true);
 
-    for ($i = 0; $i < $revolutions; $i++) {
-        $benchmark->$subject($parameters);
-    }
-
-    $endTime = microtime(true);
-    $endMemory = memory_get_usage();
-} else {
-    $startMemory = memory_get_usage();
-    $startTime = microtime(true);
-
-    for ($i = 0; $i < $revolutions; $i++) {
-        $benchmark->$subject();
-    }
-
-    $endTime = microtime(true);
-    $endMemory = memory_get_usage();
+for ($i = 0; $i < $revolutions; $i++) {
+    $benchmark->$subject({{ argString }});
 }
+
+$endTime = microtime(true);
+$endMemory = memory_get_usage();
 
 foreach ($afterMethods as $afterMethod) {
-    $benchmark->$afterMethod($parameters);
+    $benchmark->$afterMethod({{ argString }});
 }
 
 echo json_encode(array(

--- a/lib/Benchmark/Metadata/Driver/AnnotationDriver.php
+++ b/lib/Benchmark/Metadata/Driver/AnnotationDriver.php
@@ -19,6 +19,7 @@ use PhpBench\Benchmark\Metadata\BenchmarkMetadata;
 use PhpBench\Benchmark\Metadata\DocParser;
 use PhpBench\Benchmark\Metadata\DriverInterface;
 use PhpBench\Benchmark\Metadata\SubjectMetadata;
+use PhpBench\Benchmark\Remote\ReflectionClass;
 use PhpBench\Benchmark\Remote\ReflectionHierarchy;
 use PhpBench\Benchmark\Remote\ReflectionMethod;
 use PhpBench\Benchmark\Remote\Reflector;
@@ -89,6 +90,8 @@ class AnnotationDriver implements DriverInterface
 
     private function buildSubjectMetadata(SubjectMetadata $subjectMetadata, ReflectionMethod $reflectionMethod)
     {
+        $subjectMetadata->setArguments($reflectionMethod->args);
+
         $annotations = $this->docParser->parse(
             $reflectionMethod->comment,
             sprintf('subject %s::%s', $reflectionMethod->class, $reflectionMethod->name

--- a/lib/Benchmark/Metadata/SubjectMetadata.php
+++ b/lib/Benchmark/Metadata/SubjectMetadata.php
@@ -32,6 +32,11 @@ class SubjectMetadata extends AbstractMetadata
     private $benchmarkMetadata;
 
     /**
+     * @var string[]
+     */
+    private $arguments = array();
+
+    /**
      * @param BenchmarkMetadata $benchmarkMetadata
      * @param string $name
      */
@@ -72,6 +77,17 @@ class SubjectMetadata extends AbstractMetadata
         return $this->parameterSets;
     }
 
+    public function getArguments() 
+    {
+        return $this->arguments;
+    }
+    
+    public function setArguments($arguments)
+    {
+        $this->arguments = $arguments;
+    }
+    
+    
     /**
      * Return the (containing) benchmark for this subject.
      *

--- a/lib/Benchmark/Remote/ReflectionMethod.php
+++ b/lib/Benchmark/Remote/ReflectionMethod.php
@@ -16,4 +16,5 @@ class ReflectionMethod
     public $class;
     public $name;
     public $comment;
+    public $args;
 }

--- a/lib/Benchmark/Remote/Reflector.php
+++ b/lib/Benchmark/Remote/Reflector.php
@@ -70,6 +70,7 @@ class Reflector
                 $reflectionMethod->class = $classInfo['class'];
                 $reflectionMethod->name = $methodInfo['name'];
                 $reflectionMethod->comment = $methodInfo['comment'];
+                $reflectionMethod->args = $methodInfo['args'];
                 $reflectionClass->methods[$reflectionMethod->name] = $reflectionMethod;
             }
             $hierarchy->addReflectionClass($reflectionClass);

--- a/lib/Benchmark/Remote/template/reflector.template
+++ b/lib/Benchmark/Remote/template/reflector.template
@@ -27,10 +27,17 @@ foreach ($classHierarchy as $class) {
 
     foreach ($refl->getMethods() as $methodRefl) {
         $comment = $methodRefl->getDocComment();
+
+        $args = array();
+        foreach ($methodRefl->getParameters() as $reflParam) {
+            $args[] = $reflParam->name;
+        }
+
         $metadata['methods'][$methodRefl->getName()] = array(
             'class' => $class,
             'name' => $methodRefl->getName(),
             'comment' => $comment,
+            'args' => $args,
         );
     }
 

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -167,7 +167,15 @@ class Runner
             $benchmarkEl->setAttribute('class', $benchmark->getClass());
 
             $this->logger->benchmarkStart($benchmark);
-            $this->run($benchmark, $benchmarkEl);
+
+            try {
+                $this->run($benchmark, $benchmarkEl);
+            } catch (\Exception $e) {
+                throw new \Exception(sprintf(
+                    'Error encountered running benchmark class "%s"',
+                    $benchmark->getClass()
+                ), null, $e);
+            }
             $this->logger->benchmarkEnd($benchmark);
 
             $suiteEl->appendChild($benchmarkEl);

--- a/lib/Report/ReportManager.php
+++ b/lib/Report/ReportManager.php
@@ -350,13 +350,12 @@ class ReportManager
 
             try {
                 $reportConfig = $this->mergeAndValidateConfig($generator, $reportConfig);
+                $reportDom = $generator->generate($suiteDocument, $reportConfig);
             } catch (\Exception $e) {
                 throw new \InvalidArgumentException(sprintf(
-                    'Could not generate report "%s": %s', $reportName, $e->getMessage()
-                ));
+                    'Could not generate report "%s"', $reportName
+                ), null, $e);
             }
-
-            $reportDom = $generator->generate($suiteDocument, $reportConfig);
 
             if (!$reportDom instanceof Document) {
                 throw new \RuntimeException(sprintf(

--- a/tests/System/RunTest.php
+++ b/tests/System/RunTest.php
@@ -145,7 +145,7 @@ class RunTest extends SystemTestCase
     public function testOverrideParameters()
     {
         $process = $this->phpbench(
-            'run --dump --parameters=\'{"length": 333}\' benchmarks/set1/BenchmarkBench.php'
+            'run --dump --parameters=\'{"length": 333, "strategy": "left"}\' benchmarks/set1/BenchmarkBench.php'
         );
         $this->assertExitCode(0, $process);
         $output = $process->getOutput();

--- a/tests/System/benchmarks/set1/BenchmarkBench.php
+++ b/tests/System/benchmarks/set1/BenchmarkBench.php
@@ -30,7 +30,7 @@ class BenchmarkBench
      * @Groups({"parameterized"})
      * @Iterations(1)
      */
-    public function benchParameterized($params)
+    public function benchParameterized($length, $strategy)
     {
     }
 

--- a/tests/System/benchmarks/set1/IsolatedParametersBench.php
+++ b/tests/System/benchmarks/set1/IsolatedParametersBench.php
@@ -16,7 +16,7 @@ class IsolatedParameterBench
      * @Iterations(5)
      * @ParamProviders({"provideParams"})
      */
-    public function benchIterationIsolation()
+    public function benchIterationIsolation($hello, $goodbye, $goodbye1)
     {
     }
 
@@ -26,7 +26,7 @@ class IsolatedParameterBench
             array(
                 'hello' => 'Look "I am using double quotes"',
                 'goodbye' => 'Look \'I am using single quotes\'"',
-                'goodbye' => 'Look \'I am use $dollars"',
+                'goodbye1' => 'Look \'I am use $dollars"',
             ),
         );
     }

--- a/tests/Unit/Benchmark/Executor/microtimetest/ExecutorBench.php
+++ b/tests/Unit/Benchmark/Executor/microtimetest/ExecutorBench.php
@@ -34,18 +34,18 @@ class ExecutorBench
         file_put_contents(__DIR__ . '/revs.tmp', $count);
     }
 
-    public function parameterized($params)
+    public function parameterized($one, $three)
     {
-        file_put_contents(__DIR__ . '/param.tmp', json_encode($params));
+        file_put_contents(__DIR__ . '/param.tmp', json_encode(array($one, $three)));
     }
 
-    public function parameterizedBefore($params)
+    public function parameterizedBefore($one, $three)
     {
-        file_put_contents(__DIR__ . '/parambefore.tmp', json_encode($params));
+        file_put_contents(__DIR__ . '/parambefore.tmp', json_encode(array($one, $three)));
     }
 
-    public function parameterizedAfter($params)
+    public function parameterizedAfter($one, $three)
     {
-        file_put_contents(__DIR__ . '/paramafter.tmp', json_encode($params));
+        file_put_contents(__DIR__ . '/paramafter.tmp', json_encode(array($one, $three)));
     }
 }

--- a/tests/Unit/Benchmark/Remote/ReflectorTest.php
+++ b/tests/Unit/Benchmark/Remote/ReflectorTest.php
@@ -25,7 +25,7 @@ class ReflectorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should return information about a class in a different application.
+     * It should return information about a class in a different process.
      */
     public function testReflector()
     {
@@ -44,6 +44,7 @@ class ReflectorTest extends \PHPUnit_Framework_TestCase
             'provideParamsTwo',
         ), array_keys($reflection->methods));
         $this->assertContains('Method One Comment', $reflection->methods['methodOne']->comment);
+        $this->assertEquals(array('one', 'two'), $reflection->methods['methodTwo']->args);
     }
 
     /**

--- a/tests/Unit/Benchmark/Remote/reflector/ExampleClass.php
+++ b/tests/Unit/Benchmark/Remote/reflector/ExampleClass.php
@@ -19,14 +19,14 @@ class ExampleClass
     /**
      * Method One Comment.
      */
-    public function methodOne()
+    public function methodOne($one)
     {
     }
 
     /**
      * Method Two Comment.
      */
-    public function methodTwo()
+    public function methodTwo($one, $two)
     {
     }
 


### PR DESCRIPTION
This PR changes the behavior of the supply of parameters to subjec, before and after methods. Previously parameters were passed as a single array, now they are expanded to the arguments of the subjects.

If the parameter set is associative, then the parameter keys will be matched to the argument names, e.g.

``` javascript
{"fooBar": "bar", "barFoo": "foo"}
```

Would require a method signature as follows:

``` php
public function benchBar($fooBar, $barFoo)
```

(the order of arguments is not important in this case).

If the parameter set is non-associative then the naming of the arguments is irrelevant.
