### PR TITLE
Fix class name detection

### DIFF
--- a/lib/Benchmark/Remote/Reflector.php
+++ b/lib/Benchmark/Remote/Reflector.php
@@ -154,10 +154,8 @@ class Reflector
 
                 if ($tokens[$i][0] === T_CLASS) {
                     for ($j = $i + 1; $j < count($tokens); $j++) {
-                        if ($tokens[$j] === '{') {
+                        if ($tokens[$j][0] === T_STRING) {
                             $class = $tokens[$i + 2][1];
-
-                            // only parse the first class token
                             break 2;
                         }
                     }

--- a/tests/Unit/Benchmark/Remote/ReflectorTest.php
+++ b/tests/Unit/Benchmark/Remote/ReflectorTest.php
@@ -48,6 +48,16 @@ class ReflectorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * It should parse a file whose class declaration is on the 20th line.
+     * See: https://github.com/phpbench/phpbench/issues/325.
+     */
+    public function testReflector20LineFile()
+    {
+        $fname = __DIR__ . '/reflector/ExampleClass2.php';
+        $this->reflector->reflect($fname);
+    }
+
+    /**
      * It should inherit metadata from parent classes.
      */
     public function testHierarchy()

--- a/tests/Unit/Benchmark/Remote/reflector/ExampleClass2.php
+++ b/tests/Unit/Benchmark/Remote/reflector/ExampleClass2.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ZendBench\Hydrator;
+
+/**
+ * @AfterMethods({"foo"})
+ * @BeforeMethods({"classSetUp"})
+ * @Revs(1000)
+ * @Iterations(20)
+ * @Warmup(2)
+ */
+class ExampleClass2
+{
+    // code
+}


### PR DESCRIPTION
Fixes #325 

The parser (copy and pasted from stackoverflow with attribution) was reading ahead for the `{` afert the class name before resolving it. Because we read in 20 line blocks, the `{` was not in the block with the class name.

This PR simply looks for any `T_STRING` after the `T_CLASS` token and assumes that that is the class name.