### PR TITLE
Query: token value support

### DIFF
--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -242,10 +242,10 @@ following:
 
 .. code-block:: bash
 
-    $ ./vendor/bin/phpbench run benchmarks/TimeConsumerBench.php --report='{"extends": "default", "exclude": ["benchmark", "subject"]}'
+    $ ./vendor/bin/phpbench run benchmarks/TimeConsumerBench.php --report='{"extends": "aggregate", "cols": ["subject", "mode""]}'
 
 Above we configure a new report which extends the ``default`` report that we
-have already used, but we exclude the ``benchmark`` and ``subject`` columns.
+have already used, but we use only the ``subject`` and ``mode`` columns.
 A full list of all the options for the default reports can be found in the
 :doc:`report-generators` chapter.
 
@@ -264,7 +264,7 @@ Now to finish off, lets add the path and new report to the configuration file:
                 "extends": "default",
                 "title": "The Consumation of Time",
                 "description": "Benchmark how long it takes to consume time",
-                "exclude": ["benchmark", "subject", "group", "params", "revs"]
+                "cols": [ "subject", "mode" ]
             }
         }
     }

--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -53,15 +53,13 @@ see what you have got:
 
 .. code-block:: bash
 
-    $ phpbench history
-    Limit set to 10
-    Run     Date                    VCS Branch      Context
+    $ phpbench history --limit=4
+    [ Run UUID | Date | VCS Branch ]
 
-    239     2016-02-10 12:10:35     storage
-    238     2016-02-10 12:09:10     storage
-    237     2016-02-10 12:08:54     storage
-    236     2016-02-10 12:08:45     storage
-    235     2016-02-10 12:08:01     storage
+    f2ac33a104dec862826b6b70b1a9f1bf47bb4d57        2016-03-09 11:46:58     master
+    d114cec2f5b470613779a1eb9b61d4db47dc6818        2016-03-09 11:45:49     special_value
+    60120e501e7fa4f0f800db4a8955006247244542        2016-03-09 11:38:03     special_value
+    ef5a6a31dacc2543037eb9dcfd092ec7a034fc2f        2016-03-09 11:37:39     special_value
 
 Querying and Report Generation
 ------------------------------
@@ -91,6 +89,19 @@ A more complex example:
 
 This would generate a suite collection containing all the ``benchMd5``
 subjects created after ``2016-02-09``.
+
+Special Values
+~~~~~~~~~~~~~~
+
+Some fields can accept special token values which will be replaced dynamically
+before the query is executed.
+
+Currently you can specify the token ``latest`` as the value of ``run`` which
+will resolve to the UUID of the latest suite in storage.
+
+.. code-block:: bash
+
+    $ phpbench report --report=aggregate --query='run: "latest"'
 
 Logical Operators
 ~~~~~~~~~~~~~~~~~

--- a/extensions/dbal/lib/DbalExtension.php
+++ b/extensions/dbal/lib/DbalExtension.php
@@ -73,14 +73,9 @@ class DbalExtension implements ExtensionInterface
             );
         });
 
-        $container->register('storage.driver.dbal.constraint_visitor', function (Container $container) {
-            return new Storage\Driver\Dbal\ConstraintVisitor();
-        });
-
         $container->register('storage.driver.dbal.repository', function (Container $container) {
             return new Storage\Driver\Dbal\Repository(
-                $container->get('storage.driver.dbal.connection_manager'),
-                $container->get('storage.driver.dbal.constraint_visitor')
+                $container->get('storage.driver.dbal.connection_manager')
             );
         });
 

--- a/extensions/dbal/lib/Storage/Driver/Dbal/Visitor/SqlVisitor.php
+++ b/extensions/dbal/lib/Storage/Driver/Dbal/Visitor/SqlVisitor.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpBench\Extensions\Dbal\Storage\Driver\Dbal;
+namespace PhpBench\Extensions\Dbal\Storage\Driver\Dbal\Visitor;
 
 use PhpBench\Expression\Constraint\Comparison;
 use PhpBench\Expression\Constraint\Composite;
