### PR TITLE
Non-strict "JSON" support.

### DIFF
--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -29,6 +29,7 @@ use PhpBench\DependencyInjection\Container;
 use PhpBench\DependencyInjection\ExtensionInterface;
 use PhpBench\Environment\Provider;
 use PhpBench\Environment\Supplier;
+use PhpBench\Json\JsonDecoder;
 use PhpBench\Progress\Logger\BlinkenLogger;
 use PhpBench\Progress\Logger\DotsLogger;
 use PhpBench\Progress\Logger\HistogramLogger;
@@ -223,6 +224,9 @@ class CoreExtension implements ExtensionInterface
 
     private function registerJsonSchema(Container $container)
     {
+        $container->register('json.decoder', function (Container $container) {
+            return new JsonDecoder();
+        });
         $container->register('json_schema.validator', function (Container $container) {
             return new \JsonSchema\Validator();
         });
@@ -404,7 +408,8 @@ class CoreExtension implements ExtensionInterface
                 return new Registry(
                     $registryType,
                     $container,
-                    $container->get('json_schema.validator')
+                    $container->get('json_schema.validator'),
+                    $container->get('json.decoder')
                 );
             });
         }
@@ -413,7 +418,8 @@ class CoreExtension implements ExtensionInterface
             return new Registry(
                 'executor',
                 $container,
-                $container->get('json_schema.validator')
+                $container->get('json_schema.validator'),
+                $container->get('json.decoder')
             );
         });
     }

--- a/lib/Json/JsonDecoder.php
+++ b/lib/Json/JsonDecoder.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Json;
+
+use Seld\JsonLint\JsonParser;
+
+/**
+ * Decodes JSON to an array.
+ *
+ * Accepts non-strict "JSON":
+ *
+ *     - {this: ["is": {where: "sparta"}]} # quoteless keys are allowed
+ *     - this: ["is": {where: "sparta"}]   # enclosing braces can be omitted
+ *
+ * Lints the JSON using the JsonParser.
+ */
+class JsonDecoder
+{
+    public function __construct()
+    {
+        $this->parser = new JsonParser();
+    }
+
+    /**
+     * Normalize, parse and decode the given JSON(ish) encoded string into
+     * an array.
+     *
+     * @param string $jsonString
+     *
+     * @return array
+     */
+    public function decode($jsonString)
+    {
+        $jsonString = $this->normalize($jsonString);
+        $this->parser->parse($jsonString);
+
+        return json_decode($jsonString, true);
+    }
+
+    /**
+     * Taken from: https://gist.github.com/larruda/967110d74d98c1cd4ee1.
+     */
+    private function normalize($jsonString)
+    {
+        if (!is_string($jsonString)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Expected a string, got a "%s"',
+                is_object($jsonString) ? get_class($jsonString) : gettype($jsonString)
+            ));
+        }
+
+        if (substr($jsonString, 0, 1) !== '{') {
+            $jsonString = '{' . $jsonString;
+        }
+
+        if (substr($jsonString, -1) !== '}') {
+            $jsonString = $jsonString . '}';
+        }
+
+        $jsonString = preg_replace(
+            '{(\s*?\{\s*?|\s*?,\s*?)([\'"])?([\$a-zA-Z0-9]+)([\'"])?:}',
+            '\1"\3":',
+            $jsonString
+        );
+
+        return $jsonString;
+    }
+}

--- a/lib/Registry/Config.php
+++ b/lib/Registry/Config.php
@@ -17,10 +17,21 @@ namespace PhpBench\Registry;
  */
 class Config extends \ArrayObject
 {
+    /**
+     * All names must satisfy this regex.
+     */
+    const NAME_REGEX = '{^[0-9a-zA-Z_-]+$}';
+
     private $name;
 
     public function __construct($name, array $config)
     {
+        if (!preg_match(self::NAME_REGEX, $name)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Configuration names may only contain alpha-numeric characters, _ and -. Got "%s"',
+                $name
+            ));
+        }
         $this->name = $name;
         parent::__construct($config);
     }

--- a/tests/System/RunTest.php
+++ b/tests/System/RunTest.php
@@ -109,7 +109,7 @@ class RunTest extends SystemTestCase
             'run --report=\'{"name": "foo_ta\' benchmarks/set4/NothingBench.php'
         );
         $this->assertExitCode(1, $process);
