### PR TITLE
Warmup feature

### DIFF
--- a/docs/writing-benchmarks.rst
+++ b/docs/writing-benchmarks.rst
@@ -460,5 +460,38 @@ are executed within a single time unit:
 PHPBench will then render all measurements for `benchMd5` similar to
 `363,874.536ops/s`.
 
+Warming Up: Getting ready for the show
+--------------------------------------
+
+In some cases, it might be a good idea to execute a revolution or two before
+performing the revolutions time measurement. 
+
+For example, when benchmarking something that uses an class autoloader, the
+first revolution will always be slower because the autoloader will not to be
+called again.
+
+Use the ``@Warmup`` annotation to execute any number of revolutions before
+actually measuring the revolutions time.
+
+
+.. code-block:: php
+
+    <?php
+
+    // ...
+    class ReportBench
+    {
+        // ...
+
+        /**
+         * @Warmup(2)
+         * @Revs(10)
+         */
+        public function benchGenerateReport()
+        {
+            $this->generator->generateMyComplexReport();
+        }
+    }
+
 .. _cartesian product: https://en.wikipedia.org/wiki/Cartesian_product
 .. _Relative standard deviation: https://en.wikipedia.org/wiki/Coefficient_of_variation

--- a/lib/Benchmark/Executor/BaseExecutor.php
+++ b/lib/Benchmark/Executor/BaseExecutor.php
@@ -62,6 +62,7 @@ abstract class BaseExecutor implements ExecutorInterface
             'beforeMethods' => var_export($subject->getBeforeMethods(), true),
             'afterMethods' => var_export($subject->getAfterMethods(), true),
             'parameters' => var_export($iteration->getParameters()->getArrayCopy(), true),
+            'warmup' => $iteration->getWarmup() ?: 0,
         );
         $payload = $this->launcher->payload(__DIR__ . '/template/microtime.template', $tokens);
 

--- a/lib/Benchmark/Executor/template/microtime.template
+++ b/lib/Benchmark/Executor/template/microtime.template
@@ -14,6 +14,7 @@ $beforeMethods = {{ beforeMethods }};
 $afterMethods = {{ afterMethods }};
 $bootstrap = '{{ bootstrap }}';
 $parameters = {{ parameters }};
