### PR TITLE
fix unit tests when using windows

### DIFF
--- a/bin/phpbench.bat
+++ b/bin/phpbench.bat
@@ -1,0 +1,2 @@
+@echo off
+php.exe "%~dp0\phpbench.php" %*

--- a/tests/System/SystemTestCase.php
+++ b/tests/System/SystemTestCase.php
@@ -25,7 +25,7 @@ class SystemTestCase extends \PHPUnit_Framework_TestCase
     public function createResult($benchmark = 'benchmarks/set4')
     {
         $process = $this->phpbench(
-            'run ' . $benchmark . ' --executor=debug --dump-file=' . $this->fname
+            'run ' . $benchmark . ' --executor=debug --dump-file=' . escapeshellarg($this->fname)
         );
 
         if ($process->getExitCode() !== 0) {
@@ -49,6 +49,7 @@ class SystemTestCase extends \PHPUnit_Framework_TestCase
     {
         chdir($this->getWorkingDir($workingDir));
         $bin = __DIR__ . '/../../bin/phpbench --verbose';
+        $bin = str_replace('/', DIRECTORY_SEPARATOR, $bin);
         $process = new Process($bin . ' ' . $command);
         $process->run();
 


### PR DESCRIPTION
It's not complete, still some broken tests. Mostly related to console and processes, one example below. I'll try to continue when I'm home.

```
2) PhpBench\Tests\System\RunTest::testCommandWithReportConfigurationUnknown
Failed asserting that '

  [Symfony\Component\Console\Exception\RuntimeException]
  Too many arguments.
```
