### PR TITLE
Catch warnings and div by zero

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "symfony/finder": "^2.4|^3.0",
         "symfony/process": "^2.1|^3.0",
         "symfony/filesystem": "^2.4|^3.0",
+        "symfony/debug": "^2.4|^3.0",
         "phpbench/tabular": "dev-master",
         "seld/jsonlint": "^1.0",
         "justinrainbow/json-schema": "^1.0",

--- a/lib/Benchmark/IterationCollection.php
+++ b/lib/Benchmark/IterationCollection.php
@@ -150,28 +150,48 @@ class IterationCollection implements \IteratorAggregate, \ArrayAccess, \Countabl
             $times[] = $iteration->getResult()->getTime() / $iteration->getRevolutions();
         }
 
-        // standard deviation for T Distribution
-        $this->stats['stdev'] = Statistics::stdev($times);
-
-        // mean of the times
-        $this->stats['mean'] = Statistics::mean($times);
-
-        // mode based on the kernel distribution function
-        $this->stats['mode'] = Statistics::kdeMode($times);
-
-        // relative standard error
-        $this->stats['rstdev'] = $this->stats['stdev'] / $this->stats['mean'] * 100;
-
-        // variance
-        $this->stats['variance'] = Statistics::variance($times);
+        $this->stats = array(
+            'stdev' => 0,
+            'mean' => 0,
+            'mode' => 0,
+            'rstdev' => 0,
+            'variance' => 0,
+            'min' => 0,
+            'max' => 0,
+        );
 
         // min and max
         $this->stats['min'] = min($times);
         $this->stats['max'] = max($times);
 
+        if ($this->stats['min'] > 0 && $this->stats['max'] > 0) {
+            // standard deviation for T Distribution
+            $this->stats['stdev'] = Statistics::stdev($times);
+
+            // mean of the times
+            $this->stats['mean'] = Statistics::mean($times);
+
+            // mode based on the kernel distribution function
+            $this->stats['mode'] = Statistics::kdeMode($times);
+
+            // relative standard error
+            $this->stats['rstdev'] = $this->stats['stdev'] / $this->stats['mean'] * 100;
+
+            // variance
+            $this->stats['variance'] = Statistics::variance($times);
+        }
+
         foreach ($this->iterations as $iteration) {
             // deviation is the percentage different of the value from the mean of the set.
-            $deviation = 100 / $this->stats['mean'] * (($iteration->getResult()->getTime() / $iteration->getRevolutions()) - $this->stats['mean']);
+            if ($this->stats['mean'] > 0) {
+                $deviation = 100 / $this->stats['mean'] * (
+                    (
+                        $iteration->getResult()->getTime() / $iteration->getRevolutions()
+                    ) - $this->stats['mean']
+                );
+            } else {
+                $deviation = 0;
+            }
             $iteration->setDeviation($deviation);
 
             // the Z-Value represents the number of standard deviations this

--- a/lib/PhpBench.php
+++ b/lib/PhpBench.php
@@ -14,6 +14,7 @@ namespace PhpBench;
 use PhpBench\DependencyInjection\Container;
 use Seld\JsonLint\JsonParser;
 use Seld\JsonLint\ParsingException;
+use Symfony\Component\Debug\ErrorHandler;
 
 class PhpBench
 {
@@ -21,6 +22,9 @@ class PhpBench
 
     public static function run()
     {
+        // Converts warnings to exceptions
+        ErrorHandler::register();
+
         $config = self::loadConfig();
         $container = new Container($config['extensions']);
         unset($config['extensions']);

--- a/tests/System/RunTest.php
+++ b/tests/System/RunTest.php
@@ -385,4 +385,15 @@ class RunTest extends SystemTestCase
         $this->assertEquals(1, $success);
         $this->assertEquals(6, strlen($matches[1]));
     }
+
+    /**
+     * It should not crash when zeros are reported as times.
+     */
+    public function testZeroTimedIterations()
+    {
+        $process = $this->phpbench(
+            'run benchmarks/set1 --executor=\'{"executor": "debug", "times": [0]}\''
+        );
+        $this->assertExitCode(0, $process);
+    }
 }


### PR DESCRIPTION
This PR 

- adds a dependency on the Symfony Debug component, which provides an error handler.
- handles the situation (which can occur on Windows apparently) where all the iterations return 0 and we get a div by zero error.