+$warmup = {{ warmup }};
 
 if ($bootstrap) {
     require_once($bootstrap);
@@ -27,26 +28,10 @@ foreach ($beforeMethods as $beforeMethod) {
     $benchmark->$beforeMethod($parameters);
 }
 
-// run the benchmarks: note that passing arguments to the method slightly increases
-// the calltime, so we explicitly do one thing or the other depending on if parameters
-// are provided.
-if ($parameters) {
-    $startTime = microtime(true);
+// warmup if required
+benchmark($benchmark, $subject, $warmup, $parameters);
 
-    for ($i = 0; $i < $revolutions; $i++) {
-        $benchmark->$subject($parameters);
-    }
-
-    $endTime = microtime(true);
-} else {
-    $startTime = microtime(true);
-
-    for ($i = 0; $i < $revolutions; $i++) {
-        $benchmark->$subject();
-    }
-
-    $endTime = microtime(true);
-}
+$time = benchmark($benchmark, $subject, $revolutions, $parameters);
 
 foreach ($afterMethods as $afterMethod) {
     $benchmark->$afterMethod($parameters);
@@ -57,8 +42,34 @@ ob_end_clean();
 
 echo json_encode(array(
     'memory' => memory_get_peak_usage(),
-    'time' => ($endTime * 1000000) - ($startTime * 1000000),
+    'time' => $time,
     'buffer' => $buffer,
 ));
+
+function benchmark($benchmark, $subject, $revolutions, $parameters)
+{
+    // run the benchmarks: note that passing arguments to the method slightly increases
+    // the calltime, so we explicitly do one thing or the other depending on if parameters
+    // are provided.
+    if ($parameters) {
+        $startTime = microtime(true);
+
+        for ($i = 0; $i < $revolutions; $i++) {
+            $benchmark->$subject($parameters);
+        }
+
+        $endTime = microtime(true);
+    } else {
+        $startTime = microtime(true);
+
+        for ($i = 0; $i < $revolutions; $i++) {
+            $benchmark->$subject();
+        }
+
+        $endTime = microtime(true);
+    }
+
+    return ($endTime * 1000000) - ($startTime * 1000000);
+}
 
 exit(0);

--- a/lib/Benchmark/Iteration.php
+++ b/lib/Benchmark/Iteration.php
@@ -19,6 +19,7 @@ use PhpBench\Benchmark\Metadata\SubjectMetadata;
 class Iteration
 {
     private $collection;
+    private $warmup;
     private $revolutions;
     private $parameters = array();
     private $index;
@@ -37,12 +38,14 @@ class Iteration
         $index,
         IterationCollection $collection,
         $revolutions,
+        $warmup,
         ParameterSet $parameters
     ) {
         $this->index = $index;
         $this->revolutions = $revolutions;
         $this->parameters = $parameters;
         $this->collection = $collection;
+        $this->warmup = $warmup;
     }
 
     public function getCollection()
@@ -189,5 +192,13 @@ class Iteration
     public function getRejectionCount()
     {
         return $this->rejectionCount;
+    }
+
+    /**
+     * Return the number of warmup revolutions.
+     */
+    public function getWarmup()
+    {
+        return $this->warmup;
     }
 }

--- a/lib/Benchmark/IterationCollection.php
+++ b/lib/Benchmark/IterationCollection.php
@@ -91,6 +91,7 @@ class IterationCollection implements \IteratorAggregate, \ArrayAccess, \Countabl
         ParameterSet $parameterSet,
         $iterationCount,
         $revolutionCount,
+        $warmupCount = 0,
         $rejectionThreshold = null
     ) {
         $this->subject = $subject;
@@ -100,7 +101,7 @@ class IterationCollection implements \IteratorAggregate, \ArrayAccess, \Countabl
         $this->revolutionCount = $revolutionCount;
 
         for ($index = 0; $index < $this->iterationCount; $index++) {
-            $this->add(new Iteration($index, $this, $revolutionCount, $parameterSet));
+            $this->add(new Iteration($index, $this, $revolutionCount, $warmupCount, $parameterSet));
         }
     }
 

--- a/lib/Benchmark/Metadata/AbstractMetadata.php
+++ b/lib/Benchmark/Metadata/AbstractMetadata.php
@@ -49,6 +49,11 @@ abstract class AbstractMetadata
     private $revs = 1;
 
     /**
+     * @var int
+     */
+    private $warmup = 0;
+
+    /**
      * @var string
      */
     private $class;
@@ -191,5 +196,15 @@ abstract class AbstractMetadata
     public function setOutputMode($outputMode)
     {
         $this->outputMode = $outputMode;
+    }
+
+    public function getWarmup()
+    {
+        return $this->warmup;
+    }
+
+    public function setwarmup($warmup)
+    {
+        $this->warmup = $warmup;
     }
 }

--- a/lib/Benchmark/Metadata/Annotations/Warmup.php
+++ b/lib/Benchmark/Metadata/Annotations/Warmup.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Benchmark\Metadata\Annotations;
+
+/**
+ * @Annotation
+ * @Taget({"METHOD", "CLASS"})
+ * @Attributes({
+ *    @Attribute("value", required = true, type="integer")
+ * })
+ */
+class Warmup
+{
+    private $revs;
+
+    public function __construct($revs)
+    {
+        $this->revs = (int) $revs['value'];
+    }
+
+    public function getRevs()
+    {
+        return $this->revs;
+    }
+}

--- a/lib/Benchmark/Metadata/DocParser.php
+++ b/lib/Benchmark/Metadata/DocParser.php
@@ -33,6 +33,7 @@ class DocParser
         'Sleep' => 'PhpBench\Benchmark\Metadata\Annotations\Sleep',
         'OutputTimeUnit' => 'PhpBench\Benchmark\Metadata\Annotations\OutputTimeUnit',
         'OutputMode' => 'PhpBench\Benchmark\Metadata\Annotations\OutputMode',
