### PR TITLE
Added baseline env provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
 script: 
   - phpunit
   # run the benchmarks in order to test them
-  - php bin/phpbench run --iterations=1 --revs=1
+  - php bin/phpbench run --iterations=1 --revs=1 --report=env
   - php bin/phpbench run --iterations=1 --revs=1 --config=extensions/dbal/benchmarks/phpbench.json
 
 matrix:

--- a/docs/environment.rst
+++ b/docs/environment.rst
@@ -17,8 +17,8 @@ This information is recorded in the XML document:
       <vcs system="git" branch="env_info" version="edde9dc7542cfa8e3ef4da459f0aaa5dfb095109"/>
     </env>
 
-It can be readily viewed using the :ref:`report_env` report.
-
+This information can be readily viewed with the :ref:`report_env` report and can also be
+displayed when using the :ref:`table report generator <generator_table>`.
 
 GIT
 ---
@@ -55,6 +55,22 @@ Unix Sysload
 
 Provides the `CPU load`_ for the following time periods: 1 minute, 5 minutes and
 15 minutes.
+
+Baseline
+--------
+
+**Class**: ``PhpBench\Environment\Provider\Baseline``
+**Available**: Always
+
+Provides baseline measurements, by default it will provide mean times for
+executing the following micro-benchmarks (1000 revolutions):
+
+- ``nothing``: An empty method.
+- ``md5``: Calculation of an MD5 hash.
+- ``file_rw``: File read and write.
+
+These measurements can help determine the relative speed of the system under
+test compared to other systems.
 
 .. _CPU load: https://en.wikipedia.org/wiki/Load_(computing)
 .. _php_uname: http://php.net/manual/en/function.php-uname.php

--- a/docs/reports.rst
+++ b/docs/reports.rst
@@ -227,8 +227,6 @@ Shows aggregate details of each each set of iterations:
 
 It is uses the ``table`` generator, see :ref:`generator_table` for more information.
 
-.. _report_env:
-
 
 ``default``
 ~~~~~~~~~~~
@@ -249,6 +247,8 @@ The default report presents the result of *each iteration*:
     +------------------+-------------+---------+--------+------+------+-----+----------+----------+---------+--------+
 
 It is uses the ``table`` generator, see :ref:`generator_table` for more information.
+
+.. _report_env:
 
 ``env``
 ~~~~~~~

--- a/lib/Benchmark/Baseline/Baselines.php
+++ b/lib/Benchmark/Baseline/Baselines.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Benchmark\Baseline;
+
+/**
+ * Class providing some static methods which are used
+ * to provide base line measurements.
+ *
+ * @see \PhpBench\Benchmark\BaselineManager
+ */
+class Baselines
+{
+    /**
+     * Do nothing.
+     */
+    public static function nothing($revs)
+    {
+        for ($i = 0; $i < $revs; $i++) {
+        }
+    }
+
+    /**
+     * Calculate an md5 hash.
+     */
+    public static function md5($revs)
+    {
+        for ($i = 0; $i < $revs; $i++) {
+            md5('lorem ipusm');
+        }
+    }
+
+    /**
+     * Open a file, write a string to it $revs times, then
+     * read each line back.
+     */
+    public static function fwriteFread($revs)
+    {
+        $tempName = tempnam(sys_get_temp_dir(), 'phpbench_baseline');
+        $handle = fopen($tempName, 'w');
+
+        for ($i = 0; $i < $revs; $i++) {
+            fwrite($handle, 'lorum ipsum');
+        }
+
+        fclose($handle);
+
+        $handle = fopen($tempName, 'w');
+
+        $line = true;
+        while ($line) {
+            $line = fgets($handle);
+        }
+
+        fclose($handle);
+    }
+}

