### PR TITLE
[WIP] XML storage

### DIFF
--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -445,6 +445,20 @@ class CoreExtension implements ExtensionInterface
         $container->register('storage.driver_factory', function (Container $container) {
             return new Storage\DriverFactory($container, $container->getParameter('storage'));
         });
+
+        $container->register('storage.driver.xml.persister', function (Container $container) {
+            return new Storage\Driver\Xml\Persister(
+                $container->get('serializer.encoder.xml'),
+                'foo'
+            );
+        });
+
+        $container->register('storage.driver.xml', function (Container $container) {
+            return new Storage\Driver\XmlDriver(
+                $container->get('storage.driver.xml.persister'),
+                'foo'
+            );
+        }, ['storage_driver' => ['name' => 'xml']]);
     }
 
     private function registerExpression(Container $container)

--- a/lib/Model/Suite.php
+++ b/lib/Model/Suite.php
@@ -173,6 +173,15 @@ class Suite implements \IteratorAggregate
         return $this->envInformations;
     }
 
+    public function getVcsBranch()
+    {
+        if (isset($this->envInformations['vcs']['branch'])) {
+            return $this->envInformations['vcs']['branch'];
+        }
+
+        return null;
+    }
+
     /**
      * The identifier uniquely identifies this suite.
      *

--- a/lib/Storage/Driver/Xml/ConstraintVisitor.php
+++ b/lib/Storage/Driver/Xml/ConstraintVisitor.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Storage\Driver\Xml;
+
+use PhpBench\Expression\Constraint\Comparison;
+use PhpBench\Expression\Constraint\Composite;
+use PhpBench\Expression\Constraint\Constraint;
+
+/**
+ * XML Constraint Visitor.
+ *
+ * This class needs to provide methods to:
+ *
+ * 1. Provide criteria with which to reduce the list of XML documents which
+ *    need to be loaded -- i.e. it needs to provide a list of explicit dates and run IDs and
+ *    lower and upper bounds (date < 2015-01-01, run ID in 1234,4321,1235 etc).
+ *
+ * 2. Convert the Constraint into an XPath query which can be run against an
+ *    aggregate SuiteCollection document.
+ */
+class ConstraintVisitor
+{
+    /**
+     * Convert the given constraint into an SQL query.
+     *
+     * @param Constraint $constraint
+     *
+     * @return string
+     */
+    public function visit(Constraint $constraint)
+    {
+        if ($constraint instanceof Comparison) {
+            return $this->visitComparison($constraint);
+        }
+
+        if ($constraint instanceof Composite) {
+            return $this->visitComposite($constraint);
+        }
+    }
+
+    private function visitComparison(Constraint $constraint)
+    {
+    }
+
+    private function visitComposite(Constraint $constraint)
+    {
+    }
+}

