### PR TITLE
Detailed verbose logging

### DIFF
--- a/docs/benchmark-runner.rst
+++ b/docs/benchmark-runner.rst
@@ -104,7 +104,7 @@ The ``--report`` option can be specified multiple times.
 .. note::
 
     If you want to suppress all other output and only show the output from the
-    reports you can use the ``--quiet`` option. This is especially useful when
+    reports you can use the ``--progress=none`` option. This is especially useful when
     piping a report to another program.
 
 .. _retry_threshold:
@@ -209,10 +209,26 @@ specified using the ``--progress`` option:
 
 The built-in progress loggers are:
 
-- ``dots``: The default logger, shows one dot per subject (like PHPUnit).
+- ``verbose``: The default logger, format: `[R<retry nb.>] I<iter nb.> P<parameter set nb.> <mean per rev.> <standard deviation per rev.> <relative standard deviation per rev.>` ).
+- ``dots``: Shows one dot per subject (like PHPUnit).
 - ``classdots``: Shows the benchmark class, and then a dot for each subject.
-- ``verbose``: Verbose output (format `R<retry nb.> I<iter nb.> #<parameter set
-  nb.>`).
+
+All of the progress reports contain the following footer:
+
+.. code-block:: bash
+
+    3 subjects, 30 iterations, 30000 revs, 0 rejects
+    min mean max: 0.84 1.13 1.66 (μs/r)
+    ⅀T: 33987μs μSD/r 0.16μs μRSD/r: 14.92%
+
+It provides a summary of the minimum, mean, and maximum subject times, given
+microseconds per revolution. ⅀T is the aggregate total time, μSD/r is the mean
+standard deviation, and μRSD/r is the mean relative standard deviation.
+
+.. warning::
+
+    These summary statistics can be misleading. You should always verify the
+    individual subject statistics before drawing any conclusions.
 
 Configuration File
 ------------------

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -127,9 +127,11 @@ And you should see some output similar to the following:
 
     PhpBench 0.8.0-dev. Running benchmarks.
 
-    . 
+    \TimeConsumerBench
 
-    1 subjects, 1 samples, 1 revs, 0 rejects
+        benchConsume                  I0 P0         μ/r: 173.00μs   μSD/r 0.00μs    μRSD/r: 0.00%
+
+    1 subjects, 1 iterations, 1 revs, 0 rejects
     ⅀T: 173μs μSD/r 0.00μs μRSD/r: 0.00%
     min mean max: 173.00 173.00 173.00 (μs/r)
 
@@ -207,9 +209,9 @@ rather than ``default``:
 Increase Stability
 ------------------
 
-You will see the columns `stdev` and `rstdev`. `stdev` is the `Standard
-Deviation` of the set of iterations and `rstdev` is `Relative Standard
-Deviation`_.
+You will see the columns `stdev` and `rstdev`. `stdev` is the `standard
+deviation`_ of the set of iterations and `rstdev` is `relative standard
+deviation`_.
 
 Stability can be inferred from `rstdev`, with 0% being the best and anything
 about 2% should be treated as suspicious.
@@ -231,13 +233,6 @@ threshold:
 
     Lower values for ``retry-threshold``, depending on the stability of your
     system,  generally lead to increased total benchmarking time.
-
-You may get a better view of what is going on by using the ``verbose``
-progress logger:
-
-.. code-block:: bash
-
-    $ php vendor/bin/phpbench run benchmarks/TimeConsumerBench.php --report=aggregate --retry-threshold=5 --progress=verbose
 
 Customize Reports
 -----------------
@@ -297,3 +292,5 @@ This quick start demonstrated some of the features of PHPBench, but there is
 more to discover everything can be found in this manual. Happy benchmarking.
 
 .. _composer: http://getcomposer.org
+.. _Relative standard deviation: https://en.wikipedia.org/wiki/Coefficient_of_variation
+.. _standard deviation: https://en.wikipedia.org/wiki/Standard_deviation

--- a/docs/writing-benchmarks.rst
+++ b/docs/writing-benchmarks.rst
@@ -35,12 +35,12 @@ And it can be executed as follows:
 
 .. code-block:: bash
 
-    $ phpbench run examples/HashBench.php
+    $ phpbench run examples/HashBench.php --progress=dots
     PhpBench 0.8.0-dev. Running benchmarks.
 
     ... 
 