+        'Warmup' => 'PhpBench\Benchmark\Metadata\Annotations\Warmup',
     );
     private static $globalIgnoredNames = array(
         // Annotation tags

--- a/lib/Benchmark/Metadata/Driver/AnnotationDriver.php
+++ b/lib/Benchmark/Metadata/Driver/AnnotationDriver.php
@@ -162,6 +162,10 @@ class AnnotationDriver implements DriverInterface
             $metadata->setRevs($annotation->getRevs());
         }
 
+        if ($annotation instanceof Annotations\Warmup) {
+            $metadata->setWarmup($annotation->getRevs());
+        }
+
         if ($annotation instanceof Annotations\Skip) {
             $metadata->setSkip(true);
         }

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -157,6 +157,7 @@ class Runner
             $variantEl->setAttribute('output-time-unit', $subject->getOutputTimeUnit() ?: TimeUnit::MICROSECONDS);
             $variantEl->setAttribute('output-mode', $subject->getOutputMode() ?: TimeUnit::MODE_TIME);
             $variantEl->setAttribute('revs', $context->getRevolutions($subject->getRevs()));
+            $variantEl->setAttribute('warmup', $context->getWarmup($subject->getWarmup()));
             foreach ($parameterSet as $name => $value) {
                 $parameterEl = $this->createParameter($subjectEl, $name, $value);
                 $variantEl->appendChild($parameterEl);
@@ -198,6 +199,7 @@ class Runner
     {
         $iterationCount = $context->getIterations($subject->getIterations());
         $revolutionCount = $context->getRevolutions($subject->getRevs());
+        $warmupCount = $context->getWarmup($subject->getWarmUp());
         $executorConfig = $this->executorRegistry->getConfig($context->getExecutor());
 
         $iterationCollection = new IterationCollection(
@@ -205,6 +207,7 @@ class Runner
             $parameterSet,
             $iterationCount,
             $revolutionCount,
+            $warmupCount,
             $context->getRetryThreshold($this->retryThreshold)
         );
 

--- a/lib/Benchmark/RunnerContext.php
+++ b/lib/Benchmark/RunnerContext.php
@@ -43,6 +43,7 @@ class RunnerContext
             'parameters' => null,
             'retry_threshold' => null,
             'sleep' => null,
+            'warmup' => null,
         );
 
         $options = array_merge(
@@ -107,6 +108,13 @@ class RunnerContext
 
                 $numericValidator('Revolutions', $v);
             },
+            'warmup' => function ($v) use ($numericValidator) {
+                if (null === $v) {
+                    return;
+                }
+
+                $numericValidator('Warmup', $v);
+            },
         );
 
         foreach ($validators as $optionName => $validator) {
@@ -161,13 +169,23 @@ class RunnerContext
     }
 
     /**
-     * Override the number of rev(olutions) to run.
+     * Get the number of rev(olutions) to run.
      *
-     * @param int
+     * @param int $default
      */
     public function getRevolutions($default = null)
     {
         return $this->options['revolutions'] ?: $default;
+    }
+
+    /**
+     * Return the number of warmup revolutions that should be exectuted.
+     *
+     * @param int $default
+     */
+    public function getWarmup($default = null)
+    {
+        return $this->options['warmup'] ?: $default;
     }
 
     /**

--- a/lib/Console/Command/RunCommand.php
+++ b/lib/Console/Command/RunCommand.php
@@ -56,6 +56,7 @@ EOT
         $this->addOption('dump-file', 'd', InputOption::VALUE_OPTIONAL, 'Dump XML result to named file');
         $this->addOption('dump', null, InputOption::VALUE_NONE, 'Dump XML result to stdout and suppress all other output');
         $this->addOption('iterations', null, InputOption::VALUE_REQUIRED, 'Override number of iteratios to run in (all) benchmarks');
+        $this->addOption('warmup', null, InputOption::VALUE_REQUIRED, 'Override number of warmup revolutions on all benchmarks');
         $this->addOption('retry-threshold', 'r', InputOption::VALUE_REQUIRED, 'Set target allowable deviation', null);
         $this->addOption('sleep', null, InputOption::VALUE_REQUIRED, 'Number of microseconds to sleep between iterations');
         $this->addOption('context', null, InputOption::VALUE_REQUIRED, 'Context label to apply to the suite result (useful when comparing reports)');
@@ -69,6 +70,7 @@ EOT
             'retry_threshold' => $input->getOption('retry-threshold'),
             'sleep' => $input->getOption('sleep'),
             'iterations' => $input->getOption('iterations'),
+            'warmup' => $input->getOption('warmup'),
         ));
 
         if ($dumpFile = $input->getOption('dump-file')) {

--- a/tests/Unit/Benchmark/Executor/MicrotimeExecutorTest.php
+++ b/tests/Unit/Benchmark/Executor/MicrotimeExecutorTest.php
@@ -87,6 +87,7 @@ class MicrotimeExecutorTest extends \PHPUnit_Framework_TestCase
         $this->subject->getName()->willReturn('doSomething');
         $this->iteration->getSubject()->willReturn($this->subject);
         $this->iteration->getRevolutions()->willReturn(10);
+        $this->iteration->getWarmup()->willReturn(1);
         $this->iteration->getParameters()->willReturn(new ParameterSet());
 
         $result = $this->executor->execute($this->iteration->reveal(), new Config('test', array()));
@@ -97,7 +98,9 @@ class MicrotimeExecutorTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(file_exists($this->beforeMethodFile));
         $this->assertFalse(file_exists($this->afterMethodFile));
         $this->assertTrue(file_exists($this->revFile));
-        $this->assertEquals('10', file_get_contents($this->revFile));
+
+        // 10 revolutions + 1 warmup
+        $this->assertEquals('11', file_get_contents($this->revFile));
     }
 
     /**
@@ -113,6 +116,7 @@ class MicrotimeExecutorTest extends \PHPUnit_Framework_TestCase
         $this->subject->getName()->willReturn('benchOutput');
         $this->iteration->getSubject()->willReturn($this->subject);
         $this->iteration->getRevolutions()->willReturn(10);
+        $this->iteration->getWarmup()->willReturn(0);
         $this->iteration->getParameters()->willReturn(new ParameterSet());
 
         $result = $this->executor->execute($this->iteration->reveal(), new Config('test', array()));
@@ -130,6 +134,7 @@ class MicrotimeExecutorTest extends \PHPUnit_Framework_TestCase
         $this->subject->getName()->willReturn('doSomething');
         $this->iteration->getSubject()->willReturn($this->subject);
         $this->iteration->getRevolutions()->willReturn(1);
+        $this->iteration->getWarmup()->willReturn(0);
         $this->iteration->getParameters()->willReturn(new ParameterSet());
 
         $this->executor->execute($this->iteration->reveal(), new Config('test', array()));
@@ -147,6 +152,7 @@ class MicrotimeExecutorTest extends \PHPUnit_Framework_TestCase
         $this->subject->getName()->willReturn('doSomething');
         $this->iteration->getSubject()->willReturn($this->subject);
         $this->iteration->getRevolutions()->willReturn(1);
+        $this->iteration->getWarmup()->willReturn(0);
         $this->iteration->getParameters()->willReturn(new ParameterSet());
 
         $this->executor->execute($this->iteration->reveal(), new Config('test', array()));
@@ -165,6 +171,7 @@ class MicrotimeExecutorTest extends \PHPUnit_Framework_TestCase
 
         $this->iteration->getSubject()->willReturn($this->subject);
         $this->iteration->getRevolutions()->willReturn(1);
+        $this->iteration->getWarmup()->willReturn(0);
         $this->iteration->getParameters()->willReturn(new ParameterSet(0, array(
             'one' => 'two',
             'three' => 'four',
@@ -195,6 +202,7 @@ class MicrotimeExecutorTest extends \PHPUnit_Framework_TestCase
 
         $this->iteration->getSubject()->willReturn($this->subject);
         $this->iteration->getRevolutions()->willReturn(1);
+        $this->iteration->getWarmup()->willReturn(0);
         $this->iteration->getParameters()->willReturn($expected);
 
         $this->executor->execute($this->iteration->reveal(), new Config('test', array()));

--- a/tests/Unit/Benchmark/IterationCollectionTest.php
+++ b/tests/Unit/Benchmark/IterationCollectionTest.php
@@ -32,7 +32,7 @@ class IterationCollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testIteration()
     {
-        $iterations = new IterationCollection($this->subject->reveal(), $this->parameterSet->reveal(), 4, 10);
+        $iterations = new IterationCollection($this->subject->reveal(), $this->parameterSet->reveal(), 4, 10, 0);
 
         $this->assertCount(4, $iterations);
 
@@ -46,7 +46,7 @@ class IterationCollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testComputeStats()
     {
-        $iterations = new IterationCollection($this->subject->reveal(), $this->parameterSet->reveal(), 4, 1);
+        $iterations = new IterationCollection($this->subject->reveal(), $this->parameterSet->reveal(), 4, 1, 0);
 
         $iterations[0]->setResult(new IterationResult(4, null));
         $iterations[1]->setResult(new IterationResult(8, null));
@@ -73,7 +73,7 @@ class IterationCollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testComputeDeviationZeroIterations()
     {
-        $iterations = new IterationCollection($this->subject->reveal(), $this->parameterSet->reveal(), 0, 1);
+        $iterations = new IterationCollection($this->subject->reveal(), $this->parameterSet->reveal(), 0, 1, 0);
         $iterations->computeStats();
     }
 
@@ -82,7 +82,7 @@ class IterationCollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testReject()
     {
-        $iterations = new IterationCollection($this->subject->reveal(), $this->parameterSet->reveal(), 4, 1, 50);
+        $iterations = new IterationCollection($this->subject->reveal(), $this->parameterSet->reveal(), 4, 1, 0, 50);
 
         $iterations[0]->setResult(new IterationResult(4, null));
         $iterations[1]->setResult(new IterationResult(8, null));
@@ -121,7 +121,7 @@ class IterationCollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testExceptionAwareness()
     {
-        $iterations = new IterationCollection($this->subject->reveal(), $this->parameterSet->reveal(), 4, 1);
+        $iterations = new IterationCollection($this->subject->reveal(), $this->parameterSet->reveal(), 4, 1, 0);
         $exception = new \Exception('Test');
 
         $this->assertFalse($iterations->hasException());
@@ -137,7 +137,7 @@ class IterationCollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testExceptionNoneGet()
     {
-        $iterations = new IterationCollection($this->subject->reveal(), $this->parameterSet->reveal(), 4, 1);
+        $iterations = new IterationCollection($this->subject->reveal(), $this->parameterSet->reveal(), 4, 1, 0);
         $iterations->getException();
     }
 
@@ -149,7 +149,7 @@ class IterationCollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetStatsNoComputeException()
     {
-        $iterations = new IterationCollection($this->subject->reveal(), $this->parameterSet->reveal(), 4, 1);
+        $iterations = new IterationCollection($this->subject->reveal(), $this->parameterSet->reveal(), 4, 1, 0);
         $iterations->getStats();
     }
 
@@ -161,7 +161,7 @@ class IterationCollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetStatsWithExceptionException()
     {
-        $iterations = new IterationCollection($this->subject->reveal(), $this->parameterSet->reveal(), 1, 1);
+        $iterations = new IterationCollection($this->subject->reveal(), $this->parameterSet->reveal(), 1, 1, 0);
         $iterations[0]->setResult(new IterationResult(4, null));
         $iterations->computeStats();
         $iterations->setException(new \Exception('Test'));

--- a/tests/Unit/Benchmark/IterationTest.php
+++ b/tests/Unit/Benchmark/IterationTest.php
@@ -29,8 +29,17 @@ class IterationTest extends \PHPUnit_Framework_TestCase
             0,
             $this->collection->reveal(),
             5,
+            4,
             new ParameterSet()
         );
+    }
+
+    /**
+     * It should have getters that return its values.
+     */
+    public function testGetters()
+    {
+        $this->assertEquals(4, $this->iteration->getWarmup());
     }
 
     /**

--- a/tests/Unit/Benchmark/Metadata/Driver/AnnotationDriverTest.php
+++ b/tests/Unit/Benchmark/Metadata/Driver/AnnotationDriverTest.php
@@ -51,6 +51,7 @@ class AnnotationDriverTest extends \PHPUnit_Framework_TestCase
  * @Sleep(500)
  * @OutputTimeUnit("seconds")
  * @OutputMode("throughput")
+ * @Warmup(501)
  */
 EOT;
         $hierarchy = new ReflectionHierarchy();