--- a/lib/Benchmark/BaselineManager.php
+++ b/lib/Benchmark/BaselineManager.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Benchmark;
+
+/**
+ * The baseline manager is responsible for collecting and executing
+ * baseline benchmarks.
+ *
+ * Baseline benchmarks are standard microbenchmarks which can be used to
+ * determine the "baseline" performance of the test platform.
+ *
+ * These measurements can be used to establish a baseline speed for the system,
+ * or to provide counterweights to iteration measurements (and so attempt to
+ * cancel out any fluctuations of the test platforms performance).
+ */
+class BaselineManager
+{
+    /**
+     * @var mixed[]
+     */
+    private $callables;
+
+    /**
+     * Add a baseline callable. The callable can be any
+     * callable accepted by call_user_func.
+     *
+     * Throws an invalid argument exception if the name has
+     * already been registered.
+     *
+     * @param string
+     * @param mixed
+     *
+     * @throws InvalidArgumentException
+     */
+    public function addBaselineCallable($name, $callable)
+    {
+        if (isset($this->callables[$name])) {
+            throw new \InvalidArgumentException(sprintf(
+                'Baseline callable "%s" has already been registered.',
+                $name
+            ));
+        }
+
+        if (!is_callable($callable)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Given baseline "%s" callable "%s" is not callable.',
+                $name, is_string($callable) ? $callable : gettype($callable)
+            ));
+        }
+
+        $this->callables[$name] = $callable;
+    }
+
+    /**
+     * Return mean time taken to execute the named baseline
+     * callable in microseconds.
+     *
+     * @return float
+     */
+    public function benchmark($name, $revs)
+    {
+        if (!isset($this->callables[$name])) {
+            throw new \InvalidArgumentException(sprintf(
+                'Unknown baseline callable "%s", known baseline callables: "%s"',
+                $name, implode('", "', array_keys($this->callables))
+            ));
+        }
+
+        $start = microtime(true);
+        call_user_func($this->callables[$name], $revs);
+
+        return (microtime(true) - $start) / $revs * 1E6;
+    }
+}

