### PR TITLE
Xml Storage Driver

### DIFF
--- a/benchmarks/Macro/BaseBenchCase.php
+++ b/benchmarks/Macro/BaseBenchCase.php
@@ -12,9 +12,9 @@
 namespace PhpBench\Benchmarks\Macro;
 
 use PhpBench\DependencyInjection\Container;
+use PhpBench\Tests\Util\Workspace;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Base class for PHPBench macro benchmarks.
@@ -53,9 +53,7 @@ class BaseBenchCase
      */
     public static function createWorkspace()
     {
-        if (!file_exists(self::getWorkspacePath())) {
-            mkdir(self::getWorkspacePath());
-        }
+        Workspace::initWorkspace();
     }
 
     /**
@@ -64,10 +62,7 @@ class BaseBenchCase
      */
     public static function removeWorkspace()
     {
-        $filesystem = new Filesystem();
-        if (file_exists(self::getWorkspacePath())) {
-            $filesystem->remove(self::getWorkspacePath());
-        }
+        Workspace::cleanWorkspace();
     }
 
     protected function getContainer()
@@ -80,6 +75,7 @@ class BaseBenchCase
 
     public function runCommand($serviceId, $args)
     {
+        chdir(Workspace::getWorkspacePath());
         $input = new ArrayInput($args);
         $output = new BufferedOutput();
         $command = $this->getContainer()->get($serviceId);
@@ -102,7 +98,7 @@ class BaseBenchCase
 
     protected static function getWorkspacePath()
     {
-        return __DIR__ . '/_workspace';
+        return Workspace::getWorkspacePath();
     }
 
     protected function addContainerExtensionClass($extensionClass)

--- a/benchmarks/Macro/LogBench.php
+++ b/benchmarks/Macro/LogBench.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Benchmarks\Macro;
+
+/**
+ * Benchmark for the log command.
+ *
+ * @BeforeClassMethods({"createWorkspace", "createResults"})
+ */
+class LogBench extends BaseBenchCase
+{
+    public static function createResults()
+    {
+        for ($i = 0; $i < 10; $i++) {
+            // instantiate the benchmark class (this) so that we can
+            // run a command.
+            $case = new self();
+            $case->runCommand('console.command.run', [
+                'path' => self::getFunctionalBenchmarkPath(),
+                '--executor' => 'debug',
+                '--iterations' => [100],
+                '--store' => true,
+                '--progress' => 'none',
+            ]);
+        }
+    }
+
+    public function benchLog()
+    {
+        $this->runCommand('console.command.log', [
+            '--no-pagination' => true,
+        ]);
+    }
+}

--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -2,38 +2,24 @@ Storage and Querying
 ====================
 
 PHPBench allows benchmarking results to be persisted using a configured
-storage driver. Persisted results can later be against using the ``report``
-command.
+storage driver. You can inspect the results with either the ``show`` or
+``report`` commands.
 
 Configuring a Storage Driver
 ----------------------------
 
-By default PHPBench does not have any storage drivers enabled. You can however
-easily enable the bundled :doc:`dbal extension <extensions/dbal>` in your configuration file:
+PHPBench will use XML storage by default, which is fine for most purposes. If
+you want advanced functionality (e.g. the ability to query benchmarks) then
+you can install the :doc:`Doctrine DBAL extrension<extensions/dbal>`.
+
+The XML storage driver will place benchmarks in a folder called ``_storage``
+by default, this can be changed in the configuration as follows:
 
 .. code-block:: javascript
 
     {
-        "storage": "sqlite",
-        "extensions": [
-            "PhpBench\\Extensions\\Dbal\\DbalExtension"
-        ]
+        'xml_storage_path' => '_storage'
     }
-
-Above you register the DBAL extension and select it as the storage driver
-for your project.
-
-By default it is configured with an sqlite database in `.phpbench.sqlite` in the
-current working directory. It is recommended that you add this to your git
-ignore file:
-
-.. code-block:: bash
-
-    # .gitignore
-    # ...
-    .phpbench.sqlite
-
-For more details see the documentation :doc:`documentation <extensions/dbal>`
 
 Storing Results
 ---------------
@@ -72,15 +58,26 @@ see what you have got:
 
     ...
 
-Querying and Report Generation
-------------------------------
+Report Generation
+-----------------
 
-You can query the benchmarking history of the project and use any of the
-existing :doc:`reports`:
+You can report on a single given run ID using the ``show`` command:
 
 .. code-block:: bash
 
-    $ phpbench report --query='run: 239' --report=aggregate
+    $ phpbench show 9d38a760e6ebec0a466c80f148264a7a4bb7a203
+
+You may also specify a different report with the ``--report`` option. In order
+to compare two or more reports, you should use the ``report`` command as
+detailed in the following section.
+
+Querying
+--------
+
+.. important::
+
+    The XML storage driver does not support querying, if you require this
+    functionality install the :doc:`Doctrine DBAL extrension<extensions/dbal>`.
 
 PHPBench uses a query language very similar to that of MongoDB. A simple
 example:

--- a/extensions/dbal/lib/Storage/Driver/Dbal/Repository.php
+++ b/extensions/dbal/lib/Storage/Driver/Dbal/Repository.php
@@ -101,7 +101,7 @@ EOT;
     public function hasRun($runId)
     {
         $conn = $this->manager->getConnection();
-        $stmt = $conn->prepare('SELECT id FROM run WHERE id = ?');
+        $stmt = $conn->prepare('SELECT id FROM run WHERE uuid = ?');
         $stmt->execute([$runId]);
 
         return $stmt->fetch() ? true : false;
@@ -134,7 +134,7 @@ SELECT
     run.total_time AS total_time
     FROM run
     LEFT OUTER JOIN environment ON environment.provider = "vcs" AND environment.run_id = run.id AND environment.ekey = "branch"
-    ORDER BY run.id DESC
+    ORDER BY run.date DESC
 EOT;
 
         $conn = $this->manager->getConnection();

--- a/extensions/dbal/lib/Storage/Driver/DbalDriver.php
+++ b/extensions/dbal/lib/Storage/Driver/DbalDriver.php
@@ -68,14 +68,14 @@ class DbalDriver implements DriverInterface
      */
     public function fetch($runId)
     {
-        $comparison = new Comparison('$eq', 'run', $runId);
-        $collection = $this->query($comparison);
-
-        if (count($collection->getSuites()) === 0) {
+        if (!$this->repository->hasRun($runId)) {
             throw new \InvalidArgumentException(sprintf(
                 'Could not find suite with run ID "%s"', $runId
             ));
         }
+
+        $comparison = new Comparison('$eq', 'run', $runId);
+        $collection = $this->query($comparison);
 
         return $collection;
     }

--- a/extensions/dbal/tests/Functional/Storage/Driver/Dbal/HistoryIteratorTest.php
+++ b/extensions/dbal/tests/Functional/Storage/Driver/Dbal/HistoryIteratorTest.php
@@ -71,17 +71,17 @@ class HistoryIteratorTest extends DbalTestCase
 
         $current = $this->iterator->current();
         $this->assertInstanceOf('PhpBench\Storage\HistoryEntry', $current);
-        $this->assertEquals('2015-01-01', $current->getDate()->format('Y-m-d'));
-        $this->assertEquals('branch_2', $current->getVcsBranch());
-        $this->assertEquals('two', $current->getContext());
-        $this->assertEquals(2, $current->getRunId());
-
-        $this->iterator->next();
-        $current = $this->iterator->current();
-        $this->assertInstanceOf('PhpBench\Storage\HistoryEntry', $current);
         $this->assertEquals('2016-01-01', $current->getDate()->format('Y-m-d'));
         $this->assertEquals('branch_1', $current->getVcsBranch());
         $this->assertEquals('one', $current->getContext());
         $this->assertEquals(1, $current->getRunId());
+
+        $this->iterator->next();
+        $current = $this->iterator->current();
+        $this->assertInstanceOf('PhpBench\Storage\HistoryEntry', $current);
+        $this->assertEquals('2015-01-01', $current->getDate()->format('Y-m-d'));
+        $this->assertEquals('branch_2', $current->getVcsBranch());
+        $this->assertEquals('two', $current->getContext());
+        $this->assertEquals(2, $current->getRunId());
     }
 }

--- a/extensions/dbal/tests/Functional/Storage/Driver/Dbal/RepositoryTest.php
+++ b/extensions/dbal/tests/Functional/Storage/Driver/Dbal/RepositoryTest.php
@@ -66,10 +66,10 @@ class RepositoryTest extends DbalTestCase
 
         $this->assertEquals([
             [
-                'run_date' => '2015-01-01 00:00:00',
-                'context' => 'two',
-                'vcs_branch' => 'branch_2',
-                'run_uuid' => 2,
+                'run_date' => '2016-01-01 00:00:00',
+                'context' => 'one',
+                'vcs_branch' => 'branch_1',
+                'run_uuid' => 1,
                 'nb_subjects' => '1',
                 'nb_iterations' => '2',
                 'nb_revolutions' => '5',
@@ -80,10 +80,10 @@ class RepositoryTest extends DbalTestCase
                 'total_time' => '6.0',
             ],
             [
-                'run_date' => '2016-01-01 00:00:00',
-                'context' => 'one',
-                'vcs_branch' => 'branch_1',
-                'run_uuid' => 1,
+                'run_date' => '2015-01-01 00:00:00',
+                'context' => 'two',
+                'vcs_branch' => 'branch_2',
+                'run_uuid' => 2,
                 'nb_subjects' => '1',
                 'nb_iterations' => '2',
                 'nb_revolutions' => '5',
@@ -143,5 +143,22 @@ class RepositoryTest extends DbalTestCase
         $latestUuid = $this->repository->getLatestRunUuid();
 
         $this->assertEquals(7, $latestUuid);
+    }
+
+    /**
+     * It can determine if run exists.
+     */
+    public function testHasRun()
+    {
+        $suiteCollection = new SuiteCollection([
+            TestUtil::createSuite([
+                'uuid' => 1234,
+            ]),
+        ]);
+
+        $this->persister->persist($suiteCollection);
+
+        $this->assertTrue($this->repository->hasRun(1234));
+        $this->assertFalse($this->repository->hasRun(4321));
     }
 }

--- a/extensions/dbal/tests/Unit/Storage/Driver/DbalDriverTest.php
+++ b/extensions/dbal/tests/Unit/Storage/Driver/DbalDriverTest.php
@@ -65,6 +65,18 @@ class DbalDriverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * It should throw an exception if getting a non-existant run.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Could not find suite with run
+     */
+    public function testFetchNonExisting()
+    {
+        $this->repository->hasRun('1234')->willReturn(false);
+        $this->driver->fetch('1234');
+    }
+
+    /**
      * It should return a history iterator.
      */
     public function testHistory()

--- a/lib/Console/CharacterReader.php
+++ b/lib/Console/CharacterReader.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Console;
+
+class CharacterReader
+{
+    /**
+     * If readline is installed, then prevent the user having to
+     * press <return> in order to paginate.
+     */
+    public function __construct()
+    {
+        // we could use extension_loaded but HHVM returns true and
+        // still doesn't have this function..
+        if (function_exists('readline_callback_handler_install')) {
+            readline_callback_handler_install('', function () { });
+        }
+    }
+
+    /**
+     * Wait for a single character input and return it.
+     *
+     * @return string
+     */
+    public function read()
+    {
+        while (false !== $character = fgetc(STDIN)) {
+            return $character;
+        }
+    }
+}

--- a/lib/Console/Command/ArchiveCommand.php
+++ b/lib/Console/Command/ArchiveCommand.php
@@ -64,6 +64,6 @@ EOT
             return;
         }
 
-        $this->archiver->archive($output);
+        $this->archiver->getService()->archive($output);
     }
 }