--- a/lib/Storage/Driver/Xml/HistoryIterator.php
+++ b/lib/Storage/Driver/Xml/HistoryIterator.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Storage\Driver\Xml;
+
+use PhpBench\Storage\HistoryEntry;
+use PhpBench\Storage\HistoryIteratorInterface;
+
+/**
+ * Lazily load history entries from the database.
+ */
+class HistoryIterator implements HistoryIteratorInterface
+{
+    private $position = 0;
+    private $files;
+
+    /**
+     * @param Repository $repository
+     */
+    public function __construct($path)
+    {
+        $this->path = $path;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function current()
+    {
+        $this->init();
+
+        $filename = $this->files[$this->position];
+        $meta = XmlDriverUtil::parseFilename($filename);
+
+        $entry = new HistoryEntry(
+            $meta['id'],
+            $meta['date'],
+            $meta['vcs_branch'],
+            $meta['context']
+        );
+
+        return $entry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function next()
+    {
+        $this->position++;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function key()
+    {
+        return $this->position;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rewind()
+    {
+        $this->position = 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function valid()
+    {
+        $this->init();
+
+        return isset($this->files[$this->position]);
+    }
+
+    private function init()
+    {
+        if (null !== $this->files) {
+            return;
+        }
+
+        $files = array();
+        foreach (new \DirectoryIterator($this->path) as $file) {
+            if (false === $file->isFile()) {
+                continue;
+            }
+
+            if ('xml' !== $file->getExtension()) {
+                continue;
+            }
+
+            $files[] = $file->getFilename();
+        }
+
+        rsort($files);
+
+        $this->files = $files;
+    }
+}

--- a/lib/Storage/Driver/Xml/Persister.php
+++ b/lib/Storage/Driver/Xml/Persister.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace PhpBench\Storage\Driver\Xml;
+
+use PhpBench\Storage\DriverInterface;
+use PhpBench\Serializer\XmlEncoder;
+use Symfony\Component\Filesystem\Filesystem;
+use PhpBench\Model\SuiteCollection;
+
+class Persister
+{
+    private $xmlEncoder;
+    private $path;
+    private $filesystem;
+
+    public function __construct(XmlEncoder $xmlEncoder, $path, Filesystem $filesystem = null)
+    {
+        $this->xmlEncoder = $xmlEncoder;
+        $this->path = $path;
+        $this->filesystem = $filesystem ?: new Filesystem();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function persist(SuiteCollection $collection)
+    {
+        foreach ($collection as $suite) {
+            $filename = XmlDriverUtil::getFilenameForSuite($suite);
+
+            $collection = new SuiteCollection([$suite]);
+            $document = $this->xmlEncoder->encode($collection);
+            $path = sprintf('%s/%s', $this->path, $filename);
+            if (!$this->filesystem->exists(dirname($path))) {
+                $this->filesystem->mkdir(dirname($path));
+            }
+
+            $document->save($path);
+        }
+    }
+}
+

--- a/lib/Storage/Driver/Xml/XmlDriverUtil.php
+++ b/lib/Storage/Driver/Xml/XmlDriverUtil.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace PhpBench\Storage\Driver\Xml;
+
+use PhpBench\Model\Suite;
+
+class XmlDriverUtil
+{
+    public static function getFilenameForSuite(Suite $suite)
+    {
+        return sprintf(
+            '%s-%s-%s-%s.xml',
+            $suite->getDate()->format('YmdHis'),
+            uniqid(), 
+            $suite->getVcsBranch(),
+            $suite->getContextName()
+        );
+    }
+
+    public static function parseFilename($filename)
+    {
+        // remove XML extension
+        if (substr($filename, -4) !== '.xml') {
+            throw new \InvalidArgumentException(sprintf(
+                'Expected .xml extension when parsing filename "%s"', $filename
+            ));
+
+        }
+
+        $filename = substr($filename, 0, -4);
+
+        $parts = explode('-', $filename);
+
+        return [
+            'id' => $parts[1],
+            'date' => new \DateTime($parts[0]),
+            'vcs_branch' => isset($parts[2]) ? $parts[2] : null,
+            'context' => isset($parts[3]) ? $parts[3] : null,
+        ];
+    }
+}

--- a/lib/Storage/Driver/XmlDriver.php
+++ b/lib/Storage/Driver/XmlDriver.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace PhpBench\Storage\Driver;
+
+use PhpBench\Storage\DriverInterface;
+use PhpBench\Serializer\XmlEncoder;
+use PhpBench\Model\SuiteCollection;
+use PhpBench\Expression\Constraint\Constraint;
+use PhpBench\Storage\Driver\Xml\Persister;
+use PhpBench\Storage\Driver\Xml\HistoryIterator;
+
+class XmlDriver implements DriverInterface
+{
+    private $persister;
+    private $path;
+
+    public function __construct(Persister $persister, $path)
+    {
+        $this->persister = $persister;
+        $this->path = $path;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function store(SuiteCollection $collection)
+    {
+        $this->persister->persist($collection);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function query(Constraint $constraint)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function history()
+    {
+        return new HistoryIterator($this->path);
+    }
+}


### PR DESCRIPTION
An XML storage layer for persisting and querying benchmark results.

- [x] Store in XML
- [x] Implement history
- [ ] Query ...

This PR tackles the problem of storing XML documents as follows:

- It creates a single XML file per-suite with a naming schema `<run ID><date><vcs_branch>.xml`
- Queries will be converted to XPath queries and then executed against a PHPBench XML document which contains all of the suites relevant to the query.

The main issues here are:

1. The need to store and *order* an unbounded number of XML documents. (note that if GIT storage is implemented around this driver, the number will only continue to rise).
2. The need to reduce the number of XML documents prior to querying.

(1.) is required so that benchmarks can be listed in order using the `history` command, and it means reading and then ordering all of the filenames (which is perhaps not so bad).

(2.) requires the query to be analyzed to return the limiting criteria (run ID should be in 1,2,3 AND date > 2015 AND date < 2018 OR date IN 2015-01-01, 2016-02-01 etc) - we can then filter the filenames of the XML documents we should load.