### PR TITLE
Fixed bootstrap require scope

### DIFF
--- a/lib/Benchmark/Executor/template/benchmark_static_methods.template
+++ b/lib/Benchmark/Executor/template/benchmark_static_methods.template
@@ -6,7 +6,9 @@ $methods = {{ methods }};
 $bootstrap = '{{ bootstrap }}';
 
 if ($bootstrap) {
-    require_once($bootstrap);
+    call_user_func(function () use ($bootstrap) {
+        require_once($bootstrap);
+    });
 }
 
 require_once($file);

--- a/lib/Benchmark/Executor/template/microtime.template
+++ b/lib/Benchmark/Executor/template/microtime.template
@@ -17,7 +17,9 @@ $parameters = {{ parameters }};
 $warmup = {{ warmup }};
 
 if ($bootstrap) {
-    require_once($bootstrap);
+    call_user_func(function () use ($bootstrap) {
+        require_once($bootstrap);
+    });
 }
 
 require_once($file);

--- a/lib/Benchmark/Remote/template/parameter_set_extractor.template
+++ b/lib/Benchmark/Remote/template/parameter_set_extractor.template
@@ -7,7 +7,9 @@ $file = '{{ file }}';
 $class = '{{ class }}';
 
 if ($bootstrap) {
-    require_once($bootstrap);
+    call_user_func(function () use ($bootstrap) {
+        require_once($bootstrap);
+    });
 }
 
 require_once($file);

--- a/lib/Benchmark/Remote/template/reflector.template
+++ b/lib/Benchmark/Remote/template/reflector.template
@@ -7,7 +7,9 @@ $class = '{{ class }}';
 $file = '{{ file }}';
 
 if ($bootstrap) {
-    require_once($bootstrap);
+    call_user_func(function () use ($bootstrap) {
+        require_once($bootstrap);
+    });
 }
 
 require_once($file);

--- a/tests/System/RunTest.php
+++ b/tests/System/RunTest.php
@@ -233,6 +233,20 @@ class RunTest extends SystemTestCase
     }
 
     /**
+     * It should set the bootstrap file which contains variables that conflict with the
+     * script templates.
+     */
+    public function testSetConflictBootstrap()
+    {
+        // The foobar_bootstrap defines a single class which is used by FoobarBench
+        $process = $this->phpbench(
+            'run --bootstrap=bootstrap/conflicting.bootstrap benchmarks/set2/FoobarBench.php'
+        );
+
+        $this->assertExitCode(0, $process);
+    }
+
+    /**
      * It should set the bootstrap using the short option.
      */
     public function testSetBootstrapShort()

--- a/tests/System/bootstrap/conflicting.bootstrap
+++ b/tests/System/bootstrap/conflicting.bootstrap
@@ -1,0 +1,9 @@
+<?php
+
+namespace Test;
+
+$file = 'foobar';
+
+class Foobar
+{
+}


### PR DESCRIPTION
Bootstrap files are currently included directly into the remote scripts, which means that any variables they have can overwrite any previously declared variable.

This PR scopes the `require` in an anonymous function call.