@@ -18,7 +18,7 @@ use PhpBench\Expression\Constraint\Constraint;
 /**
  * Converts a Constraint object graph into an SQL query.
  */
-class ConstraintVisitor
+class SqlVisitor
 {
     /**
      * @var int

--- a/extensions/dbal/lib/Storage/Driver/Dbal/Visitor/TokenValueVisitor.php
+++ b/extensions/dbal/lib/Storage/Driver/Dbal/Visitor/TokenValueVisitor.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Extensions\Dbal\Storage\Driver\Dbal\Visitor;
+
+use PhpBench\Expression\Constraint\Comparison;
+use PhpBench\Expression\Constraint\Composite;
+use PhpBench\Expression\Constraint\Constraint;
+use PhpBench\Extensions\Dbal\Storage\Driver\Dbal\Repository;
+
+/**
+ * Resolves token values, for example "latest" will be resolved to the latest
+ * run UUID.
+ */
+class TokenValueVisitor
+{
+    /**
+     * @var Repository
+     */
+    private $repository;
+
+    public function __construct(Repository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * @param Constraint $constraint
+     */
+    public function visit(Constraint $constraint)
+    {
+        $this->doVisit($constraint);
+    }
+
+    private function doVisit(Constraint $constraint)
+    {
+        if ($constraint instanceof Comparison) {
+            $this->visitComparison($constraint);
+        }
+
+        if ($constraint instanceof Composite) {
+            $this->visitComposite($constraint);
+        }
+    }
+
+    /**
+     * Replace token values in the comparison values.
+     */
+    private function visitComparison(Comparison $comparison)
+    {
+        if ($comparison->getField() === 'run') {
+            $this->replaceValue($comparison, 'latest', $this->repository->getLatestRunUuid());
+        }
+    }
+
+    private function visitComposite(Composite $composite)
+    {
+        $this->doVisit($composite->getConstraint1());
+        $this->doVisit($composite->getConstraint2());
+    }
+
+    private function replaceValue(Comparison $comparison, $token, $tokenValue)
+    {
+        $value = $comparison->getValue();
+        $isArray = is_array($value);
+        $values = (array) $value;
+
+        $found = false;
+        foreach ($values as &$value) {
+            $value = trim($value);
+            if ($value === $token) {
+                $found = true;
+                $value = $tokenValue;
+            }
+        }
+
+        if (false === $found) {
+            return;
+        }
+
+        if (false === $isArray) {
+            $comparison->replaceValue(reset($values));
+
+            return;
+        }
+
+        $comparison->replaceValue($values);
+    }
+}

--- a/extensions/dbal/tests/Functional/Storage/Driver/Dbal/HistoryIteratorTest.php
+++ b/extensions/dbal/tests/Functional/Storage/Driver/Dbal/HistoryIteratorTest.php
@@ -71,17 +71,17 @@ class HistoryIteratorTest extends DbalTestCase
 
         $current = $this->iterator->current();
         $this->assertInstanceOf('PhpBench\Storage\HistoryEntry', $current);
-        $this->assertEquals('2016-01-01', $current->getDate()->format('Y-m-d'));
-        $this->assertEquals('branch_1', $current->getVcsBranch());
-        $this->assertEquals('one', $current->getContext());
-        $this->assertEquals(1, $current->getRunId());
-
-        $this->iterator->next();
-        $current = $this->iterator->current();
-        $this->assertInstanceOf('PhpBench\Storage\HistoryEntry', $current);
         $this->assertEquals('2015-01-01', $current->getDate()->format('Y-m-d'));
         $this->assertEquals('branch_2', $current->getVcsBranch());
         $this->assertEquals('two', $current->getContext());
         $this->assertEquals(2, $current->getRunId());
+
+        $this->iterator->next();
+        $current = $this->iterator->current();
+        $this->assertInstanceOf('PhpBench\Storage\HistoryEntry', $current);
+        $this->assertEquals('2016-01-01', $current->getDate()->format('Y-m-d'));
+        $this->assertEquals('branch_1', $current->getVcsBranch());
+        $this->assertEquals('one', $current->getContext());
+        $this->assertEquals(1, $current->getRunId());
     }
 }