--- a/lib/Console/Command/ShowCommand.php
+++ b/lib/Console/Command/ShowCommand.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Console\Command;
+
+use PhpBench\Console\Command\Handler\DumpHandler;
+use PhpBench\Console\Command\Handler\ReportHandler;
+use PhpBench\Console\Command\Handler\TimeUnitHandler;
+use PhpBench\Registry\Registry;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Command to show/report on a specific run.
+ */
+class ShowCommand extends Command
+{
+    private $storage;
+    private $reportHandler;
+    private $timeUnitHandler;
+    private $dumpHandler;
+
+    public function __construct(
+        Registry $storage,
+        ReportHandler $reportHandler,
+        TimeUnitHandler $timeUnitHandler,
+        DumpHandler $dumpHandler
+    ) {
+        parent::__construct();
+        $this->storage = $storage;
+        $this->reportHandler = $reportHandler;
+        $this->timeUnitHandler = $timeUnitHandler;
+        $this->dumpHandler = $dumpHandler;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure()
+    {
+        $this->setName('show');
+        $this->setDescription('Show the details of a specific run.');
+        $this->addArgument('run_id', InputArgument::REQUIRED, 'Run ID');
+        $this->setHelp(<<<'EOT'
+Show the results of a specific run.
+
+    $ %command.full_name% <run id>
+
+Any report can be used to display the results:
+
+    $ %command.full_name% <run id> --report=env
+
+EOT
+        );
+        ReportHandler::configure($this);
+        TimeUnitHandler::configure($this);
+        DumpHandler::configure($this);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        if (!$input->getOption('report')) {
+            $input->setOption('report', ['aggregate']);
+        }
+
+        $storage = $this->storage->getService();
+        $collection = $storage->fetch($input->getArgument('run_id'));
+        $this->timeUnitHandler->timeUnitFromInput($input);
+        $this->reportHandler->reportsFromInput($input, $output, $collection);
+    }
+}

--- a/lib/Model/Subject.php
+++ b/lib/Model/Subject.php
@@ -112,13 +112,14 @@ class Subject
      *
      * @return Variant.
      */
-    public function createVariant(ParameterSet $parameterSet, $revolutions, $warmup)
+    public function createVariant(ParameterSet $parameterSet, $revolutions, $warmup, array $computedStats = [])
     {
         $variant = new Variant(
             $this,
             $parameterSet,
             $revolutions,
-            $warmup
+            $warmup,
+            $computedStats
         );
         $this->variants[] = $variant;
 

--- a/lib/Model/Suite.php
+++ b/lib/Model/Suite.php
@@ -189,19 +189,17 @@ class Suite implements \IteratorAggregate
     /**
      * Generate a universally unique identifier.
      *
-     * Based on the GIT hashing detailed here:
-     *     http://alblue.bandlem.com/2011/08/git-tip-of-week-objects.html
+     * The first 7 characters are the year month and in hex, the rest is a
+     * truncated sha1 string encoding the environmental information, the
+     * microtime and the configuration path.
      */
     public function generateUuid()
     {
         $serialized = serialize($this->envInformations);
-
-        $this->uuid = sha1(implode([
-            'suite',
-            strlen($serialized),
+        $this->uuid = dechex($this->getDate()->format('Ymd')) . substr(sha1(implode([
             microtime(),
             $serialized,
             $this->configPath,
-        ]));
+        ])), 0, -7);
     }
 }

--- a/lib/Model/Variant.php
+++ b/lib/Model/Variant.php
@@ -53,6 +53,11 @@ class Variant implements \IteratorAggregate, \ArrayAccess, \Countable
     private $stats;
 
     /**
+     * @var array
+     */
+    private $computedStats;
+
+    /**
      * @var bool
      */
     private $computed = false;
@@ -71,12 +76,14 @@ class Variant implements \IteratorAggregate, \ArrayAccess, \Countable
         Subject $subject,
         ParameterSet $parameterSet,
         $revolutions,
-        $warmup
+        $warmup,
+        array $computedStats = []
     ) {
         $this->subject = $subject;
         $this->parameterSet = $parameterSet;
         $this->revolutions = $revolutions;
         $this->warmup = $warmup;
+        $this->computedStats = $computedStats;
     }
 
     /**
@@ -198,7 +205,7 @@ class Variant implements \IteratorAggregate, \ArrayAccess, \Countable
         $times = $this->getTimes();
         $retryThreshold = $this->getSubject()->getRetryThreshold();
 
-        $this->stats = new Distribution($times);
+        $this->stats = new Distribution($times, $this->computedStats);
 
         foreach ($this->iterations as $iteration) {
             // deviation is the percentage different of the value from the mean of the set.

--- a/lib/Serializer/XmlDecoder.php
+++ b/lib/Serializer/XmlDecoder.php
@@ -136,9 +136,22 @@ class XmlDecoder
         foreach ($subjectEl->query('./variant') as $index => $variantEl) {
             $parameters = $this->getParameters($variantEl);
             $parameterSet = new ParameterSet($index, $parameters);
-            $variant = $subject->createVariant($parameterSet, $variantEl->getAttribute('revs'), $variantEl->getAttribute('warmup'));
+            $stats = $this->getComputedStats($variantEl);
+            $variant = $subject->createVariant($parameterSet, $variantEl->getAttribute('revs'), $variantEl->getAttribute('warmup'), $stats);
             $this->processVariant($variant, $variantEl);
         }
+    }
+
+    private function getComputedStats(\DOMElement $element)
+    {
+        $stats = [];
+        foreach ($element->query('./stats') as $statsEl) {
+            foreach ($statsEl->attributes as $key => $attribute) {
+                $stats[$key] = $attribute->nodeValue;
+            }
+        }
+
+        return $stats;
     }
 
     private function getParameters(\DOMElement $element)

--- a/lib/Storage/Archiver/XmlArchiver.php
+++ b/lib/Storage/Archiver/XmlArchiver.php
@@ -27,7 +27,7 @@ class XmlArchiver implements ArchiverInterface
     /**
      * @var DriverFactory
      */