@@ -68,6 +69,7 @@ EOT;
         $this->assertEquals(500, $metadata->getSleep());
         $this->assertEquals('seconds', $metadata->getOutputTimeUnit());
         $this->assertEquals('throughput', $metadata->getOutputMode());
+        $this->assertEquals(501, $metadata->getWarmup());
         $this->assertTrue($metadata->getSkip());
     }
 

--- a/tests/Unit/Benchmark/RunnerContextTest.php
+++ b/tests/Unit/Benchmark/RunnerContextTest.php
@@ -66,7 +66,7 @@ class RunnerContextTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should throw an exception if the iterations is not numeric.
+     * It should throw an exception if the revolutions are not numeric.
      *
      * @expectedException InvalidArgumentException
      * @expectedExceptionMessage Revolutions must be a number
@@ -75,6 +75,19 @@ class RunnerContextTest extends \PHPUnit_Framework_TestCase
     {
         new RunnerContext(__DIR__, array(
             'revolutions' => 'asd',
+        ));
+    }
+
+    /**
+     * It should throw an exception if the warmup is not numeric.
+     *
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Warmup must be a number
+     */
+    public function testWarmupNotNumeric()
+    {
+        new RunnerContext(__DIR__, array(
+            'warmup' => 'asd',
         ));
     }
 