--- a/extensions/dbal/tests/Functional/Storage/Driver/Dbal/LoaderTest.php
+++ b/extensions/dbal/tests/Functional/Storage/Driver/Dbal/LoaderTest.php
@@ -12,10 +12,10 @@
 namespace PhpBench\Extensions\Dbal\Tests\Functional\Storage\Driver\Dbal;
 
 use PhpBench\Expression\Constraint\Comparison;
-use PhpBench\Extensions\Dbal\Storage\Driver\Dbal\ConstraintVisitor;
 use PhpBench\Extensions\Dbal\Storage\Driver\Dbal\Loader;
 use PhpBench\Extensions\Dbal\Storage\Driver\Dbal\Persister;
 use PhpBench\Extensions\Dbal\Storage\Driver\Dbal\Repository;
+use PhpBench\Extensions\Dbal\Storage\Driver\Dbal\Visitor\SqlVisitor;
 use PhpBench\Extensions\Dbal\Tests\Functional\DbalTestCase;
 use PhpBench\Model\SuiteCollection;
 use PhpBench\Tests\Util\TestUtil;
@@ -34,7 +34,7 @@ class LoaderTest extends DbalTestCase
         // instantiate persister
         $this->persister = new Persister($this->manager);
 
-        $this->visitor = new ConstraintVisitor();
+        $this->visitor = new SqlVisitor();
         $repository = new Repository($this->manager, $this->visitor);
         $this->loader = new Loader($repository);
     }

--- a/extensions/dbal/tests/Functional/Storage/Driver/Dbal/RepositoryTest.php
+++ b/extensions/dbal/tests/Functional/Storage/Driver/Dbal/RepositoryTest.php
@@ -66,16 +66,16 @@ class RepositoryTest extends DbalTestCase
 
         $this->assertEquals([
             [
-                'run_date' => '2016-01-01 00:00:00',
-                'context' => 'one',
-                'vcs_branch' => 'branch_1',
-                'run_uuid' => 1,
-            ],
-            [
                 'run_date' => '2015-01-01 00:00:00',
                 'context' => 'two',
                 'vcs_branch' => 'branch_2',
                 'run_uuid' => 2,
+            ],
+            [
+                'run_date' => '2016-01-01 00:00:00',
+                'context' => 'one',
+                'vcs_branch' => 'branch_1',
+                'run_uuid' => 1,
             ],
         ], $rows);
     }
@@ -101,5 +101,31 @@ class RepositoryTest extends DbalTestCase
         $params = $this->repository->getParameters(1);
 
         $this->assertEquals($parameters, $params);
+    }
+
+    /**
+     * It should retrieve the latest suite UUID.
+     */
+    public function testLastestSuiteUuid()
+    {
+        $suiteCollection = new SuiteCollection([
+            TestUtil::createSuite([
+                'uuid' => 50,
+            ]),
+            TestUtil::createSuite([
+                'uuid' => 5,
+            ]),
+            TestUtil::createSuite([
+                'uuid' => 500,
+            ]),
+            TestUtil::createSuite([
+                'uuid' => 7,
+            ]),
+        ]);
+
+        $this->persister->persist($suiteCollection);
+        $latestUuid = $this->repository->getLatestRunUuid();
+
+        $this->assertEquals(7, $latestUuid);
     }
 }

--- a/extensions/dbal/tests/Unit/Storage/Driver/Dbal/Visitor/SqlVisitorTest.php
+++ b/extensions/dbal/tests/Unit/Storage/Driver/Dbal/Visitor/SqlVisitorTest.php
@@ -9,21 +9,21 @@
  * file that was distributed with this source code.
  */
 
-namespace PhpBench\Tests\Unit\Storage\Driver\Dbal;
+namespace PhpBench\Tests\Unit\Storage\Driver\Dbal\Visitor;
 
 use PhpBench\Expression\Constraint\Comparison;
 use PhpBench\Expression\Constraint\Composite;
 use PhpBench\Expression\Constraint\Constraint;
 use PhpBench\Expression\Parser;