-    3 subjects, 30 samples, 30000 revs, 0 rejects
+    3 subjects, 30 iterations, 30000 revs, 0 rejects
     ⅀T: 30543μs μSD/r 0.05μs μRSD/r: 4.83%
     min mean max: 0.78 1.02 1.47 (μs/r)
 

--- a/lib/Benchmark/IterationCollection.php
+++ b/lib/Benchmark/IterationCollection.php
@@ -11,6 +11,7 @@
 
 namespace PhpBench\Benchmark;
 
+use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Math\Statistics;
 
 /**
@@ -19,6 +20,16 @@ use PhpBench\Math\Statistics;
  */
 class IterationCollection implements \IteratorAggregate
 {
+    /**
+     * @var SubjectMetadata
+     */
+    private $subject;
+
+    /**
+     * @var ParameterSet
+     */
+    private $parameterSet;
+
     /**
      * @var Iteration[]
      */
@@ -58,8 +69,10 @@ class IterationCollection implements \IteratorAggregate
     /**
      * @param float $rejectionThreshold
      */
-    public function __construct($rejectionThreshold = null)
+    public function __construct(SubjectMetadata $subject, ParameterSet $parameterSet, $rejectionThreshold = null)
     {
+        $this->subject = $subject;
+        $this->parameterSet = $parameterSet;
         $this->rejectionThreshold = $rejectionThreshold;
     }
 
@@ -174,5 +187,29 @@ class IterationCollection implements \IteratorAggregate
     public function getStats()
     {
         return $this->stats;
+    }
+
+    /**
+     * Spawn a given number of iterations with a given number of revolutions each.
+     *
+     * @param int $count
+     * @param int $revolutionCount
+     *
+     * @return Iteration[]
+     */
+    public function spawnIterations($count, $revolutionCount)
+    {
+        $iterations = array();
+
+        for ($index = 0; $index < $count; $index++) {
+            $iterations[] = new Iteration($index, $this->subject, $revolutionCount, $this->parameterSet);
+        }
+
+        return $iterations;
+    }
+
+    public function getParameterSet()
+    {
+        return $this->parameterSet;
     }
 }

--- a/lib/Benchmark/SuiteDocument.php
+++ b/lib/Benchmark/SuiteDocument.php
@@ -12,6 +12,7 @@
 namespace PhpBench\Benchmark;
 
 use PhpBench\Dom\Document;