--- a/tests/Unit/Benchmark/RunnerTest.php
+++ b/tests/Unit/Benchmark/RunnerTest.php
@@ -231,6 +231,31 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * It should set the warmup attribute in the DOM.
+     */
+    public function testWarmup()
+    {
+        $this->collection->getBenchmarks()->willReturn(array(
+            $this->benchmark,
+        ));
+        TestUtil::configureSubject($this->subject, array(
+            'warmup' => 50,
+        ));
+        $this->benchmark->getSubjectMetadatas()->willReturn(array(
+            $this->subject->reveal(),
+        ));
+        TestUtil::configureBenchmark($this->benchmark);
+        $this->executor->execute(Argument::type('PhpBench\Benchmark\Iteration'), $this->executorConfig)
+            ->shouldBeCalledTimes(1)
+            ->willReturn(new IterationResult(10, 10));
+
+        $result = $this->runner->run(new RunnerContext(__DIR__, array()));
+
+        $this->assertInstanceOf('PhpBench\Benchmark\SuiteDocument', $result);
+        $this->assertEquals(50, $result->evaluate('number(//variant/@warmup)'), true);
+    }
+
+    /**
      * It should serialize the retry threshold.
      */
     public function testRetryThreshold()

--- a/tests/Util/TestUtil.php
+++ b/tests/Util/TestUtil.php
@@ -28,6 +28,7 @@ class TestUtil
             'parameterSets' => array(array(array())),
             'groups' => array(),
             'revs' => 1,
+            'warmup' => 0,
             'notApplicable' => false,
             'skip' => false,
             'sleep' => 0,
@@ -45,6 +46,7 @@ class TestUtil
         $subject->getGroups()->willReturn($options['groups']);
         $subject->getRevs()->willReturn($options['revs']);
         $subject->getSkip()->willReturn($options['skip']);
+        $subject->getWarmup()->willReturn($options['warmup']);
         $subject->getParamProviders()->willReturn($options['paramProviders']);
         $subject->getOutputTimeUnit()->willReturn($options['outputTimeUnit']);
         $subject->getOutputMode()->willReturn($options['outputMode']);


### PR DESCRIPTION
This PR allows the code to be executed *x* times before measurements are taken. This is done via. the `@Warmup(x)` annotation.