### PR TITLE
Archive and restore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
   - phpunit
   # run the benchmarks in order to test them
   - php bin/phpbench run --iterations=1 --revs=1
+  - php bin/phpbench run --iterations=1 --revs=1 --config=extensions/sqlite/benchmarks/phpbench.json
 
 matrix:
     include:

--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -78,9 +78,6 @@ existing :doc:`reports`:
 
     $ phpbench report --query='run: 239' --report=aggregate
 
-Query Language
---------------
-
 PHPBench uses a query language very similar to that of MongoDB. A simple
 example:
 
@@ -172,7 +169,7 @@ queries::
     benchmark: { $regex: "Foo.*Bench" }
 
 Fields
-------
+~~~~~~
 
 The following fields are currently available for querying:
 
@@ -190,3 +187,39 @@ be enclosed in square brackets as follows::
     param[nb_elements]: 10
 
     param[points]: { $gt: 50 }
+
+Archiving
+---------
+
+Archiving provides a way to export and reimport data from and to the
+configured storage. This allows you to:
+
+- Backup your results (for example to a GIT repository).
+- Migrate to other storage drivers.
+
+By default PHPBench is configured to use an ``XML`` archiver, which will dump
+results to a directory in the current working directory, ``_archive``.
+
+.. note::
+
+    In the future it will be possible to select GIT as an archiving
+    mechanism, so that your benchmarks are always stored in your codes GIT
+    repository.
+
+To archive::
+
+    $ phpbench archive
+
+To restore::
+
+    $ phpbench archive --restore 
+
+Both operations are idempotent - they will skip any existing records.
+
+You may configure a different archiver in the configuration:
+
+.. code-block:: javascript
+
+    {
+        "archiver": "xml"
+    }

--- a/extensions/sqlite/benchmarks/StorageBench.php
+++ b/extensions/sqlite/benchmarks/StorageBench.php
@@ -12,9 +12,16 @@
 namespace PhpBench\Extensions\Sqlite\Benchmarks;
 
 use PhpBench\Benchmarks\Macro\BaseBenchCase;
+use PhpBench\Tests\Util\TestUtil;
 
+/**
+ * @OutputTimeUnit("milliseconds", precision=2)
+ * @Revs(1)
+ */
 class StorageBench extends BaseBenchCase
 {
+    private $driver;
+
     public function __construct()
     {
         $this->addContainerExtensionClass('PhpBench\\Extensions\\Sqlite\\SqliteExtension');
@@ -22,26 +29,28 @@ class StorageBench extends BaseBenchCase
             'storage' => 'sqlite',
             'storage.sqlite.db_path' => $this->getWorkspacePath() . '/test.sqlite',
         ]);
+        $this->driver = $this->getContainer()->get('storage.driver.sqlite');
     }
 