-        $this->assertContains('Could not decode', $process->getErrorOutput());
+        $this->assertContains('Parse error', $process->getErrorOutput());
     }
 
     /**

--- a/tests/Unit/Json/JsonDecoderTest.php
+++ b/tests/Unit/Json/JsonDecoderTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Tests\Unit\Json;
+
+use PhpBench\Json\JsonDecoder;
+
+class JsonDecoderTest extends \PHPUnit_Framework_TestCase
+{
+    private $jsonDecoder;
+
+    public function setUp()
+    {
+        $this->jsonDecoder = new JsonDecoder();
+    }
+
+    /**
+     * It should convert "non-strict" JSON to JSON.
+     *
+     * @dataProvider provideNormalizer
+     */
+    public function testNormalizer($string, $expected)
+    {
+        $result = $this->jsonDecoder->decode($string);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function provideNormalizer()
+    {
+        return array(
+            array(
+                '{$eq: "barfoo"}',
+                array('$eq' => 'barfoo'),
+            ),
+            array(
+                '{foobar: "barfoo"}',
+                array('foobar' => 'barfoo'),
+            ),
+            array(
+                'foobar: "barfoo"',
+                array('foobar' => 'barfoo'),
+            ),
+            array(
+                'foobar: "barfoo"',
+                array('foobar' => 'barfoo'),
+            ),
+            array(
+                'foobar": "barfoo"',
+                array('foobar' => 'barfoo'),
+            ),
+            array(
+                '$and: [ {$gt: {date: "2016-01-30 09:27"}}, {$eq: {subject: "benchMySubject"}}]',
+                array(
+                    '$and' => array(
+                        array(
+                            '$gt' => array(
+                                'date' => '2016-01-30 09:27',
+                            ),
+                        ),
+                        array(
+                            '$eq' => array(
+                                'subject' => 'benchMySubject',
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            array(
+                'foo: 10',
+                array(
+                    'foo' => 10,
+                ),
+            ),
+            array(
+                '10: 10',
+                array(
+                    10 => 10,
+                ),
+            ),
+        );
+    }
+
+    /**
+     * It should throw an exception if a non-string value is passed.
+     *
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Expected a string
+     */
+    public function testThrowException()
+    {
+        $this->jsonDecoder->decode(new \stdClass());
+    }
+}

--- a/tests/Unit/Registry/ConfigTest.php
+++ b/tests/Unit/Registry/ConfigTest.php
@@ -19,15 +19,6 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->config = new Config(
-            'test',
-            array(
-            'foo' => 'bar',
-            'bar' => array(
-                'one' => 1,
-                'two' => 2,
-            ),
-        ));
     }
 
     /**
@@ -38,6 +29,56 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
      */
     public function testExceptionOffsetNotExist()
     {
-        $this->config['offset_not_exist'];
+        $config = new Config(
+            'test',
+            array(
+            'foo' => 'bar',
+            'bar' => array(
+                'one' => 1,
+                'two' => 2,
+            ),
+        ));
+        $config['offset_not_exist'];
+    }
+
+    /**
+     * It should throw an exception if an invalid name is given.
+     *
+     * @expectedException InvalidArgumentException
+     * @dataProvider provideInvalidName
+     */
+    public function testInvalidName($name)
+    {
+        new Config($name, array());
+    }
+
+    public function provideInvalidName()
+    {
+        return array(
+            array('he lo'),
+            array('foo&'),
+            array(':'),
+            array(''),
+        );
+    }
+
+    /**
+     * It should allow good names.
+     *
+     * @dataProvider provideGoodName
+     */
+    public function testGoodName($name)
+    {
+        $config = new Config($name, array());
+        $this->assertEquals($name, $config->getName());
+    }
+
+    public function provideGoodName()
+    {
+        return array(
+            array('helo'),
+            array('foo-bar'),
+            array('foo_bar'),
+        );
     }
 }

--- a/tests/Unit/Registry/RegistryTest.php
+++ b/tests/Unit/Registry/RegistryTest.php
@@ -12,6 +12,7 @@
 namespace PhpBench\Tests\Unit\Registry;
 
 use JsonSchema\Validator;
+use PhpBench\Json\JsonDecoder;
 use PhpBench\Registry\Config;
 use PhpBench\Registry\Registry;
 
@@ -33,7 +34,8 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
         $this->registry = new Registry(
             'test',
             $this->container->reveal(),
-            $this->validator
+            $this->validator,
+            new JsonDecoder()
         );
     }
 
@@ -270,8 +272,7 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
     /**
      * If a invalid JSON encoded string is passed to getConfig, then it should throw an exception.
      *
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Could not decode
+     * @expectedException Seld\JsonLint\ParsingException
      */
     public function testGetConfigJsonStringInvalid()
     {
@@ -279,7 +280,7 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
         $this->service1->getDefaultConfig()->willReturn(array());
         $this->service1->getSchema()->willReturn(array());
 
-        $result = $this->registry->getConfig('{test": "service"}');
+        $result = $this->registry->getConfig('{test": service}');
         $this->assertEquals(new Config('test', array(
             'test' => 'service',
         )), $result);


### PR DESCRIPTION
- New JsonDecoder.
- Allows unquoted keys.
- Allows non encapsulated strings.
- Parses using JsonParse.
- Applies to all things that can be configured from the CLI with JSON.

From:

```bash
$ phpbench run --report='{"extends": "aggregate", "exclude": ["benchmark", "params"]}'
```

To:

```bash
$ phpbench run --report='extends: "aggregate", exclude: ["benchmark", "params"]'
$ phpbench run --executor='extends: "debug", times: [1, 2, 3, 4], spread: [0, 1, 2]'
```