+use PhpBench\Math\Statistics;
 
 /**
  * DOMDocument implementation for containing the benchmark suite
@@ -100,14 +101,12 @@ class SuiteDocument extends Document
      */
     public function getMeanRelStDev()
     {
-        $rStDevs = 0;
-        foreach ($this->query('//stats') as $i => $stats) {
-            $rStDevs += $stats->getAttribute('stdev') / $stats->getAttribute('mean');
+        $rStDevs = array();
+        foreach ($this->query('//stats') as $stats) {
+            $rStDevs[] = $stats->getAttribute('rstdev');
         }
 
-        $mean = ($rStDevs / ($i + 1)) * 100;
-
-        return $mean;
+        return Statistics::mean($rStDevs);
     }
 
     /**

--- a/lib/Console/Command/RunCommand.php
+++ b/lib/Console/Command/RunCommand.php
@@ -20,7 +20,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class RunCommand extends BaseReportCommand
@@ -97,7 +96,6 @@ EOT
         $inputPath = $input->getArgument('path');
         $retryThreshold = $input->getOption('retry-threshold');
         $sleep = $input->getOption('sleep');
-        $quiet = $input->getOption('quiet');
 
         $path = $inputPath ?: $this->benchPath;
 
@@ -122,45 +120,10 @@ EOT
             }
         }
 
-        if ($dump || $quiet) {
-            $consoleOutput = new NullOutput();
-            $output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
-        }
-
-        $consoleOutput->writeln('PhpBench ' . PhpBench::VERSION . '. Running benchmarks.');
-
-        if ($this->configPath) {
-            $consoleOutput->writeln(sprintf('Using configuration file: %s', $this->configPath));
-        }
-
         $progressLogger = $this->loggerRegistry->getProgressLogger($progressLoggerName);
         $progressLogger->setOutput($consoleOutput);
 
-        $consoleOutput->writeln('');
         $suiteResult = $this->executeBenchmarks($contextName, $path, $filters, $groups, $parameters, $iterations, $revs, $configPath, $retryThreshold, $sleep, $progressLogger);
-        $consoleOutput->writeln('');
-        $consoleOutput->writeln('');
-
-        $consoleOutput->writeln(sprintf(
-            '%s subjects, %s samples, %s revs, %s rejects',
-            $suiteResult->getNbSubjects(),
-            $suiteResult->getNbIterations(),
-            $suiteResult->getNbRevolutions(),
-            $suiteResult->getNbRejects()
-        ));
-        $consoleOutput->writeln(sprintf(
-            '⅀T: %sμs μSD/r %sμs μRSD/r: %s%%',
-            $suiteResult->getTotalTime(),
-            number_format($suiteResult->getMeanStDev(), 2),
-            number_format($suiteResult->getMeanRelStDev(), 2)
-        ));
-        $consoleOutput->writeln(sprintf(
-            'min mean max: %s %s %s (μs/r)',
-            number_format($suiteResult->getMin(), 2),
-            number_format($suiteResult->getMeanTime(), 2),
-            number_format($suiteResult->getMax(), 2)
-        ));
-
         if ($dumpfile) {
             $xml = $suiteResult->dump();
             file_put_contents($dumpfile, $xml);

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -24,6 +24,7 @@ use PhpBench\Console\Command\RunCommand;
 use PhpBench\DependencyInjection\Container;
 use PhpBench\DependencyInjection\ExtensionInterface;
 use PhpBench\Progress\Logger\DotsLogger;
+use PhpBench\Progress\Logger\NullLogger;
 use PhpBench\Progress\Logger\VerboseLogger;
 use PhpBench\Progress\LoggerRegistry;
 use PhpBench\Report\Generator\CompositeGenerator;
@@ -81,7 +82,7 @@ class CoreExtension implements ExtensionInterface
             'reports' => array(),
             'outputs' => array(),
             'config_path' => null,
-            'progress' => 'dots',
+            'progress' => 'verbose',
             'retry_threshold' => null,
         ));
     }
@@ -210,6 +211,10 @@ class CoreExtension implements ExtensionInterface
         $container->register('progress_logger.verbose', function (Container $container) {
             return new VerboseLogger();
         }, array('progress_logger' => array('name' => 'verbose')));
+
+        $container->register('progress_logger.null', function (Container $container) {
+            return new NullLogger();
+        }, array('progress_logger' => array('name' => 'none')));
     }
 
     private function registerReportGenerators(Container $container)

--- a/lib/Progress/Logger/DotsLogger.php
+++ b/lib/Progress/Logger/DotsLogger.php
@@ -14,12 +14,10 @@ namespace PhpBench\Progress\Logger;
 use PhpBench\Benchmark\Iteration;
 use PhpBench\Benchmark\Metadata\BenchmarkMetadata;
 use PhpBench\Benchmark\Metadata\SubjectMetadata;
-use PhpBench\Progress\LoggerInterface;
-use Symfony\Component\Console\Output\OutputInterface;
+use PhpBench\Benchmark\SuiteDocument;
 
-class DotsLogger implements LoggerInterface
+class DotsLogger extends PhpBenchLogger
 {
-    private $output;
     private $showBench;
 
     private $buffer;
@@ -27,11 +25,6 @@ class DotsLogger implements LoggerInterface
     public function __construct($showBench = false)
     {
         $this->showBench = $showBench;
-    }
-
-    public function setOutput(OutputInterface $output)
-    {
-        $this->output = $output;
     }
 
     public function benchmarkStart(BenchmarkMetadata $benchmark)
@@ -47,14 +40,6 @@ class DotsLogger implements LoggerInterface
 
             $this->output->writeln($benchmark->getClass());
         }
-    }
-
-    public function benchmarkEnd(BenchmarkMetadata $benchmark)
-    {
-    }
-
-    public function subjectStart(SubjectMetadata $subject)
-    {
     }
 
     public function subjectEnd(SubjectMetadata $subject)
@@ -83,11 +68,9 @@ class DotsLogger implements LoggerInterface
         ));
     }
 
-    public function iterationEnd(Iteration $iteration)
+    public function endSuite(SuiteDocument $suiteDocument)
     {
-    }
-
-    public function retryStart($rejectionCount)
-    {
+        $this->output->write(PHP_EOL . PHP_EOL);
+        parent::endSuite($suiteDocument);
     }
 }

--- a/lib/Progress/Logger/NullLogger.php
+++ b/lib/Progress/Logger/NullLogger.php
@@ -12,42 +12,96 @@
 namespace PhpBench\Progress\Logger;
 
 use PhpBench\Benchmark\Iteration;
+use PhpBench\Benchmark\IterationCollection;
 use PhpBench\Benchmark\Metadata\BenchmarkMetadata;
 use PhpBench\Benchmark\Metadata\SubjectMetadata;
+use PhpBench\Benchmark\SuiteDocument;
 use PhpBench\Progress\LoggerInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class NullLogger implements LoggerInterface
 {
+    /**
+     * {@inheritdoc}
+     */
     public function setOutput(OutputInterface $output)
     {
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function benchmarkStart(BenchmarkMetadata $benchmark)
     {
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function benchmarkEnd(BenchmarkMetadata $benchmark)
     {
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function subjectStart(SubjectMetadata $subject)
     {
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function subjectEnd(SubjectMetadata $subject)
     {
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function iterationStart(Iteration $iteration)
     {
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function iterationEnd(Iteration $iteration)
     {
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function iterationsStart(IterationCollection $iterations)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function iterationsEnd(IterationCollection $iterations)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function retryStart($rejectionCount)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function startSuite(SuiteDocument $suiteDocument)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function endSuite(SuiteDocument $suiteDocument)
     {
     }
 }

--- a/lib/Progress/Logger/PhpBenchLogger.php
+++ b/lib/Progress/Logger/PhpBenchLogger.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Progress\Logger;
+
+use PhpBench\Benchmark\SuiteDocument;
+use PhpBench\Console\OutputAwareInterface;
+use PhpBench\PhpBench;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class PhpBenchLogger extends NullLogger implements OutputAwareInterface
+{
+    protected $output;
+
+    public function setOutput(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    public function startSuite(SuiteDocument $suiteDocument)
+    {
+        $this->output->writeln('PhpBench ' . PhpBench::VERSION . '. Running benchmarks.');
+
+        if ($configPath = $suiteDocument->firstChild->firstChild->getAttribute('config-path')) {
+            $this->output->writeln(sprintf('Using configuration file: %s', $configPath));
+        }
+
+        $this->output->writeln('');
+    }
+
+    public function endSuite(SuiteDocument $suiteDocument)
+    {
+        $this->output->writeln(sprintf(
+            '%s subjects, %s iterations, %s revs, %s rejects',
+            $suiteDocument->getNbSubjects(),
+            $suiteDocument->getNbIterations(),
+            $suiteDocument->getNbRevolutions(),
+            $suiteDocument->getNbRejects()
+        ));
+        $this->output->writeln(sprintf(
+            'min mean max: %s %s %s (μs/r)',
+            number_format($suiteDocument->getMin(), 2),
+            number_format($suiteDocument->getMeanTime(), 2),
+            number_format($suiteDocument->getMax(), 2)
+        ));
+        $this->output->writeln(sprintf(
+            '⅀T: %sμs μSD/r %sμs μRSD/r: %s%%',
+            $suiteDocument->getTotalTime(),
+            number_format($suiteDocument->getMeanStDev(), 2),
+            number_format($suiteDocument->getMeanRelStDev(), 2)
+        ));
+    }
+}

--- a/lib/Progress/LoggerInterface.php
+++ b/lib/Progress/LoggerInterface.php
@@ -12,8 +12,10 @@
 namespace PhpBench\Progress;
 
 use PhpBench\Benchmark\Iteration;
+use PhpBench\Benchmark\IterationCollection;
 use PhpBench\Benchmark\Metadata\BenchmarkMetadata;
 use PhpBench\Benchmark\Metadata\SubjectMetadata;
+use PhpBench\Benchmark\SuiteDocument;
 use PhpBench\Console\OutputAwareInterface;
 
 interface LoggerInterface extends OutputAwareInterface
@@ -47,6 +49,20 @@ interface LoggerInterface extends OutputAwareInterface
     public function subjectStart(SubjectMetadata $subject);
 
     /**
+     * Log the end of an an iteration run>.
+     *
+     * @param Iteration $iterations
+     */
+    public function iterationsEnd(IterationCollection $iterations);
+
+    /**
+     * Log the start of an iteration run.
+     *
+     * @param Iteration $iterations
+     */
+    public function iterationsStart(IterationCollection $iterations);
+
+    /**
      * Log the end of an iteration.
      *
      * @param Iteration $iteration
@@ -66,4 +82,18 @@ interface LoggerInterface extends OutputAwareInterface
      * @param int $rejectionCount
      */
     public function retryStart($rejectionCount);
+
+    /**
+     * Called at the start of the suite run.
+     *
+     * @param SuiteDocument $suiteDocument
+     */
+    public function startSuite(SuiteDocument $suiteDocument);
+
+    /**
+     * Called at the end of the suite run.
+     *
+     * @param SuiteDocument $suiteDocument
+     */
+    public function endSuite(SuiteDocument $suiteDocument);
 }

--- a/lib/Report/Generator/tabular/aggregate.json
+++ b/lib/Report/Generator/tabular/aggregate.json
@@ -35,23 +35,24 @@
                     "expr": "count(descendant-or-self::iteration)"
                 },
                 {
-                    "name": "rej",
-                    "expr": "sum(descendant-or-self::iteration/@rejection-count)"
-                },
-                {
                     "name": "mem",
                     "class": "mem",
                     "expr": "average(descendant-or-self::iteration/@memory)"
                 },
                 {
-                    "name": "time",
+                    "name": "min",
+                    "class": "time",
+                    "expr": "number(./stats/@min)"
+                },
+                {
+                    "name": "mean",
                     "class": "time",
                     "expr": "number(./stats/@mean)"
                 },
                 {
-                    "name": "range",
+                    "name": "max",
                     "class": "time",
-                    "expr": "number(./stats/@max) - number(./stats/@min)"
+                    "expr": "number(./stats/@max)"
                 },
                 {
                     "name": "stdev",

--- a/tests/System/RunTest.php
+++ b/tests/System/RunTest.php
@@ -113,7 +113,7 @@ class RunTest extends SystemTestCase
     }
 
     /**
-     * It should dump to an XML file.
+     * It should dump none to an XML file.
      */
     public function testDumpXml()
     {
@@ -132,7 +132,7 @@ class RunTest extends SystemTestCase
     public function testDumpXmlStdOut()
     {
         $process = $this->phpbench(
-            'run --dump --quiet benchmarks/set1/BenchmarkBench.php'
+            'run --dump --progress=none benchmarks/set1/BenchmarkBench.php'
         );
         $this->assertExitCode(0, $process);
         $output = $process->getOutput();
@@ -145,7 +145,7 @@ class RunTest extends SystemTestCase
     public function testOverrideParameters()
     {
         $process = $this->phpbench(
-            'run --dump --parameters=\'{"length": 333}\' benchmarks/set1/BenchmarkBench.php'
+            'run --dump --progress=none --parameters=\'{"length": 333}\' benchmarks/set1/BenchmarkBench.php'
         );
         $this->assertExitCode(0, $process);
         $output = $process->getOutput();
@@ -158,7 +158,7 @@ class RunTest extends SystemTestCase
     public function testOverrideParametersInvalidJson()
     {
         $process = $this->phpbench(
-            'run --dump --parameters=\'{"length": 333\' benchmarks/set1/BenchmarkBench.php'
+            'run --dump --progress=none --parameters=\'{"length": 333\' benchmarks/set1/BenchmarkBench.php'
         );
 
         $this->assertExitCode(1, $process);
@@ -171,7 +171,7 @@ class RunTest extends SystemTestCase
     public function testOverrideIterations()
     {
         $process = $this->phpbench(
-            'run --filter=benchRandom --dump --iterations=10 benchmarks/set1/BenchmarkBench.php'
+            'run --filter=benchRandom --progress=none --dump --iterations=10 benchmarks/set1/BenchmarkBench.php'
         );
 
         $this->assertExitCode(0, $process);
@@ -263,7 +263,7 @@ class RunTest extends SystemTestCase
     public function testGroups()
     {
         $process = $this->phpbench(
-            'run --group=do_nothing --dump benchmarks/set1/BenchmarkBench.php'
+            'run --group=do_nothing --dump --progress=none benchmarks/set1/BenchmarkBench.php'
         );
 
         $this->assertExitCode(0, $process);

--- a/tests/Unit/Benchmark/IterationCollectionTest.php
+++ b/tests/Unit/Benchmark/IterationCollectionTest.php
@@ -17,13 +17,22 @@ use Prophecy\Argument;
 
 class IterationCollectionTest extends \PHPUnit_Framework_TestCase
 {
+    private $subject;
+    private $parameterSet;
+
+    public function setUp()
+    {
+        $this->subject = $this->prophesize('PhpBench\Benchmark\Metadata\SubjectMetadata');
+        $this->parameterSet = $this->prophesize('PhpBench\Benchmark\ParameterSet');
+    }
+
     /**
      * It should be iterable
      * It sohuld be countable.
      */
     public function testIteration()
     {
-        $iterations = new IterationCollection();
+        $iterations = new IterationCollection($this->subject->reveal(), $this->parameterSet->reveal());
         $iterations->replace(array(
             $this->createIteration(4),
             $this->createIteration(4),
@@ -43,7 +52,7 @@ class IterationCollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testComputeStats()
     {
-        $iterations = new IterationCollection();
+        $iterations = new IterationCollection($this->subject->reveal(), $this->parameterSet->reveal());
         $iterations->replace(array(
             $this->createIteration(4, -50, -0.70710678118655),
             $this->createIteration(8, 0, 1E-12),
@@ -59,7 +68,7 @@ class IterationCollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testComputeDeviationZeroIterations()
     {
-        $iterations = new IterationCollection();
+        $iterations = new IterationCollection($this->subject->reveal(), $this->parameterSet->reveal());
         $iterations->computeStats();
     }
 
@@ -68,7 +77,7 @@ class IterationCollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testReject()
     {
-        $iterations = new IterationCollection(50);
+        $iterations = new IterationCollection($this->subject->reveal(), $this->parameterSet->reveal(), 50);
         $iterations->replace(array(
             $iter1 = $this->createIteration(4, -50),
             $iter2 = $this->createIteration(8, 0),

--- a/tests/Unit/Benchmark/RunnerTest.php
+++ b/tests/Unit/Benchmark/RunnerTest.php
@@ -88,7 +88,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         return array(
             array(
                 1,
-                array(1),
+                1,
                 array(),
                 array(
                     'count(//iteration) = 1',
@@ -96,25 +96,23 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
             ),
             array(
                 1,
-                array(1, 3),
+                3,
                 array(),
                 array(
                     'count(//iteration[@revs=3]) = 1',
-                    'count(//iteration[@revs=1]) = 1',
                 ),
             ),
             array(
                 4,
-                array(1, 3),
+                3,
                 array(
-                    'count(//iteration[@revs=1]) = 4',
                     'count(//iteration[@revs=3]) = 4',
                 ),
                 array(),
             ),
             array(
                 1,
-                array(1),
+                1,
                 array('one' => 'two', 'three' => 'four'),
                 array(
                     'count(//parameter[@name="one"]) = 1',
@@ -123,7 +121,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
             ),
             array(
                 1,
-                array(1),
+                1,
                 array('one', 'two'),
                 array(
                     'count(//parameter[@name="0"]) = 1',
@@ -132,7 +130,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
             ),
             array(
                 1,
-                array(1),
+                1,
                 array('one' => array('three' => 'four')),
                 array(
                     'count(//parameter[@name="one"]/parameter[@name="three"]) = 1',
@@ -140,7 +138,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
             ),
             array(
                 1,
-                array(1),
+                1,
                 array('one' => array('three' => new \stdClass())),
                 array(),
                 array('InvalidArgumentException', 'Parameters must be either scalars or arrays, got: stdClass'),
@@ -261,32 +259,6 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         ));
 
         $this->runner->runAll('context', __DIR__);
-    }
-
-    private function configureSubject($subject, array $options)
-    {
-        $options = array_merge(array(
-            'iterations' => 1,
-            'name' => 'benchFoo',
-            'beforeMethods' => array(),
-            'afterMethods' => array(),
-            'parameterSets' => array(array(array())),
-            'groups' => array(),
-            'revs' => 1,
-            'notApplicable' => false,
-            'skip' => false,
-            'sleep' => 0,
-        ), $options);
-
-        $subject->getIterations()->willReturn($options['iterations']);
-        $subject->getSleep()->willReturn($options['sleep']);
-        $subject->getName()->willReturn($options['name']);
-        $subject->getBeforeMethods()->willReturn($options['beforeMethods']);
-        $subject->getAfterMethods()->willReturn($options['afterMethods']);
-        $subject->getParameterSets()->willReturn($options['parameterSets']);
-        $subject->getGroups()->willReturn($options['groups']);
-        $subject->getRevs()->willReturn($options['revs']);
-        $subject->getSkip()->willReturn($options['skip']);
     }
 }
 


### PR DESCRIPTION
This PR adds some realtime statistics to the verbose logger and moves all of responsibility for the "non-report" output (including the `PHPBench Version x.x. Running Benchmarks` header) to the progress loggers.

This enables us to remove the `--quiet` flag - the same can now be achieved using `--progress=none`.