-    /**
-     * @ParamProviders({"provideIterations"})
-     */
-    public function benchStore($params)
+    public function benchStore()
     {
-        $this->runCommand('console.command.run', [
-            'path' => $this->getFunctionalBenchmarkPath(),
-            '--store' => true,
-            '--iterations' => $params['nb_iterations'],
+        static $index = 0;
+
+        $collection = TestUtil::createCollection([
+            [
+                'uuid' => $index . 'a',
+                'env' => [
+                    'foo' => ['foo' => 'bar', 'bar' => 'foo'],
+                    'bar' => ['foo' => 'bar', 'bar' => 'foo'],
+                    'baz' => ['foo' => 'bar', 'bar' => 'foo'],
+                    'bog' => ['foo' => 'bar', 'bar' => 'foo'],
+                ],
+            ],
+            ['uuid' => $index . 'b'],
+            ['uuid' => $index . 'c'],
+            ['uuid' => $index . 'd'],
         ]);
-    }
-
-    public function provideIterations()
-    {
-        return [
-            ['nb_iterations' => 1],
-            ['nb_iterations' => 10],
-            ['nb_iterations' => 100],
-        ];
+        $this->driver->store($collection);
+        $index++;
     }
 }

--- a/extensions/sqlite/benchmarks/phpbench.json
+++ b/extensions/sqlite/benchmarks/phpbench.json
@@ -1,0 +1,8 @@
+{
+    "bootstrap": "../../../vendor/autoload.php",
+    "path": ".",
+    "extensions": [
+        "PhpBench\\Extensions\\Sqlite\\SqliteExtension"
+    ],
+    "storage": "sqlite"
+}

--- a/extensions/sqlite/lib/Storage/Driver/Sqlite/Persister.php
+++ b/extensions/sqlite/lib/Storage/Driver/Sqlite/Persister.php
@@ -27,20 +27,23 @@ class Persister
         $conn = $this->manager->getConnection();
 
         foreach ($collection->getSuites() as $suite) {
-            $runId = $this->insertUpdate($conn, 'run', [
+            $this->insertUpdate($conn, 'run', [
+                'id' => $suite->getUuid(),
                 'context' => $suite->getContextName(),
                 'date' => $suite->getDate()->format('Y-m-d H:i:s'),
             ]);
 
             foreach ($suite->getEnvInformations() as $information) {
+                $envData = [];
                 foreach ($information as $key => $value) {
-                    $this->insertUpdate($conn, 'environment', [
-                        'run_id' => $runId,
+                    $envData[] = [
+                        'run_id' => $suite->getUuid(),
                         'provider' => $information->getName(),
                         'key' => $key,
                         'value' => $value,
-                    ]);
+                    ];
                 }
+                $this->insertMultiple($conn, 'environment', $envData);
             }
 
             foreach ($suite->getBenchmarks() as $benchmark) {
@@ -66,7 +69,7 @@ class Persister
                             'sleep' => $subject->getSleep(),
                             'warmup' => $variant->getWarmup(),
                             'subject_id' => $subjectId,
-                            'run_id' => $runId,
+                            'run_id' => $suite->getUuid(),
                         ];
                         $variantId = $this->insertUpdate($conn, 'variant', $data);
 

--- a/extensions/sqlite/lib/Storage/Driver/Sqlite/Repository.php
+++ b/extensions/sqlite/lib/Storage/Driver/Sqlite/Repository.php
@@ -35,7 +35,9 @@ class Repository
         $stmt = $conn->prepare($sql);
         $stmt->execute($values);
 
-        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+        $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+        return $rows;
     }
 
     public function getRunEnvInformationRows($runId)
@@ -93,6 +95,15 @@ EOT;
         return $parameters;
     }
 
+    public function hasRun($runId)
+    {
+        $conn = $this->manager->getConnection();
+        $stmt = $conn->prepare('SELECT id FROM run WHERE id = ?');
+        $stmt->execute([$runId]);
+
+        return $stmt->fetch() ? true : false;
+    }
+
     public function getHistoryStatement()
     {
         $sql = <<<'EOT'
@@ -103,7 +114,7 @@ SELECT
     environment.value AS vcs_branch
     FROM run
     LEFT OUTER JOIN environment ON environment.provider = "vcs" AND environment.run_id = run.id AND environment.key = "branch"
-    ORDER BY run.id DESC
+    ORDER BY run.date DESC
 EOT;
 
         $conn = $this->manager->getConnection();

--- a/extensions/sqlite/lib/Storage/Driver/Sqlite/sqlite.sql
+++ b/extensions/sqlite/lib/Storage/Driver/Sqlite/sqlite.sql
@@ -1,5 +1,5 @@
 CREATE TABLE run (
-    id INTEGER PRIMARY KEY,
+    id VARCHAR PRIMARY KEY,
     context VARCHAR,
     date DATE
 );

--- a/extensions/sqlite/lib/Storage/Driver/SqliteDriver.php
+++ b/extensions/sqlite/lib/Storage/Driver/SqliteDriver.php
@@ -11,6 +11,7 @@
 
 namespace PhpBench\Extensions\Sqlite\Storage\Driver;
 
+use PhpBench\Expression\Constraint\Comparison;
 use PhpBench\Expression\Constraint\Constraint;
 use PhpBench\Extensions\Sqlite\Storage\Driver\Sqlite\HistoryIterator;
 use PhpBench\Extensions\Sqlite\Storage\Driver\Sqlite\Loader;
@@ -52,6 +53,31 @@ class SqliteDriver implements DriverInterface
     public function store(SuiteCollection $collection)
     {
         $this->persister->persist($collection);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($runId)
+    {
+        return $this->repository->hasRun($runId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetch($runId)
+    {
+        $comparison = new Comparison('$eq', 'run', $runId);
+        $collection = $this->query($comparison);
+
+        if (count($collection->getSuites()) === 0) {
+            throw new \InvalidArgumentException(sprintf(
+                'Could not find suite with run ID "%s"', $runId
+            ));
+        }
+
+        return $collection;
     }
 
     /**

--- a/extensions/sqlite/tests/Functional/Storage/Driver/Sqlite/HistoryIteratorTest.php
+++ b/extensions/sqlite/tests/Functional/Storage/Driver/Sqlite/HistoryIteratorTest.php
@@ -46,6 +46,7 @@ class HistoryIteratorTest extends FunctionalTestCase
     {
         $suiteCollection = new SuiteCollection([
             TestUtil::createSuite([
+                'uuid' => 1,
                 'env' => [
                     'vcs' => [
                         'system' => 'git',
@@ -56,6 +57,7 @@ class HistoryIteratorTest extends FunctionalTestCase
                 'date' => '2016-01-01',
             ]),
             TestUtil::createSuite([
+                'uuid' => 2,
                 'date' => '2015-01-01',
                 'env' => [
                     'vcs' => [
@@ -71,17 +73,17 @@ class HistoryIteratorTest extends FunctionalTestCase
 
         $current = $this->iterator->current();
         $this->assertInstanceOf('PhpBench\Storage\HistoryEntry', $current);
-        $this->assertEquals('2015-01-01', $current->getDate()->format('Y-m-d'));
-        $this->assertEquals('branch_2', $current->getVcsBranch());
-        $this->assertEquals('two', $current->getContext());
-        $this->assertEquals(2, $current->getRunId());
-
-        $this->iterator->next();
-        $current = $this->iterator->current();
-        $this->assertInstanceOf('PhpBench\Storage\HistoryEntry', $current);
         $this->assertEquals('2016-01-01', $current->getDate()->format('Y-m-d'));
         $this->assertEquals('branch_1', $current->getVcsBranch());
         $this->assertEquals('one', $current->getContext());
         $this->assertEquals(1, $current->getRunId());
+
+        $this->iterator->next();
+        $current = $this->iterator->current();
+        $this->assertInstanceOf('PhpBench\Storage\HistoryEntry', $current);
+        $this->assertEquals('2015-01-01', $current->getDate()->format('Y-m-d'));
+        $this->assertEquals('branch_2', $current->getVcsBranch());
+        $this->assertEquals('two', $current->getContext());
+        $this->assertEquals(2, $current->getRunId());
     }
 }

--- a/extensions/sqlite/tests/Functional/Storage/Driver/Sqlite/LoaderTest.php
+++ b/extensions/sqlite/tests/Functional/Storage/Driver/Sqlite/LoaderTest.php
@@ -53,6 +53,7 @@ class LoaderTest extends FunctionalTestCase
     {
         $suiteCollection = new SuiteCollection([
             TestUtil::createSuite([
+                'uuid' => '1',
                 'subjects' => ['benchOne', 'benchTwo'],
                 'benchmarks' => ['BenchOne', 'BenchTwo'],
                 'groups' => ['one', 'two'],
@@ -75,7 +76,9 @@ class LoaderTest extends FunctionalTestCase
                     ],
                 ],
             ]),
-            TestUtil::createSuite(),
+            TestUtil::createSuite([
+                'uuid' => '2',
+            ]),
         ]);
         $this->persister->persist($suiteCollection);
 
@@ -164,11 +167,13 @@ class LoaderTest extends FunctionalTestCase
     {
         $suiteCollection = new SuiteCollection([
             TestUtil::createSuite([
+                'uuid' => '1',
                 'benchmark' => ['benchOne'],
                 'subjects' => ['benchOne'],
                 'groups' => ['one', 'two'],
             ]),
             TestUtil::createSuite([
+                'uuid' => '2',
                 'benchmark' => ['benchOne'],
                 'subjects' => ['benchTwo', 'benchThree'],
                 'groups' => ['foobar'],

--- a/extensions/sqlite/tests/Functional/Storage/Driver/Sqlite/PeristerTest.php
+++ b/extensions/sqlite/tests/Functional/Storage/Driver/Sqlite/PeristerTest.php
@@ -48,6 +48,7 @@ class PeristerTest extends FunctionalTestCase
     {
         $suiteCollection = new SuiteCollection([
             TestUtil::createSuite([
+                'uuid' => '1',
                 'subjects' => ['benchOne', 'benchTwo'],
                 'groups' => ['one', 'two'],
                 'parameters' => [
@@ -67,6 +68,7 @@ class PeristerTest extends FunctionalTestCase
                 ],
             ]),
             TestUtil::createSuite([
+                'uuid' => '2',
                 'subjects' => ['benchThree'],
                 'groups' => ['five'],
             ]),
@@ -90,7 +92,9 @@ class PeristerTest extends FunctionalTestCase
     public function testPhpBenchVersion()
     {
         $suiteCollection = new SuiteCollection([
-            TestUtil::createSuite([]),
+            TestUtil::createSuite([
+                'uuid' => 1,
+            ]),
         ]);
 
         $this->persister->persist($suiteCollection);
@@ -99,6 +103,11 @@ class PeristerTest extends FunctionalTestCase
         $row = current($rows);
         $this->assertEquals(PhpBench::VERSION, $row['phpbench_version']);
 
+        $suiteCollection = new SuiteCollection([
+            TestUtil::createSuite([
+                'uuid' => 2,
+            ]),
+        ]);
         $this->persister->persist($suiteCollection);
         $this->assertEquals(1, $this->sqlCount('SELECT * FROM version'));
     }

--- a/extensions/sqlite/tests/Functional/Storage/Driver/Sqlite/RepositoryTest.php
+++ b/extensions/sqlite/tests/Functional/Storage/Driver/Sqlite/RepositoryTest.php
@@ -44,6 +44,7 @@ class RepositoryTest extends FunctionalTestCase
     {
         $suiteCollection = new SuiteCollection([
             TestUtil::createSuite([
+                'uuid' => 1,
                 'env' => [
                     'vcs' => [
                         'system' => 'git',
@@ -54,6 +55,7 @@ class RepositoryTest extends FunctionalTestCase
                 'date' => '2016-01-01',
             ]),
             TestUtil::createSuite([
+                'uuid' => 2,
                 'date' => '2015-01-01',
                 'env' => [
                     'vcs' => [
@@ -71,16 +73,16 @@ class RepositoryTest extends FunctionalTestCase
 
         $this->assertEquals([
             [
-                'run_date' => '2015-01-01 00:00:00',
-                'context' => 'two',
-                'vcs_branch' => 'branch_2',
-                'run_id' => 2,
-            ],
-            [
                 'run_date' => '2016-01-01 00:00:00',
                 'context' => 'one',
                 'vcs_branch' => 'branch_1',
                 'run_id' => 1,
+            ],
+            [
+                'run_date' => '2015-01-01 00:00:00',
+                'context' => 'two',
+                'vcs_branch' => 'branch_2',
+                'run_id' => 2,
             ],
         ], $rows);
     }

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -97,6 +97,7 @@ class Runner
             $benchmark = $suite->createBenchmark($benchmarkMetadata->getClass());
             $this->runBenchmark($executor, $context, $benchmark, $benchmarkMetadata);
         }
+        $suite->generateUuid();
 
         $this->logger->endSuite($suite);
 

--- a/lib/Console/Command/ArchiveCommand.php
+++ b/lib/Console/Command/ArchiveCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Console\Command;
+
+use PhpBench\Registry\Registry;
+use PhpBench\Storage\Archiver;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Archive and restore from and to storage.
+ */
+class ArchiveCommand extends Command
+{
+    private $archiver;
+
+    public function __construct(
+        Registry $archiver
+    ) {
+        parent::__construct();
+        $this->archiver = $archiver;
+    }
+
+    public function configure()
+    {
+        $this->setName('archive');
+        $this->setDescription('Archives and restore suites from and to storage.');
+        $this->setHelp(<<<'EOT'
+This command will dump (archive) or restore from an archive from and to the
+configured storage driver.
+
+Archive contents of Storage:
+
+    $ %command.full_name%
+
+Restore from archive to Storage:
+
+    $ %command.full_name% --restore
+
+Existing entries on both operations will be skipped.
+EOT
+    );
+        $this->addOption('restore', null, InputOption::VALUE_NONE, 'Restore the archive');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $restore = $input->getOption('restore');
+
+        if ($restore) {
+            $this->archiver->getService()->restore($output);
+
+            return;
+        }
+
+        $this->archiver->archive($output);
+    }
+}

--- a/lib/Console/Command/HistoryCommand.php
+++ b/lib/Console/Command/HistoryCommand.php
@@ -52,14 +52,19 @@ EOT
         if ($limit) {
             $output->writeln(sprintf('<comment>Limit set to %s</comment>', $limit));
         }
-        $entries = $this->storage->getService()->history();
+
         $output->writeln(sprintf(
-            "%s\t%s\t\t\t%s\t%s\n",
-            'Run',
-            'Date',
-            'VCS Branch',
-            'Context'
+            '<info>[</> %s<info> ]</>',
+            implode(' <info>|</> ', [
+                'Run UUID',
+                'Date',
+                'VCS Branch',
+                'Context',
+            ])
         ));
+        $output->write(PHP_EOL);
+
+        $entries = $this->storage->getService()->history();
         foreach ($entries as $index => $entry) {
             $output->write(sprintf(
                 "%s\t%s\t%s\t%s\n",

--- a/lib/Model/Suite.php
+++ b/lib/Model/Suite.php
@@ -25,7 +25,7 @@ class Suite implements \IteratorAggregate
     private $configPath;
     private $envInformations = [];
     private $benchmarks = [];
-    private $identifier;
+    private $uuid;
 
     /**
      * __construct.
@@ -42,14 +42,14 @@ class Suite implements \IteratorAggregate
         $configPath = null,
         array $benchmarks = [],
         array $envInformations = [],
-        $identifier = null
+        $uuid = null
     ) {
         $this->contextName = $contextName;
         $this->date = $date;
         $this->configPath = $configPath;
         $this->envInformations = $envInformations;
         $this->benchmarks = $benchmarks;
-        $this->identifier = $identifier;
+        $this->uuid = $uuid;
     }
 
     public function getBenchmarks()
@@ -174,15 +174,34 @@ class Suite implements \IteratorAggregate
     }
 
     /**
-     * The identifier uniquely identifies this suite.
+     * The uuid uniquely identifies this suite.
      *
-     * The identifier is determined by the storage driver, and may be empty
+     * The uuid is determined by the storage driver, and may be empty
      * only when dynamically generating reports on-the-fly.
      *
      * @return mixed
      */
-    public function getIdentifier()
+    public function getUuid()
     {
-        return $this->identifier;
+        return $this->uuid;
+    }
+
+    /**
+     * Generate a universally unique identifier.
+     *
+     * Based on the GIT hashing detailed here:
+     *     http://alblue.bandlem.com/2011/08/git-tip-of-week-objects.html
+     */
+    public function generateUuid()
+    {
+        $serialized = serialize($this->envInformations);
+
+        $this->uuid = sha1(implode([
+            'suite',
+            strlen($serialized),
+            microtime(),
+            $serialized,
+            $this->configPath,
+        ]));
     }
 }

--- a/lib/Report/Generator/EnvGenerator.php
+++ b/lib/Report/Generator/EnvGenerator.php
@@ -88,7 +88,7 @@ class EnvGenerator implements GeneratorInterface, OutputAwareInterface
         foreach ($suiteCollection as $suite) {
             $tableEl = $reportEl->appendElement('table');
             $tableEl->setAttribute('title', sprintf(
-                'Suite #%s %s', $suite->getIdentifier(), $suite->getDate()->format('Y-m-d H:i:s')
+                'Suite #%s %s', $suite->getUuid(), $suite->getDate()->format('Y-m-d H:i:s')
             ));
 
             $groupEl = $tableEl->appendElement('group');

--- a/lib/Report/Generator/TableGenerator.php
+++ b/lib/Report/Generator/TableGenerator.php
@@ -380,7 +380,7 @@ class TableGenerator implements GeneratorInterface, OutputAwareInterface
                 foreach ($benchmark->getSubjects() as $subject) {
                     foreach ($subject->getVariants() as $variant) {
                         $row = new Row([
-                            'suite' => $suite->getIdentifier(),
+                            'suite' => $suite->getUuid(),
                             'date' => $suite->getDate()->format('Y-m-d'),
                             'stime' => $suite->getDate()->format('H:i:s'),
                             'benchmark' => $this->getClassShortName($benchmark->getClass()),

--- a/lib/Serializer/XmlDecoder.php
+++ b/lib/Serializer/XmlDecoder.php
@@ -76,7 +76,10 @@ class XmlDecoder
         $suite = new Suite(
             $suiteEl->getAttribute('context'),
             new \DateTime($suiteEl->getAttribute('date')),
-            $suiteEl->getAttribute('config-path')
+            $suiteEl->getAttribute('config-path'),
+            [],
+            [],
+            $suiteEl->getAttribute('uuid')
         );
 
         $informations = [];

--- a/lib/Serializer/XmlEncoder.php
+++ b/lib/Serializer/XmlEncoder.php
@@ -43,6 +43,7 @@ class XmlEncoder
             $suiteEl->setAttribute('context', $suite->getContextName());
             $suiteEl->setAttribute('date', $suite->getDate()->format('Y-m-d H:i:s'));
             $suiteEl->setAttribute('config-path', $suite->getConfigPath());
+            $suiteEl->setAttribute('uuid', $suite->getUuid());
 
             $envEl = $suiteEl->appendElement('env');
 

--- a/lib/Storage/Archiver/XmlArchiver.php
+++ b/lib/Storage/Archiver/XmlArchiver.php
@@ -1,0 +1,176 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Storage\Archiver;
+
+use PhpBench\Dom\Document;
+use PhpBench\Registry\Registry;
+use PhpBench\Serializer\XmlDecoder;
+use PhpBench\Serializer\XmlEncoder;
+use PhpBench\Storage\ArchiverInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * XML archiver using the Xml encoder and decoder.
+ */
+class XmlArchiver implements ArchiverInterface
+{
+    /**
+     * @var DriverFactory
+     */
+    private $registry;
+
+    /**
+     * @var string
+     */
+    private $archivePath;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var XmlEncoder
+     */
+    private $xmlEncoder;
+
+    /**
+     * @var XmlDecoder
+     */
+    private $xmlDecoder;
+
+    public function __construct(
+        Registry $registry,
+        XmlEncoder $xmlEncoder,
+        XmlDecoder $xmlDecoder,
+        $archivePath,
+        Filesystem $filesystem = null
+    ) {
+        $this->registry = $registry;
+        $this->xmlEncoder = $xmlEncoder;
+        $this->xmlDecoder = $xmlDecoder;
+        $this->archivePath = $archivePath;
+        $this->filesystem = $filesystem ?: new Filesystem();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function archive(OutputInterface $output)
+    {
+        $driver = $this->registry->getService();
+
+        if (!$this->filesystem->exists($this->archivePath)) {
+            $this->filesystem->mkdir($this->archivePath);
+        }
+
+        $runIds = [];
+        foreach ($driver->history() as $entry) {
+            $runIds[] = $entry->getRunId();
+        }
+
+        $output->writeln(sprintf('Archiving "%s" suites', count($runIds)));
+
+        foreach ($runIds as $index => $runId) {
+            $filename = $runId . '.xml';
+            $path = sprintf('%s/%s', $this->archivePath, $filename);
+
+            if ($this->filesystem->exists($path)) {
+                $this->writeProgress($output, $index, count($runIds), 'S');
+                continue;
+            }
+
+            $this->writeProgress($output, $index, count($runIds), '.');
+
+            $collection = $driver->fetch($runId);
+            $document = $this->xmlEncoder->encode($collection);
+            $document->save($path);
+        }
+
+        $output->writeln(PHP_EOL);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function restore(OutputInterface $output)
+    {
+        $driver = $this->registry->getService();
+
+        $iterator = new \DirectoryIterator($this->archivePath);
+        $files = $this->filterFiles($iterator);
+        $totalCount = count($files);
+        $files = $this->filterExisting($driver, $files);
+        $count = count($files);
+
+        $output->writeln(sprintf('Restoring %s of %s suites.', $count, $totalCount));
+        foreach ($files as $index => $file) {
+            $this->writeProgress($output, $index, $count, '.');
+
+            $document = new Document();
+            $document->load($file->getPathname());
+            $collection = $this->xmlDecoder->decode($document);
+            $driver->store($collection);
+        }
+        $output->write(PHP_EOL);
+    }
+
+    private function filterExisting($driver, array $files)
+    {
+        $newFiles = [];
+
+        foreach ($files as $file) {
+            // by this point the last 4 chatacters of the filename
+            // will be ".xml", so we strip them off and rest MUST
+            // be the identifier.
+            $identifier = substr($file->getFilename(), 0, -4);
+
+            // if the driver already has the given identifier, then
+            // skip it.
+            if ($driver->has($identifier)) {
+                continue;
+            }
+
+            $newFiles[] = $file;
+        };
+
+        return $newFiles;
+    }
+
+    private function filterFiles(\DirectoryIterator $iterator)
+    {
+        $files = [];
+
+        foreach ($iterator as $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+
+            if ('xml' !== $file->getExtension()) {
+                continue;
+            }
+
+            $files[] = clone $file;
+        }
+
+        return $files;
+    }
+
+    private function writeProgress(OutputInterface $output, $index, $count, $char = '.')
+    {
+        if ($index > 0 && $index % 64 === 0) {
+            $output->writeln(sprintf(' (%s/%s)', $index, $count));
+        }
+        $output->write($char);
+    }
+}

--- a/lib/Storage/ArchiverInterface.php
+++ b/lib/Storage/ArchiverInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Storage;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Archivers handle archiving and retoring the contents of the configured
+ * storage driver.
+ */
+interface ArchiverInterface
+{
+    /**
+     * Archive all suites in the configured storage driver.
+     *
+     * In the case that a given record already exists in the archive,
+     * then that record should be skipped.
+     *
+     * Progress should be written to the given console output class.
+     *
+     * @param OutputInterface
+     */
+    public function archive(OutputInterface $output);
+
+    /**
+     * Restore the archive to storage. If a given record exists in
+     * the storage, it should be skipped.
+     *
+     * Progress should be written to the given console output class.
+     */
+    public function restore(OutputInterface $output);
+}

--- a/lib/Storage/DriverInterface.php
+++ b/lib/Storage/DriverInterface.php
@@ -36,6 +36,23 @@ interface DriverInterface
     public function query(Constraint $constraint);
 
     /**
+     * Return the suite collection with the given run ID.
+     * If no suite is found an exception will be thrown.
+     *
+     * @param int $runId
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return SuiteCollection
+     */
+    public function fetch($runId);
+
+    /**
+     * Return true if the driver has the given run ID.
+     */
+    public function has($runId);
+
+    /**
      * Return a history iterator of HistoryEntries in descending
      * chronological order.
      *

--- a/tests/System/ReportOutputTest.php
+++ b/tests/System/ReportOutputTest.php
@@ -85,13 +85,18 @@ class ReportOutputTest extends SystemTestCase
     private function assertGeneratedContents($output, $name)
     {
         $lines = explode("\n", $output);
+
         array_pop($lines);
         $generatedFilename = array_pop($lines);
         $this->assertFileExists($generatedFilename);
-        $this->assertContains(
-            file_get_contents(trim(__DIR__ . '/output/' . $name)),
-            file_get_contents(trim($generatedFilename))
-        );
+
+        $expected = file_get_contents(trim(__DIR__ . '/output/' . $name));
+        $actual = file_get_contents(trim($generatedFilename));
+
+        // replace the unique suite hash with %run_id%
+        $actual = preg_replace('{([0-9a-f]{40})}', '%run_id%', $actual);
+
+        $this->assertContains($expected, $actual);
         unlink($generatedFilename);
     }
 }

--- a/tests/System/output/markdown.md
+++ b/tests/System/output/markdown.md
@@ -1,7 +1,7 @@
 PHPBench Benchmark Results
 ==========================
 
-### suite: 
+### suite: %run_id%
 
 benchmark | subject | groups | params | revs | iter | rej | mem | time | z-value | diff
  --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- 

--- a/tests/Unit/Console/Command/HistoryCommandTest.php
+++ b/tests/Unit/Console/Command/HistoryCommandTest.php
@@ -68,7 +68,7 @@ class HistoryCommandTest extends \PHPUnit_Framework_TestCase
 
         $expected = <<<'EOT'
 Limit set to 10
-Run     Date                    VCS Branch      Context
+[ Run UUID | Date | VCS Branch | Context ]
 
 1       2016-01-01 00:00:00     branch1 foo
 2       2016-01-01 00:00:00     branch2 foo

--- a/tests/Unit/Serializer/XmlTestCase.php
+++ b/tests/Unit/Serializer/XmlTestCase.php
@@ -45,6 +45,7 @@ class XmlTestCase extends \PHPUnit_Framework_TestCase
         ], $params);
 
         $this->suiteCollection->getSuites()->willReturn([$this->suite->reveal()]);
+        $this->suite->getUuid()->willReturn(1234);
         $this->suite->getDate()->willReturn(new \DateTime('2015-01-01'));
         $this->suite->getContextName()->willReturn('test');
         $this->suite->getConfigPath()->willReturn('/path/to/config.json');
@@ -124,7 +125,7 @@ class XmlTestCase extends \PHPUnit_Framework_TestCase
                 <<<'EOT'
 <?xml version="1.0"?>
 <phpbench version="PHPBENCH_VERSION">
-  <suite context="test" date="2015-01-01 00:00:00" config-path="/path/to/config.json">
+  <suite context="test" date="2015-01-01 00:00:00" config-path="/path/to/config.json" uuid="1234">
     <env>
       <info1 foo="bar"/>
     </env>
@@ -152,7 +153,7 @@ EOT
                 <<<'EOT'
 <?xml version="1.0"?>
 <phpbench version="PHPBENCH_VERSION">
-  <suite context="test" date="2015-01-01 00:00:00" config-path="/path/to/config.json">
+  <suite context="test" date="2015-01-01 00:00:00" config-path="/path/to/config.json" uuid="1234">
     <env>
       <info1 foo="bar"/>
     </env>

--- a/tests/Unit/Storage/Archiver/XmlArchiverTest.php
+++ b/tests/Unit/Storage/Archiver/XmlArchiverTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Tests\Unit\Storage\Archiver;
+
+use PhpBench\Dom\Document;
+use PhpBench\Model\SuiteCollection;
+use PhpBench\Registry\Registry;
+use PhpBench\Serializer\XmlDecoder;
+use PhpBench\Serializer\XmlEncoder;
+use PhpBench\Storage\Archiver\XmlArchiver;
+use PhpBench\Storage\DriverInterface;
+use PhpBench\Storage\HistoryEntry;
+use Prophecy\Argument;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Filesystem\Filesystem;
+
+class XmlArchiverTest extends \PHPUnit_Framework_TestCase
+{
+    private $registry;
+    private $xmlEncoder;
+    private $xmlDecoder;
+    private $filesystem;
+    private $archivePath;
+
+    public function setUp()
+    {
+        $this->archivePath = __DIR__ . '/archive';
+        $this->registry = $this->prophesize(Registry::class);
+        $this->xmlEncoder = $this->prophesize(XmlEncoder::class);
+        $this->xmlDecoder = $this->prophesize(XmlDecoder::class);
+        $this->filesystem = $this->prophesize(Filesystem::class);
+
+        $this->archiver = new XmlArchiver(
+            $this->registry->reveal(),
+            $this->xmlEncoder->reveal(),
+            $this->xmlDecoder->reveal(),
+            $this->archivePath,
+            $this->filesystem->reveal()
+        );
+
+        $this->historyEntry = $this->prophesize(HistoryEntry::class);
+        $this->output = new BufferedOutput();
+        $this->storage = $this->prophesize(DriverInterface::class);
+        $this->document = $this->prophesize(Document::class);
+        $this->collection = $this->prophesize(SuiteCollection::class);
+        $this->collection2 = $this->prophesize(SuiteCollection::class);
+
+        $this->registry->getService()->willReturn($this->storage->reveal());
+    }
+
+    /**
+     * It should create the archive directory if it doesn't exist.
+     */
+    public function testArchiveCreateDirectory()
+    {
+        $this->filesystem->exists($this->archivePath)->willReturn(false);
+        $this->filesystem->mkdir($this->archivePath)->shouldBeCalled();
+        $this->storage->history()->willReturn([]);
+        $this->archiver->archive($this->output);
+    }
+
+    /**
+     * It should not create a directory if it already exists.
+     */
+    public function testArchiveExistingDirectoryDoNotCreate()
+    {
+        $this->filesystem->exists($this->archivePath)->willReturn(true);
+        $this->filesystem->mkdir($this->archivePath)->shouldNotBeCalled();
+        $this->storage->history()->willReturn([]);
+        $this->archiver->archive($this->output);
+    }
+
+    /**
+     * It should skip existing archive history entries.
+     * It should write non-existing archive entries.
+     */
+    public function testArchiveSkipExisting()
+    {
+        $this->filesystem->exists($this->archivePath)->willReturn(true);
+        $this->storage->history()->willReturn([
+            $this->createHistoryEntry(1),
+            $this->createHistoryEntry(2),
+            $this->createHistoryEntry(3),
+        ]);
+        $this->filesystem->exists($this->archivePath . '/1.xml')->willReturn(true);
+        $this->filesystem->exists($this->archivePath . '/2.xml')->willReturn(false);
+        $this->filesystem->exists($this->archivePath . '/3.xml')->willReturn(true);
+
+        $this->storage->fetch(2)->willReturn($this->collection->reveal());
+        $this->xmlEncoder->encode($this->collection->reveal())->willReturn($this->document->reveal());
+        $this->document->save($this->archivePath . '/2.xml')->shouldBeCalled();
+
+        $this->archiver->archive($this->output);
+    }
+
+    /**
+     * It should restore to storage.
+     * It should skip existing records.
+     */
+    public function testRestore()
+    {
+        $this->xmlDecoder->decode(Argument::type(Document::class))
+            ->shouldBeCalledTimes(1)
+            ->willReturn($this->collection->reveal(), $this->collection2->reveal());
+
+        $this->storage->has(1)->willReturn(true);
+        $this->storage->has(2)->willReturn(false);
+        $this->storage->store($this->collection->reveal())->shouldBeCalled();
+
+        $this->archiver->restore($this->output);
+    }
+
+    private function createHistoryEntry($identifier)
+    {
+        return new HistoryEntry($identifier, new \DateTime(), 'foo', 'branch');
+    }
+
+    private function createFileInfo($path)
+    {
+        $file = $this->prophesize(\SplFileInfo::class)->reveal();
+        $file->isFile()->willReturn(true);
+        $file->getExtension()->willReturn(substr($path, -3));
+        $file->getFilename()->willReturn(basename($path));
+
+        return $file;
+    }
+}

--- a/tests/Unit/Storage/Archiver/archive/1.xml
+++ b/tests/Unit/Storage/Archiver/archive/1.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<foo>
+    <title>This is a valid XML document</title>
+</foo>

--- a/tests/Unit/Storage/Archiver/archive/2.txt
+++ b/tests/Unit/Storage/Archiver/archive/2.txt
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<foo>
+    <title>This is a valid XML document</title>
+</foo>

--- a/tests/Unit/Storage/Archiver/archive/2.xml
+++ b/tests/Unit/Storage/Archiver/archive/2.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<foo>
+    <title>This is a valid XML document</title>
+</foo>

--- a/tests/Util/TestUtil.php
+++ b/tests/Util/TestUtil.php
@@ -71,9 +71,10 @@ class TestUtil
         $benchmark->getPath()->willReturn($options['path']);
     }
 
-    public static function createSuite(array $options = [], $suiteIndex = 0)
+    public static function createSuite(array $options = [], $suiteIndex = null)
     {
         $options = array_merge([
+            'uuid' => $suiteIndex,
             'date' => '2016-02-06',
             'revs' => 5,
             'warmup' => 10,
@@ -102,7 +103,7 @@ class TestUtil
             null,
             [],
             [],
-            $suiteIndex
+            $options['uuid']
         );
 
         foreach ($options['benchmarks'] as $benchmarkClass) {


### PR DESCRIPTION
This feature allows the contents of the storage driver to be dumped to PHPBench XML files and then later restored.

XML is the default archiving implementation, but others may be implemented and configured - notably a GIT archiver (which will use the XML archiver).

This will permit:

- Serialization of benchmarking results in plain text (i.e. possiblity to store in GIT).
- Changing storage drivers.

```bash
$ phpbench archive
$ phpbench archive --restore
```

## TODO

- [x] Strore unique hash as run ID (based on GIT hash)
- [x] Store / restore
- [x] Skip existing entries (on both operations)
- [x] Archive "registry" - eventually be able to choose GIT archiving strategy.

## Next steps:

- Optimize Sqlite driver insertion (batch insert for suites / benchmarks / subjects / variants)
- "Delete" query on storage layer - need ability to be able to remove results from storage (and so be able to have some control over the archive by regeneration).
- GIT archive