-use PhpBench\Extensions\Dbal\Storage\Driver\Dbal\ConstraintVisitor;
+use PhpBench\Extensions\Dbal\Storage\Driver\Dbal\Visitor\SqlVisitor;
 
-class ConstraintVisitorTest extends \PHPUnit_Framework_TestCase
+class SqlVisitorTest extends \PHPUnit_Framework_TestCase
 {
     private $visitor;
 
     public function setUp()
     {
-        $this->visitor = new ConstraintVisitor();
+        $this->visitor = new SqlVisitor();
         $this->parser = new Parser();
     }
 

--- a/extensions/dbal/tests/Unit/Storage/Driver/Dbal/Visitor/TokenValueVisitorTest.php
+++ b/extensions/dbal/tests/Unit/Storage/Driver/Dbal/Visitor/TokenValueVisitorTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Tests\Unit\Storage\Driver\Dbal\Visitor;
+
+use PhpBench\Expression\Parser;
+use PhpBench\Extensions\Dbal\Storage\Driver\Dbal\Repository;
+use PhpBench\Extensions\Dbal\Storage\Driver\Dbal\Visitor\TokenValueVisitor;
+
+class TokenValueVisitorTest extends \PHPUnit_Framework_TestCase
+{
+    private $visitor;
+
+    public function setUp()
+    {
+        $this->repository = $this->prophesize(Repository::class);
+        $this->visitor = new TokenValueVisitor($this->repository->reveal());
+        $this->parser = new Parser();
+    }
+
+    /**
+     * It should replace "latest" with the latest suite UUID.
+     */
+    public function testLatest()
+    {
+        $constraint = $this->parser->parse('run: "latest"');
+        $this->repository->getLatestRunUuid()->willReturn(42);
+        $this->visitor->visit($constraint);
+
+        $this->assertEquals(42, $constraint->getValue());
+    }
+
+    /**
+     * It should not replace values that are not tokens!
+     */
+    public function testLatestNotReplaceOtherValues()
+    {
+        $constraint = $this->parser->parse('$and: [ { run: "latest" }, { "run": "foo" } ]');
+        $this->repository->getLatestRunUuid()->willReturn(42);
+        $this->visitor->visit($constraint);
+
+        $constraint1 = $constraint->getConstraint1();
+        $constraint2 = $constraint->getConstraint2();
+        $this->assertEquals(42, $constraint1->getValue());
+        $this->assertEquals('foo', $constraint2->getValue());
+    }
+}

--- a/lib/Console/Command/RunCommand.php
+++ b/lib/Console/Command/RunCommand.php
@@ -90,6 +90,7 @@ EOT
             $output->write('Storing results ... ');
             $this->storage->getService()->store($collection);
             $output->writeln('OK');
+            $output->writeln(sprintf('Run: %s', $suite->getUuid()));
         }
 
         $this->reportHandler->reportsFromInput($input, $output, $collection);

--- a/lib/Expression/Constraint/Comparison.php
+++ b/lib/Expression/Constraint/Comparison.php
@@ -72,4 +72,9 @@ class Comparison extends Constraint
     {
         return $this->value;
     }
+
+    public function replaceValue($newValue)
+    {
+        $this->value = $newValue;
+    }
 }

--- a/lib/Report/Generator/TableGenerator.php
+++ b/lib/Report/Generator/TableGenerator.php
@@ -61,7 +61,7 @@ class TableGenerator implements GeneratorInterface, OutputAwareInterface
             'title' => null,
             'description' => null,
             'cols' => ['benchmark', 'subject', 'groups', 'params', 'revs', 'its', 'mem', 'best', 'mean', 'mode', 'worst', 'stdev', 'rstdev', 'diff'],
-            'break' => ['suite'],
+            'break' => ['suite', 'date', 'stime'],
             'compare' => null,
             'compare_fields' => ['mean'],
             'diff_col' => 'mean',

