### PR TITLE
Peak memory

### DIFF
--- a/docs/reports.rst
+++ b/docs/reports.rst
@@ -32,7 +32,7 @@ Columns:
 - **iter**: The :ref:`iteration <iterations>` index.
 - **rej**: Number of rejected iterations (see :ref:`retry_threshold`).
 - **time**: Time taken to execute a single iteration in microseconds_
-- **memory**: Memory used, in bytes.
+- **memory**: Memory used by iteration (as reported by memory_get_peak_usage_, in bytes.
 - **deviation**: Deviation from the mean as a percentage (when multiple
   benchmarks / iterations are displayed).
 
@@ -68,9 +68,10 @@ Columns:
 - **iters**: Number of :ref:`iterations <iterations>` performed.
 - **rej**: Number of rejected iterations (see :ref:`retry_threshold`).
 - **time**: Average time taken for each iteration.
-- **memory**: Average memory used.
+- **memory**: Average memory used by iteration.
 - **deviation**: Deviation from the mean as a percentage (when multiple
   benchmarks).
 - **stability**: How much the time of the individual iterations differed.
 
 .. _microseconds: https://en.wikipedia.org/wiki/Microseconds
+.. _memory_get_peak_usage: http://php.net/manual/en/function.memory-get-peak-usage.php

--- a/lib/Benchmark/Executor/template/microtime.template
+++ b/lib/Benchmark/Executor/template/microtime.template
@@ -30,7 +30,6 @@ foreach ($beforeMethods as $beforeMethod) {
 // the calltime, so we explicitly do one thing or the other depending on if parameters
 // are provided.
 if ($parameters) {
-    $startMemory = memory_get_usage();
     $startTime = microtime(true);
 
     for ($i = 0; $i < $revolutions; $i++) {
@@ -38,9 +37,7 @@ if ($parameters) {
     }
 
     $endTime = microtime(true);
-    $endMemory = memory_get_usage();
 } else {
-    $startMemory = memory_get_usage();
     $startTime = microtime(true);
 
     for ($i = 0; $i < $revolutions; $i++) {
@@ -48,7 +45,6 @@ if ($parameters) {
     }
 
     $endTime = microtime(true);
-    $endMemory = memory_get_usage();
 }
 
 foreach ($afterMethods as $afterMethod) {
@@ -56,7 +52,7 @@ foreach ($afterMethods as $afterMethod) {
 }
 
 echo json_encode(array(
-    'memory' => $endMemory - $startMemory,
+    'memory' => memory_get_peak_usage(),
     'time' => ($endTime * 1000000) - ($startTime * 1000000),
 ));
 

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -313,8 +313,9 @@ class Runner
      * Utility function to return the correct sleep interval
      * in case that the sleep interval has been overridden.
      *
-     * @param integer $sleep
-     * @return integer
+     * @param int $sleep
+     *
+     * @return int
      */
     private function getSleepInterval($sleep)
     {

--- a/lib/Report/Generator/tabular/aggregate.json
+++ b/lib/Report/Generator/tabular/aggregate.json
@@ -46,7 +46,7 @@
                 {
                     "name": "memory",
                     "class": "memory",
-                    "expr": "number(descendant-or-self::iteration/@memory)"
+                    "expr": "average(descendant-or-self::iteration/@memory)"
                 },
                 {
                     "name": "deviation",

--- a/tests/Unit/Benchmark/RunnerTest.php
+++ b/tests/Unit/Benchmark/RunnerTest.php
@@ -245,7 +245,7 @@ EOT
 
     /**
      * It should set the sleep attribute in the DOM.
-     * It should allow the sleep value to be overridden
+     * It should allow the sleep value to be overridden.
      */
     public function testSleep()
     {


### PR DESCRIPTION
Use `memory_get_peak_usage` to get usage of entire iteration script nstead of the historical subtraction thing we are doing now.