--- a/lib/Environment/Provider/Baseline.php
+++ b/lib/Environment/Provider/Baseline.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Environment\Provider;
+
+use PhpBench\Benchmark\BaselineManager;
+use PhpBench\Environment\Information;
+use PhpBench\Environment\ProviderInterface;
+
+/**
+ * Runs basic micro-benchmarks via. the BaselineManager to determine some baseline
+ * characteristics of the underlying system under test.
+ */
+class Baseline implements ProviderInterface
+{
+    private $manager;
+    private $enabled = [];
+
+    public function __construct(BaselineManager $manager, array $enabled)
+    {
+        $this->manager = $manager;
+        $this->enabled = $enabled;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isApplicable()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInformation()
+    {
+        $results = [];
+        foreach ($this->enabled as $callbackName) {
+            $results[$callbackName] = $this->manager->benchmark($callbackName, 1000);
+        }
+
+        return new Information(
+            'baseline',
+            $results
+        );
+    }
+}

--- a/phpbench.json.dist
+++ b/phpbench.json.dist
@@ -2,11 +2,6 @@
     "bootstrap": "vendor/autoload.php",
     "path": "benchmarks",
     "storage": "dbal",
-    "storage.dbal.connection": {
-        "driver": "pdo_mysql",
-        "dbname": "phpbench_benchmarks",
-        "user": "root"
-    },
     "extensions": [
         "PhpBench\\Extensions\\XDebug\\XDebugExtension",
         "PhpBench\\Extensions\\Dbal\\DbalExtension"

--- a/tests/Unit/Benchmark/BaselineManagerTest.php
+++ b/tests/Unit/Benchmark/BaselineManagerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Tests\Unit\Benchmark;
+
+use PhpBench\Benchmark\BaselineManager;
+
+class BaselineManagerTest extends \PHPUnit_Framework_TestCase
+{
+    private $manager;
+
+    public static $callCount = false;
+
+    public function setUp()
+    {
+        $this->manager = new BaselineManager();
+    }
+
+    /**
+     * It should throw an exception if a baseline callable name already exists.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Baseline callable "foo" has already been registered.
+     */
+    public function testRegisterTwice()
+    {
+        $this->manager->addBaselineCallable('foo', __CLASS__ . '::baselineExample');
+        $this->manager->addBaselineCallable('foo', __CLASS__ . '::baselineExample');
+    }
+
+    /**
+     * It should measure the mean time taken to execute a callable.
+     */
+    public function testCallable()
+    {
+        static::$callCount = 0;
+        $this->manager->addBaselineCallable('foo', __CLASS__ . '::baselineExample');
+        $this->manager->benchmark('foo', 100);
+        $this->assertEquals(100, static::$callCount);
+    }
+
+    /**
+     * It should throw an exception if the callable is not callable (string).
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Given baseline "foo" callable "does_not_exist" is not callable.
+     */
+    public function testCallableNotCallable()
+    {
+        $this->manager->addBaselineCallable('foo', 'does_not_exist');
+        $this->manager->benchmark('foo', 100);
+    }
+
+    /**
+     * It should throw an exception if the callable is not callable (object).
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Given baseline "foo" callable "object" is not callable.
+     */
+    public function testCallableNotCallableObject()
+    {
+        $this->manager->addBaselineCallable('foo', new \stdClass());
+        $this->manager->benchmark('foo', 100);
+    }
+
+    public static function baselineExample($revs)
+    {
+        self::$callCount = $revs;
+    }
+}

--- a/tests/Unit/Environment/Provider/BaselineTest.php
+++ b/tests/Unit/Environment/Provider/BaselineTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Tests\Unit\Environment\Provider;
+
+use PhpBench\Benchmark\BaselineManager;
+use PhpBench\Environment\Information;
+use PhpBench\Environment\Provider\Baseline;
+
+class BaselineTest extends \PHPUnit_Framework_TestCase
+{
+    private $manager;
+    private $provider;
+
+    public function setUp()
+    {
+        $this->manager = $this->prophesize(BaselineManager::class);
+        $this->provider = new Baseline(
+            $this->manager->reveal(),
+            ['one']
+        );
+    }
+
+    /**
+     * Provider is always applicable.
+     */
+    public function testIsApplicable()
+    {
+        $this->assertTrue($this->provider->isApplicable());
+    }
+
+    /**
+     * It should get the baseline measurements from the baseline manager.
+     */
+    public function testBaselineMeasurements()
+    {
+        $this->manager->benchmark('one', 1000)->willReturn(10);
+        $info = $this->provider->getInformation();
+        $this->assertInstanceOf(Information::class, $info);
+        $this->assertEquals(iterator_to_array($info), [
+            'one' => 10,
+        ]);
+    }
+}


### PR DESCRIPTION
<strike>This PR is attempting to establish a good strategy for baseline measurements. It currently implements two new features, although one of them will probably be dropped in favor of the other.</strike>. This PR is now only abount the env provider. The other strategy is a [https://github.com/phpbench/phpbench/issues/372](separate feature).

The idea is to provide a way to better understand results taken from different machines, or anomalous results taken on the same machine.

## Environment Provider

Adds an Envrionment Provider which runs some very simple "benchmarks" (md5 10000 times, nothing 10000 times) and provides the time in microseconds.

All information made available through Environment providers are available in reports.

This provides a "better-than-nothing" indication of the performance of the machine the benchmarks are running on.

```
(standard report, selecting the `baseline_nothing` col)
+------------------+------------+------------+
| baseline_nothing | other cols | mean       |
+------------------+------------+------------+
| 0.000045ms       | ...        | 0.019320ms |
+------------------+------------+------------+

(env report)
Suite # 2016-02-28 09:32:05
+--------------+---------+------------------------------------------+
| provider     | key     | value                                    |
+--------------+---------+------------------------------------------+
| uname        | os      | Linux                                    |
| ...          | ...     | ...                                      |
| vcs          | version | fe14d5c1ee747a52cb1074d11bd6617dd31e38aa |
| baseline     | md5     | 0.29157161712646                         |
| baseline     | nothing | 0.044848918914795                        |
+--------------+---------+------------------------------------------+
```

## Per-iteration baseline

See: https://github.com/phpbench/phpbench/issues/372<S-Del>