--- a/lib/Report/schema/report.xsd
+++ b/lib/Report/schema/report.xsd
@@ -11,7 +11,7 @@
     </xsd:element>
 
     <xsd:complexType name="report">
-        <xsd:choice maxOccurs="unbounded">
+        <xsd:choice maxOccurs="unbounded" minOccurs="0">
             <xsd:element name="description" type="xsd:string"/>
             <xsd:element name="table" type="subject"/>
         </xsd:choice>

--- a/tests/System/ReportOutputTest.php
+++ b/tests/System/ReportOutputTest.php
@@ -95,6 +95,8 @@ class ReportOutputTest extends SystemTestCase
 
         // replace the unique suite hash with %run.uuid%
         $actual = preg_replace('{([0-9a-f]{40})}', '%run.uuid%', $actual);
+        $actual = preg_replace('{([0-9]{4}-[0-9]{2}-[0-9]{2})}', '%date%', $actual);
+        $actual = preg_replace('{([0-9]{2}:[0-9]{2}:[0-9]{2})}', '%time%', $actual);
 
         $this->assertContains($expected, $actual);
         unlink($generatedFilename);

--- a/tests/System/output/markdown.md
+++ b/tests/System/output/markdown.md
@@ -1,7 +1,7 @@
 PHPBench Benchmark Results
 ==========================
 
-### suite: %run.uuid%
+### suite: %run.uuid%, date: %date%, stime: %time%
 
 benchmark | subject | groups | params | revs | iter | rej | mem | time | z-value | diff
  --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- 

--- a/tests/Unit/Report/Generator/TableGeneratorTest.php
+++ b/tests/Unit/Report/Generator/TableGeneratorTest.php
@@ -288,7 +288,8 @@ class TableGeneratorTest extends GeneratorTestCase
     public function testTitles()
     {
         $collection = TestUtil::createCollection([
-            [],
+            [
+            ],
         ]);
 
         $report = $this->generate($collection, [
@@ -300,7 +301,7 @@ class TableGeneratorTest extends GeneratorTestCase
         $this->assertXPathCount($report, 1, '//report[description="The world said hello back."]');
 
         // the table title is the break criteria, in this case the suite index.
-        $this->assertXPathCount($report, 1, '//table[@title="suite: 0"]');
+        $this->assertXPathCount($report, 1, '//table[@title="suite: 0, date: 2016-02-06, stime: 00:00:00"]');
     }
 
     /**


### PR DESCRIPTION
This PR introduces query token values which will be dynamically substituted before the query is transformed into an SQL statement.

This PR is adding the `latest` token on the `run` field. The token will be replaced with the UUID of the latest suite.

This allows a report to be quickly generated comparing the latest run against a known previous run:

```
$ phpbench query --query='run: "latest"' --query='run: "<some-uuid>"' --report='generator: table'
suite: 958456c7a631bb632ae9788e5e10f781ed37b7c4, date: 2016-03-09, stime: 10:38:07, vcs_branch: db_improvements
+------------------+-----+----------+----------+----------+----------+--------+
| subject          | its | best     | mean     | mode     | worst    | rstdev |
+------------------+-----+----------+----------+----------+----------+--------+
| benchStore       | 10  | 405.49ms | 418.39ms | 412.59ms | 439.42ms | 2.58%  |
| benchStoreParams | 10  | 411.59ms | 438.62ms | 420.28ms | 604.69ms | 12.66% |
+------------------+-----+----------+----------+----------+----------+--------+

suite: f2ac33a104dec862826b6b70b1a9f1bf47bb4d57, date: 2016-03-09, stime: 11:46:58, vcs_branch: special_value
+------------------+-----+----------+----------+----------+----------+--------+
| subject          | its | best     | mean     | mode     | worst    | rstdev |
+------------------+-----+----------+----------+----------+----------+--------+
| benchStore       | 10  | 409.78ms | 417.16ms | 413.33ms | 426.75ms | 1.40%  |
| benchStoreParams | 10  | 413.16ms | 445.30ms | 423.76ms | 638.80ms | 14.56% |
+------------------+-----+----------+----------+----------+----------+--------+
```