### PR TITLE
escape script path when calling command

### DIFF
--- a/lib/Benchmark/Remote/Payload.php
+++ b/lib/Benchmark/Remote/Payload.php
@@ -109,7 +109,7 @@ class Payload
             $wrapper = $this->wrapper . ' ';
         }
 
-        $this->process->setCommandLine($wrapper . $this->phpPath . $this->getIniString() . ' ' . $scriptPath);
+        $this->process->setCommandLine($wrapper . $this->phpPath . $this->getIniString() . ' ' . escapeshellarg($scriptPath));
         $this->process->run();
         unlink($scriptPath);
 


### PR DESCRIPTION
I had escape this in order to get it working on my Windows box. My temp dir is in the user directory and there's a blank in the path. This fixes the problem and should work on *nix too in case someone has a blank in their temp path, probably never happens there though.