### PR TITLE
Non-strict JSON parser

### DIFF
--- a/lib/Json/JsonDecoder.php
+++ b/lib/Json/JsonDecoder.php
@@ -47,28 +47,116 @@ class JsonDecoder
     }
 
     /**
-     * Taken from: https://gist.github.com/larruda/967110d74d98c1cd4ee1.
+     * Allow "non-strict" JSON - i.e. if no quotes are provided then try and
+     * add them.
      */
     private function normalize($jsonString)
     {
         if (!is_string($jsonString)) {
             throw new \InvalidArgumentException(sprintf(
-                'Expected a string, got a "%s"',
-                is_object($jsonString) ? get_class($jsonString) : gettype($jsonString)
+                'Expected a string, got "%s"',
+                gettype($jsonString)
             ));
         }
+        $chars = str_split($jsonString);
+        $inRight = $inQuote = $inFakeQuote = false;
+        $fakeQuoteStart = null;
+        $addedStartBracket = false;
 
-        if (substr($jsonString, 0, 1) !== '{') {
-            $jsonString = '{' . $jsonString;
-            $jsonString = $jsonString . '}';
+        if (empty($chars)) {
+            return;
         }
 
-        $jsonString = preg_replace(
-            '{(\s*?\{\s*?|\s*?,\s*?)([\'"])?([\$\.a-zA-Z0-9\[\]\_]+)([\'"])?:}',
-            '\1"\3":',
-            $jsonString
-        );
+        if ($chars[0] !== '{') {
+            array_unshift($chars, '{');
+            $addedStartBracket = true;
+        }
 
-        return $jsonString;
+        for ($index = 0; $index < count($chars); $index++) {
+            $char = $chars[$index];
+            $prevChar = isset($chars[$index - 1]) ? $chars[$index - 1] : null;
+
+            if (!$inQuote && $prevChar == ':') {
+                $inRight = true;
+            }
+
+            if (!$inQuote && preg_match('{\{,}', $char)) {
+                $inRight = false;
+            }
+
+            // detect start of unquoted string
+            if (!$inQuote && preg_match('{[\$a-zA-Z0-9]}', $char)) {
+                array_splice($chars, $index, 0, '"');
+                $fakeQuoteStart = $index;
+                $index++;
+                $inQuote = $inFakeQuote = true;
+                continue;
+            }
+
+            // if we added a "fake" quote, look for the end of the unquoted string
+            if ($inFakeQuote && preg_match('{[\s:\}\],]}', $char)) {
+                // if we are on the left side, then "]" is OK.
+                if (!$inRight && $char === ']') {
+                    continue;
+                }
+
+                if ($inRight) {
+
+                    // extract the right hand value
+                    $string = implode('', array_slice($chars, $fakeQuoteStart + 1, $index - 1 - $fakeQuoteStart));
+
+                    // if it is a number, then we don't quote it
+                    if (is_numeric($string)) {
+                        unset($chars[$fakeQuoteStart]);
+                        $chars = array_values($chars);
+                        $inQuote = $inFakeQuote = false;
+                        $index--;
+                        continue;
+                    }
+
+                    // if it is a boolean, then we don't quote it
+                    if (in_array($string, ['true', 'false'])) {
+                        unset($chars[$fakeQuoteStart]);
+                        $chars = array_values($chars);
+                        $inQuote = $inFakeQuote = false;
+                        $index--;
+                        continue;
+                    }
+                }
+
+                // add the ending quote
+                array_splice($chars, $index, 0, '"');
+                $index++;
+                $inQuote = $inFakeQuote = false;
+                continue;
+            }
+
+            // enter standard quote mode
+            if (!$inQuote && $char === '"') {
+                $inQuote = true;
+                continue;
+            }
+
+            // if we are in quote mode and encounter a closing quote, and the last character
+            // was not the escape character
+            if ($inQuote && $char === '"' && $prevChar !== '\\') {
+                $inQuote = $inFakeQuote = false;
+                continue;
+            }
+        }
+
+        // if we were in a fake quote and hit the end, then add the closing quote
+        if ($inFakeQuote) {
+            $chars[] = '"';
+        }
+
+        $normalized = implode('', $chars);
+
+        // if we added a bracket at the begining, then add one to the end if required
+        if ($addedStartBracket) {
+            $normalized .= '}';
+        }
+
+        return $normalized;
     }
 }

--- a/tests/Unit/Json/JsonDecoderTest.php
+++ b/tests/Unit/Json/JsonDecoderTest.php
@@ -37,8 +37,24 @@ class JsonDecoderTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [
-                '{$eq: "barfoo"}',
-                ['$eq' => 'barfoo'],
+                'foo: false, bar: true, baz: [ 10, "10", true]',
+                [
+                    'foo' => false,
+                    'bar' => true,
+                    'baz' => [10, '10', true],
+                ],
+            ],
+            [
+                '{"extends": "aggregate", "foo": ["bar"]}',
+                ['extends' => 'aggregate', 'foo' => ['bar']],
+            ],
+            [
+                '{extends: aggregate, foo: ["bar"]}',
+                ['extends' => 'aggregate', 'foo' => ['bar']],
+            ],
+            [
+                '{$eq: "bar\"foo"}',
+                ['$eq' => 'bar"foo'],
             ],
             [
                 '{foobar: "barfoo"}',
@@ -98,6 +114,17 @@ class JsonDecoderTest extends \PHPUnit_Framework_TestCase
             [
                 'foo_bar: 5',
                 ['foo_bar' => 5],
+            ],
+            [
+                'generator: "table", compare: "subject", compare_fields:[ "mode"], break: ["revs"], cols: ["benchmark"], sort: {"subject:benchGetOptimized:mode": "asc"}',
+                [
+                    'generator' => 'table',
+                    'compare' => 'subject',
+                    'compare_fields' => ['mode'],
+                    'break' => ['revs'],
+                    'cols' => ['benchmark'],
+                    'sort' => ['subject:benchGetOptimized:mode' => 'asc'],
+                ],
             ],
         ];
     }

--- a/tests/Unit/Registry/ConfigurableRegistryTest.php
+++ b/tests/Unit/Registry/ConfigurableRegistryTest.php
@@ -232,7 +232,7 @@ class ConfigurableRegistryTest extends RegistryTest
         $this->service1->getDefaultConfig()->willReturn([]);
         $this->service1->getSchema()->willReturn([]);
 
-        $result = $this->registry->getConfig('{test": service}');
+        $result = $this->registry->getConfig('{tes  t: se  rvice');
         $this->assertEquals(new Config('test', [
             'test' => 'service',
         ]), $result);


### PR DESCRIPTION
Introduces a JSON normalizer for "non-strict" JSON, replacing the original and flawed `preg_replace`.

Fixes #383