-    private $registry;
+    private $storageRegistry;
 
     /**
      * @var string
@@ -50,13 +50,13 @@ class XmlArchiver implements ArchiverInterface
     private $xmlDecoder;
 
     public function __construct(
-        Registry $registry,
+        Registry $storageRegistry,
         XmlEncoder $xmlEncoder,
         XmlDecoder $xmlDecoder,
         $archivePath,
         Filesystem $filesystem = null
     ) {
-        $this->registry = $registry;
+        $this->storageRegistry = $storageRegistry;
         $this->xmlEncoder = $xmlEncoder;
         $this->xmlDecoder = $xmlDecoder;
         $this->archivePath = $archivePath;
@@ -68,7 +68,7 @@ class XmlArchiver implements ArchiverInterface
      */
     public function archive(OutputInterface $output)
     {
-        $driver = $this->registry->getService();
+        $driver = $this->storageRegistry->getService();
 
         if (!$this->filesystem->exists($this->archivePath)) {
             $this->filesystem->mkdir($this->archivePath);
@@ -105,7 +105,7 @@ class XmlArchiver implements ArchiverInterface
      */
     public function restore(OutputInterface $output)
     {
-        $driver = $this->registry->getService();
+        $driver = $this->storageRegistry->getService();
 
         $iterator = new \DirectoryIterator($this->archivePath);
         $files = $this->filterFiles($iterator);

--- a/lib/Storage/Driver/Xml/HistoryIterator.php
+++ b/lib/Storage/Driver/Xml/HistoryIterator.php
@@ -1,0 +1,269 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Storage\Driver\Xml;
+
+use PhpBench\Dom\Document;
+use PhpBench\Serializer\XmlDecoder;
+use PhpBench\Storage\HistoryEntry;
+use PhpBench\Storage\HistoryIteratorInterface;
+
+/**
+ * XML file history iterator.
+ *
+ * This command will iterate over the suite collections created by the XML
+ * storage driver.
+ */
+class HistoryIterator implements HistoryIteratorInterface
+{
+    private $xmlDecoder;
+    private $path;
+
+    private $years;
+    private $months;
+    private $days;
+    private $entries;
+    private $initialized;
+
+    public function __construct(
+        XmlDecoder $xmlDecoder,
+        $path
+    ) {
+        $this->xmlDecoder = $xmlDecoder;
+        $this->path = $path;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function current()
+    {
+        $this->init();
+
+        return $this->entries->current();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function next()
+    {
+        $this->init();
+
+        $this->entries->next();
+
+        if (!$this->entries->valid()) {
+            $this->days->next();
+
+            if (!$this->days->valid()) {
+                $this->months->next();
+
+                if (!$this->months->valid()) {
+                    $this->years->next();
+
+                    if ($this->years->valid()) {
+                        $this->months = $this->getDirectoryIterator($this->years->current());
+                    }
+                }
+
+                if ($this->months->valid()) {
+                    $this->days = $this->getDirectoryIterator($this->months->current());
+                }
+            }
+
+            if ($this->days->valid()) {
+                $this->entries = $this->getEntryIterator();
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function key()
+    {
+        $this->init();
+        $key = sprintf(
+            '%s-%s-%s-%s',
+            $this->years->key(),
+            $this->months->key(),
+            $this->days->key(),
+            $this->entries->key()
+        );
+
+        return $key;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rewind()
+    {
+        $this->init();
+        $this->years->rewind();
+        $this->months->rewind();
+        $this->days->rewind();
+        $this->entries->rewind();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function valid()
+    {
+        $this->init();
+
+        return $this->entries->valid();
+    }
+
+    private function init()
+    {
+        if ($this->initialized) {
+            return;
+        }
+
+        $this->initialized = true;
+
+        if (file_exists($this->path)) {
+            $this->years = $this->getDirectoryIterator($this->path);
+        } else {
+            $this->years = new \ArrayIterator();
+        }
+
+        // create directory iterators for each part of the date sharding
+        // (2016/01/01/<hash>.xml). if there is not valid entries for the
+        // preceding shard, just create an empty array iterator.
+        if ($this->years->valid()) {
+            $this->months = $this->getDirectoryIterator($this->years->current());
+        } else {
+            $this->months = new \ArrayIterator();
+        }
+
+        if ($this->months->valid()) {
+            $this->days = $this->getDirectoryIterator($this->months->current());
+        } else {
+            $this->days = new \ArrayIterator();
+        }
+
+        if ($this->days->valid()) {
+            $this->entries = $this->getEntryIterator();
+        } else {
+            $this->entries = new \ArrayIterator();
+        }
+    }
+
+    /**
+     * Return an iterator for the history entries.
+     *
+     * We hydrate all of the entries for the "current" day.
+     *
+     * @return \ArrayIterator
+     */
+    private function getEntryIterator()
+    {
+        $files = $this->days->current();
+        $files = new \DirectoryIterator($this->days->current());
+        $historyEntries = [];
+        foreach ($files as $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+
+            if ($file->getExtension() !== 'xml') {
+                continue;
+            }
+
+            $historyEntries[] = $this->getHistoryEntry($file->getPathname());
+        }
+        usort($historyEntries, function ($entry1, $entry2) {
+            if ($entry1->getDate()->format('U') === $entry2->getDate()->format('U')) {
+                return;
+            }
+
+            return $entry1->getDate()->format('U') < $entry2->getDate()->format('U');
+        });
+
+        return new \ArrayIterator($historyEntries);
+    }
+
+    /**
+     * Hydrate and return the history entry for the given path.
+     *
+     * The summary *should* used pre-calculated values from the XML
+     * therefore reducing the normal overhead, however this code
+     * is still quite expensive as we are creating the entire object
+     * graph for each suite run.
+     *
+     * @param string $path
+     *
+     * @return HistoryEntry
+     */
+    private function getHistoryEntry($path)
+    {
+        $dom = new Document();
+        $dom->load($path);
+        $collection = $this->xmlDecoder->decode($dom);
+        $suites = $collection->getSuites();
+        $suite = reset($suites);
+        $envInformations = $suite->getEnvInformations();
+
+        $vcsBranch = null;
+        if (isset($envInformations['vcs']['branch'])) {
+            $vcsBranch = $envInformations['vcs']['branch'];
+        }
+
+        $summary = $suite->getSummary();
+        $entry = new HistoryEntry(
+            $suite->getUuid(),
+            $suite->getDate(),
+            $suite->getContextName(),
+            $vcsBranch,
+            $summary->getNbSubjects(),
+            $summary->getNbIterations(),
+            $summary->getNbRevolutions(),
+            $summary->getMinTime(),
+            $summary->getMaxTime(),
+            $summary->getMeanTime(),
+            $summary->getMeanRelStDev(),
+            $summary->getTotalTime()
+        );
+
+        return $entry;
+    }
+
+    /**
+     * Return the iterator for a specific path (years, months, days).
+     *
+     * We sort by date in descending order.
+     *
+     * @return \ArrayIterator
+     */
+    private function getDirectoryIterator($path)
+    {
+        $nodes = new \DirectoryIterator($path);
+        $dirs = [];
+        foreach ($nodes as $dir) {
+            if (!$dir->isDir()) {
+                continue;
+            }
+
+            if ($dir->isDot()) {
+                continue;
+            }
+
+            $dirs[$dir->getFilename()] = $dir->getPathname();
+        }
+
+        krsort($dirs);
+
+        return new \ArrayIterator($dirs);
+    }
+}

--- a/lib/Storage/Driver/Xml/XmlDriver.php
+++ b/lib/Storage/Driver/Xml/XmlDriver.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Storage\Driver\Xml;
+
+use PhpBench\Dom\Document;
+use PhpBench\Expression\Constraint\Constraint;
+use PhpBench\Model\SuiteCollection;
+use PhpBench\Serializer\XmlDecoder;
+use PhpBench\Serializer\XmlEncoder;
+use PhpBench\Storage\DriverInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * XML storage driver.
+ *
+ * The collections are sharded by year, month and day in order that we can
+ * effectively sort them without hydrating all of the results.
+ */
+class XmlDriver implements DriverInterface
+{
+    private $path;
+    private $xmlEncoder;
+    private $xmlDecoder;
+    private $filesystem;
+
+    public function __construct($path, XmlEncoder $xmlEncoder, XmlDecoder $xmlDecoder, Filesystem $filesystem = null)
+    {
+        $this->path = $path;
+        $this->xmlEncoder = $xmlEncoder;
+        $this->xmlDecoder = $xmlDecoder;
+        $this->filesystem = $filesystem ?: new Filesystem();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function store(SuiteCollection $collection)
+    {
+        foreach ($collection->getSuites() as $suite) {
+            $path = $this->getPath($suite->getUuid());
+
+            if (false === $this->filesystem->exists(dirname($path))) {
+                $this->filesystem->mkdir(dirname($path));
+            }
+
+            $collection = new SuiteCollection([$suite]);
+            $dom = $this->xmlEncoder->encode($collection);
+            $dom->save($path);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function query(Constraint $constraint)
+    {
+        // TODO: Make this a separate interface?
+        throw new \BadMethodCallException(
+            'The XML storage driver does not support querying.'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetch($runId)
+    {
+        if (!$this->has($runId)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Cannot find run with UUID "%s"', $runId
+            ));
+        }
+
+        $path = $this->getPath($runId);
+
+        $dom = new Document();
+        $dom->load($path);
+        $collection = $this->xmlDecoder->decode($dom);
+
+        return $collection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($runId)
+    {
+        $path = $this->getPath($runId);
+
+        return $this->filesystem->exists($path);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function history()
+    {
+        return new HistoryIterator($this->xmlDecoder, $this->path);
+    }
+
+    private function getPath($uuid)
+    {
+        $date = new \DateTime(hexdec(substr($uuid, 0, 7)));
+
+        return sprintf(
+            '%s/%s/%s/%s/%s.xml',
+            $this->path,
+            dechex($date->format('Y')),
+            dechex($date->format('m')),
+            dechex($date->format('d')),
+            $uuid
+        );
+    }
+}

--- a/tests/Functional/FunctionalTestCase.php
+++ b/tests/Functional/FunctionalTestCase.php
@@ -14,6 +14,9 @@ namespace PhpBench\Tests\Functional;
 use PhpBench\DependencyInjection\Container;
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * NOTE: This is currently used only be the DBAL functional tests.
+ */
 class FunctionalTestCase extends \PHPUnit_Framework_TestCase
 {
     private $container;

--- a/tests/System/ArchiveTest.php
+++ b/tests/System/ArchiveTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Tests\System;
+
+class ArchiveTest extends SystemTestCase
+{
+    /**
+     * It should show a report for a specific run.
+     */
+    public function testArchive()
+    {
+        $this->createResult(null, ' --store');
+        $this->createResult(null, ' --store');
+        $process = $this->phpbench(
+            'archive'
+        );
+
+        $this->assertExitCode(0, $process);
+        $output = $process->getOutput();
+
+        // it should show two dots, one for each result
+        $this->assertContains(<<<'EOT'
+..
+EOT
+        , $output);
+
+        $process = $this->phpbench(
+            'archive --restore'
+        );
+
+        $output = $process->getOutput();
+        $this->assertContains(<<<'EOT'
+Restoring 0 of 2 suites
+EOT
+        , $output);
+    }
+}

--- a/tests/System/LogTest.php
+++ b/tests/System/LogTest.php
@@ -14,24 +14,16 @@ namespace PhpBench\Tests\System;
 class LogTest extends SystemTestCase
 {
     /**
-     * It should show an error when no storage engine is configured.
-     */
-    public function testExceptionWhenNoStorageConfigured()
-    {
-        $this->createResult();
-        $process = $this->phpbench(
-            'log --no-pagination'
-        );
-        $this->assertEquals(1, $process->getExitCode());
-        $output = $process->getErrorOutput();
-        $this->assertContains('You must configure a default storage service, registered storage services', $output);
-    }
-
-    /**
-     * It should show the history.
+     * It should show the log.
      */
     public function testLog()
     {
-        $this->markTestSkipped('Cannot functionaly test the log command until a default storage implementation is available.');
+        $this->createResult(null, ' --store');
+        $process = $this->phpbench(
+            'log'
+        );
+        $this->assertEquals(0, $process->getExitCode());
+        $output = $process->getOutput();
+        $this->assertCount(9, explode("\n", $output));
     }
 }

--- a/tests/System/RunTest.php
+++ b/tests/System/RunTest.php
@@ -399,8 +399,7 @@ class RunTest extends SystemTestCase
         );
 
         // because there is no storage driver by default the factory will throw an exception.
-        $this->assertExitCode(1, $process);
-        $this->assertContains('You must configure a default storage service,', $process->getErrorOutput());
+        $this->assertExitCode(0, $process);
     }
 
     /**

--- a/tests/System/ShowTest.php
+++ b/tests/System/ShowTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Tests\System;
+
+class ShowTest extends SystemTestCase
+{
+    /**
+     * It should show a report for a specific run.
+     */
+    public function testDefaultReport()
+    {
+        $document = $this->createResult(null, ' --store');
+        $uuid = $document->evaluate('string(./suite/@uuid)');
+        $process = $this->phpbench(
+            'show ' . $uuid
+        );
+
+        $this->assertExitCode(0, $process);
+        $output = $process->getOutput();
+        $this->assertContains(<<<'EOT'
++--------------+--------------+--------+--------+------+-----+------+----------+----------+----------+----------+---------+--------+-------+
+| benchmark    | subject      | groups | params | revs | its | mem  | best     | mean     | mode     | worst    | stdev   | rstdev | diff  |
++--------------+--------------+--------+--------+------+-----+------+----------+----------+----------+----------+---------+--------+-------+
+| NothingBench | benchNothing |        | []     | 1    | 1   | 100b | 10.000μs | 10.000μs | 10.000μs | 10.000μs | 0.000μs | 0.00%  | 0.00% |
++--------------+--------------+--------+--------+------+-----+------+----------+----------+----------+----------+---------+--------+-------+
+EOT
+    , $output);
+    }
+
+    /**
+     * It should show a specific report.
+     */
+    public function testSpecificReport()
+    {
+        $document = $this->createResult(null, ' --store');
+        $uuid = $document->evaluate('string(./suite/@uuid)');
+        $process = $this->phpbench(
+            'show ' . $uuid . ' --report=default'
+        );
+
+        $this->assertExitCode(0, $process);
+        $output = $process->getOutput();
+        $this->assertContains(<<<'EOT'
++--------------+--------------+--------+--------+------+------+-----+------+----------+---------+-------+
+| benchmark    | subject      | groups | params | revs | iter | rej | mem  | time     | z-value | diff  |
++--------------+--------------+--------+--------+------+------+-----+------+----------+---------+-------+
+| NothingBench | benchNothing |        | []     | 1    | 0    | 0   | 100b | 10.000μs | 0.00σ   | 0.00% |
++--------------+--------------+--------+--------+------+------+-----+------+----------+---------+-------+
+EOT
+    , $output);
+    }
+}

--- a/tests/Unit/Math/DistributionTest.php
+++ b/tests/Unit/Math/DistributionTest.php
@@ -103,4 +103,15 @@ class DistributionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(10, $stats['min']);
         $this->assertEquals(20, $stats['max']);
     }
+
+    /**
+     * It should throw an exception if a non-recognized pre-computed statistic is passed.
+     *
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Unknown pre-computed stat(s) encountered: "bar_stat", "boo_stat"
+     */
+    public function testNonRecognizedPreComputed()
+    {
+        new Distribution([10, 20], ['bar_stat' => 1, 'boo_stat' => 2]);
+    }
 }

--- a/tests/Unit/Storage/Archiver/XmlArchiverTest.php
+++ b/tests/Unit/Storage/Archiver/XmlArchiverTest.php
@@ -19,6 +19,7 @@ use PhpBench\Serializer\XmlEncoder;
 use PhpBench\Storage\Archiver\XmlArchiver;
 use PhpBench\Storage\DriverInterface;
 use PhpBench\Storage\HistoryEntry;
+use PhpBench\Tests\Util\Workspace;
 use Prophecy\Argument;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Filesystem\Filesystem;
@@ -33,7 +34,17 @@ class XmlArchiverTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->archivePath = __DIR__ . '/archive';
+        Workspace::initWorkspace();
+
+        $this->archivePath = Workspace::getWorkspacePath();
+
+        // create some files
+        $dom = new Document();
+        $dom->createRoot('hello');
+        $dom->save($this->archivePath . '/' . '1.xml');
+        $dom->save($this->archivePath . '/' . '2.txt');
+        $dom->save($this->archivePath . '/' . '2.xml');
+
         $this->registry = $this->prophesize(Registry::class);
         $this->xmlEncoder = $this->prophesize(XmlEncoder::class);
         $this->xmlDecoder = $this->prophesize(XmlDecoder::class);
@@ -55,6 +66,11 @@ class XmlArchiverTest extends \PHPUnit_Framework_TestCase
         $this->collection2 = $this->prophesize(SuiteCollection::class);
 
         $this->registry->getService()->willReturn($this->storage->reveal());
+    }
+
+    public function tearDown()
+    {
+        Workspace::cleanWorkspace();
     }
 
     /**

--- a/tests/Unit/Storage/Archiver/archive/1.xml
+++ b/tests/Unit/Storage/Archiver/archive/1.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" ?>
-<foo>
-    <title>This is a valid XML document</title>
-</foo>

--- a/tests/Unit/Storage/Archiver/archive/2.txt
+++ b/tests/Unit/Storage/Archiver/archive/2.txt
@@ -1,4 +1,0 @@
-<?xml version="1.0" ?>
-<foo>
-    <title>This is a valid XML document</title>
-</foo>

--- a/tests/Unit/Storage/Archiver/archive/2.xml
+++ b/tests/Unit/Storage/Archiver/archive/2.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" ?>
-<foo>
-    <title>This is a valid XML document</title>
-</foo>

--- a/tests/Unit/Storage/Driver/Xml/HistoryIteratorTest.php
+++ b/tests/Unit/Storage/Driver/Xml/HistoryIteratorTest.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Tests\Unit\Storage\Driver\Xml;
+
+use PhpBench\Dom\Document;
+use PhpBench\Environment\Information;
+use PhpBench\Model\Suite;
+use PhpBench\Model\SuiteCollection;
+use PhpBench\Model\Summary;
+use PhpBench\Serializer\XmlDecoder;
+use PhpBench\Storage\Driver\Xml\HistoryIterator;
+use PhpBench\Tests\Util\Workspace;
+use Prophecy\Argument;
+use Symfony\Component\Filesystem\Filesystem;
+
+class HistoryIteratorTest extends \PHPUnit_Framework_TestCase
+{
+    private $xmlDecoder;
+    private $iterator;
+    private $filesystem;
+
+    public function setUp()
+    {
+        Workspace::initWorkspace();
+
+        $this->xmlDecoder = $this->prophesize(XmlDecoder::class);
+        $this->iterator = new HistoryIterator(
+            $this->xmlDecoder->reveal(),
+            Workspace::getWorkspacePath()
+        );
+
+        $this->filesystem = new Filesystem();
+    }
+
+    /**
+     * It should "iterate" given an empty directory.
+     */
+    public function testIterateEmpty()
+    {
+        $entries = iterator_to_array($this->iterator);
+        $this->assertCount(0, $entries);
+    }
+
+    /**
+     * It should "iterate" if the directory does not exist.
+     */
+    public function testNoDirectoryExist()
+    {
+        $iterator = new HistoryIterator(
+            $this->xmlDecoder->reveal(),
+            'foobar_not_exist'
+        );
+
+        $iterator->current();
+    }
+
+    /**
+     * It should iterate over entries.
+     */
+    public function testIterate()
+    {
+        $collections = [];
+        $collections[1] = $this->createEntry(1, new \DateTime('2014-02-03'));
+        $collections[2] = $this->createEntry(2, new \DateTime('2016-01-01'));
+        $collections[3] = $this->createEntry(3, new \DateTime('2016-02-01'));
+        $collections[4] = $this->createEntry(4, new \DateTime('2016-02-03'));
+        $collections[5] = $this->createEntry(5, new \DateTime('2016-02-08 12:00:00'));
+        $collections[6] = $this->createEntry(6, new \DateTime('2016-02-08 06:00:00'));
+
+        $this->xmlDecoder->decode(Argument::type(Document::class))->will(function ($args) use (&$order, &$collections) {
+            $dom = $args[0];
+            $uuid = $dom->evaluate('number(./@uuid)');
+
+            return $collections[$uuid];
+        });
+
+        $entries = iterator_to_array($this->iterator);
+        $this->assertCount(6, $entries);
+        $first = array_shift($entries);
+        $this->assertEquals('2016-02-08 12:00:00', $first->getDate()->format('Y-m-d H:i:s'));
+        $this->assertEquals(5, $first->getNbSubjects());
+        $this->assertEquals(10, $first->getNbIterations());
+        $this->assertEquals(1000, $first->getNbRevolutions());
+        $this->assertEquals(1, $first->getMinTime());
+        $this->assertEquals(2, $first->getMaxTime());
+        $this->assertEquals(3, $first->getMeanTime());
+        $this->assertEquals(4, $first->getMeanRelStDev());
+        $this->assertEquals(5, $first->getTotalTime());
+
+        $last = array_pop($entries);
+        $this->assertEquals('2014-02-03', $last->getDate()->format('Y-m-d'));
+    }
+
+    private function createEntry($uuid, \DateTime $date)
+    {
+        $dom = new Document();
+        $test = $dom->createRoot('test');
+        $test->setAttribute('uuid', $uuid);
+        $path = Workspace::getWorkspacePath() . $date->format('/Y/m/d/') . '/' . $uuid . '.xml';
+        if (!$this->filesystem->exists(dirname($path))) {
+            $this->filesystem->mkdir(dirname($path));
+        }
+
+        $dom->save($path);
+
+        return $this->createCollection($uuid, $date);
+    }
+
+    private function createCollection($uuid, \DateTime $date)
+    {
+        $collection = $this->prophesize(SuiteCollection::class);
+        $suite = $this->prophesize(Suite::class);
+        $summary = $this->prophesize(Summary::class);
+
+        $collection->getSuites()->willReturn([$suite->reveal()]);
+        $suite->getUuid()->willReturn($uuid);
+        $suite->getDate()->willReturn($date);
+        $suite->getContextName()->willReturn('foo');
+        $suite->getEnvInformations()->willReturn([
+            'vcs' => [
+                'branch' => 'foo_branch',
+            ],
+        ]);
+        $suite->getSummary()->willReturn($summary->reveal());
+        $summary->getNbSubjects()->willReturn(5);
+        $summary->getNbIterations()->willReturn(10);
+        $summary->getNbRevolutions()->willReturn(1000);
+        $summary->getMinTime()->willReturn(1);
+        $summary->getMaxTime()->willReturn(2);
+        $summary->getMeanTime()->willReturn(3);
+        $summary->getMeanRelStDev()->willReturn(4);
+        $summary->getTotalTime()->willReturn(5);
+
+        return $collection;
+    }
+}

--- a/tests/Unit/Storage/Driver/Xml/XmlDriverTest.php
+++ b/tests/Unit/Storage/Driver/Xml/XmlDriverTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Tests\Unit\Storage\Driver\Xml;
+
+use PhpBench\Dom\Document;
+use PhpBench\Model\Suite;
+use PhpBench\Model\SuiteCollection;
+use PhpBench\Serializer\XmlDecoder;
+use PhpBench\Serializer\XmlEncoder;
+use PhpBench\Storage\Driver\Xml\HistoryIterator;
+use PhpBench\Storage\Driver\Xml\XmlDriver;
+use Prophecy\Argument;
+use Symfony\Component\Filesystem\Filesystem;
+
+class XmlDriverTest extends \PHPUnit_Framework_TestCase
+{
+    private $xmlEncoder;
+    private $xmlDecoder;
+    private $filesystem;
+    private $collection;
+    private $suite;
+
+    /**
+     * @var mixed
+     */
+    private $document;
+
+    public function setUp()
+    {
+        $this->xmlEncoder = $this->prophesize(XmlEncoder::class);
+        $this->xmlDecoder = $this->prophesize(XmlDecoder::class);
+        $this->filesystem = $this->prophesize(Filesystem::class);
+
+        $this->driver = new XmlDriver(
+            '/path/to',
+            $this->xmlEncoder->reveal(),
+            $this->xmlDecoder->reveal(),
+            $this->filesystem->reveal()
+        );
+
+        $this->collection = $this->prophesize(SuiteCollection::class);
+        $this->suite = $this->prophesize(Suite::class);
+        $this->document = $this->prophesize(Document::class);
+    }
+
+    /**
+     * It should store a suite collection.
+     */
+    public function testStore()
+    {
+        $this->collection->getSuites()->willReturn([
+            $this->suite->reveal(),
+        ]);
+        $this->suite->getUuid()->willReturn($uuid = '1339f38b191b77e1185f9729eb25a2aa4e262b01');
+        $this->filesystem->exists('/path/to/7e0/3/c')->willReturn(true);
+        $this->xmlEncoder->encode(Argument::type(SuiteCollection::class))->shouldBeCalled()
+            ->willReturn($this->document->reveal());
+        $this->document->save('/path/to/7e0/3/c/' . $uuid . '.xml')->shouldBeCalled();
+
+        $this->driver->store($this->collection->reveal());
+    }
+
+    /**
+     * It should create a non existing directory when storing the collection.
+     */
+    public function testStoreMkdir()
+    {
+        $this->collection->getSuites()->willReturn([
+            $this->suite->reveal(),
+        ]);
+        $this->suite->getUuid()->willReturn($uuid = '1339f38b191b77e1185f9729eb25a2aa4e262b01');
+        $this->filesystem->exists('/path/to/7e0/3/c')->willReturn(false);
+        $this->filesystem->mkdir('/path/to/7e0/3/c')->shouldBeCalled();
+        $this->xmlEncoder->encode(Argument::type(SuiteCollection::class))->shouldBeCalled()
+            ->willReturn($this->document->reveal());
+        $this->document->save('/path/to/7e0/3/c/' . $uuid . '.xml')->shouldBeCalled();
+
+        $this->driver->store($this->collection->reveal());
+    }
+
+    /**
+     * It should throw an exception if it cannot locate a given run by UUID.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Cannot find run with UUID
+     */
+    public function testFetch()
+    {
+        $uuid = '1339f38b191b77e1185f9729eb25a2aa4e262b01';
+        $this->filesystem->exists('/path/to/7e0/3/c/' . $uuid . '.xml')->willReturn(false);
+
+        $this->driver->fetch($uuid);
+    }
+
+    /**
+     * It should return true if ->has is called and the collection exists.
+     */
+    public function testHas()
+    {
+        $uuid = '1339f38b191b77e1185f9729eb25a2aa4e262b01';
+        $this->filesystem->exists('/path/to/7e0/3/c/' . $uuid . '.xml')->willReturn(true);
+
+        $this->assertTrue($this->driver->has($uuid));
+    }
+
+    /**
+     * It should return the history iterator.
+     */
+    public function testGetHistoryIterator()
+    {
+        $history = $this->driver->history();
+        $this->assertInstanceOf(HistoryIterator::class, $history);
+    }
+}

--- a/tests/Util/Workspace.php
+++ b/tests/Util/Workspace.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Tests\Util;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+class Workspace
+{
+    public static function getWorkspacePath()
+    {
+        $path = sys_get_temp_dir() . '/phpbench_test_workspace';
+
+        return $path;
+    }
+
+    public static function cleanWorkspace()
+    {
+        $filesystem = new Filesystem();
+        $path = self::getWorkspacePath();
+        if (file_exists($path)) {
+            $filesystem->remove($path);
+        }
+    }
+
+    public static function initWorkspace()
+    {
+        self::cleanWorkspace();
+        $filesystem = new Filesystem();
+        $filesystem->mkdir(self::getWorkspacePath());
+    }
+}


### PR DESCRIPTION
This is an XML only storage driver, it does not support querying, and can be used as a default driver when the DBAL storage engine is not being used.

This PR introduces a `phpbench show` command which can be used to explicitly show (via. a report) the results of a *specific* benchmark - this is useful in general but especially here as the `report` command relies upon the query feature.