### PR TITLE
Fixed overrides and added tests

### DIFF
--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -125,7 +125,7 @@ class Runner
             $subjectMetadata->setRevs($context->getRevolutions($subjectMetadata->getRevs()));
             $subjectMetadata->setWarmup($context->getWarmup($subjectMetadata->getWarmUp()));
             $subjectMetadata->setSleep($context->getSleep($subjectMetadata->getSleep()));
-            $subjectMetadata->setRetryThreshold($this->retryThreshold);
+            $subjectMetadata->setRetryThreshold($context->getRetryThreshold($this->retryThreshold));
 
             $benchmark->createSubjectFromMetadata($subjectMetadata);
         }

--- a/tests/Unit/Benchmark/RunnerTest.php
+++ b/tests/Unit/Benchmark/RunnerTest.php
@@ -214,8 +214,11 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * It should allow the sleep value to be overridden.
+     * It should allow the warmup value to be overridden.
+     * It should allow the revs value to be overridden.
+     * It should allow the retry threshold value to be overridden.
      */
-    public function testSleepOverride()
+    public function testOverrideThings()
     {
         $subject = new SubjectMetadata($this->benchmark->reveal(), 'name', 0);
         $subject->setSleep(50);
@@ -229,12 +232,18 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
             ->will(function ($args) use ($test) {
                 $iteration = $args[1];
                 $test->assertEquals(100, $iteration->getVariant()->getSubject()->getSleep());
+                $test->assertEquals(12, $iteration->getVariant()->getSubject()->getRetryThreshold());
+                $test->assertEquals(66, $iteration->getVariant()->getSubject()->getWarmup());
+                $test->assertEquals(88, $iteration->getVariant()->getSubject()->getRevs());
 
                 return new IterationResult(10, 10);
             });
 
         $suite = $this->runner->run(new RunnerContext(__DIR__, array(
             'sleep' => 100,
+            'retry_threshold' => 12,
+            'warmup' => 66,
+            'revolutions' => 88,
         )));
         $this->assertNoErrors($suite);
     }


### PR DESCRIPTION
Fixes regression with not allowing the retry threshold to be set from the CLI.