### PR TITLE
Allow configuration of launcher.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -159,3 +159,33 @@ Similarly the :ref:`mode` can be set using the `output_mode` key:
     {
         "output_mode": "throughput"
     }
+
+PHP Binary and INI settings
+---------------------------
+
+You can change the PHP binary and INI settings used to execute the benchmarks:
+
+.. code-block:: javascript
+
+    {
+        "php_binary": "hhvm",
+        "php_config": {
+            "memory_limit": "10M"
+        }
+    }
+
+Prefixing the Benchmarking Process
+----------------------------------
+
+You can prefix the benchmarking command line using the ``php_wrapper`` option:
+
+.. code-block:: javascript
+
+    {
+        "php_wrapper": "blackfire run"
+    }
+
+.. note::
+
+    This can also be set using the ``--php-wrapper`` CLI option.
+

--- a/extensions/xdebug/lib/Executor/XDebugExecutor.php
+++ b/extensions/xdebug/lib/Executor/XDebugExecutor.php
@@ -62,7 +62,8 @@ class XDebugExecutor extends BaseExecutor
     public function getDefaultConfig()
     {
         return [
-            'callback' => function () {},
+            'callback' => function () {
+            },
             'output_dir' => 'profile',
         ];
     }

--- a/lib/Benchmark/Remote/Payload.php
+++ b/lib/Benchmark/Remote/Payload.php
@@ -37,7 +37,7 @@ class Payload
     /**
      * Path to PHP binary.
      */
-    private $phpPath = PHP_BINARY;
+    private $phpBinary;
 
     /**
      * Tokens to substitute in the script template.
@@ -55,14 +55,15 @@ class Payload
      *
      * @param string $template
      */
-    public function __construct($template, array $tokens = [], Process $process = null)
+    public function __construct($template, array $tokens = [], $phpBinary = PHP_BINARY, Process $process = null)
     {
         $this->template = $template;
-        $this->process = $process ?: new Process($this->phpPath);
+        $this->process = $process ?: new Process($phpBinary);
         $this->tokens = $tokens;
 
         // disable timeout.
         $this->process->setTimeout(null);
+        $this->phpBinary = $phpBinary;
     }
 
     public function setWrapper($wrapper)
@@ -75,9 +76,9 @@ class Payload
         $this->phpConfig = $phpConfig;
     }
 
-    public function setPhpPath($phpPath)
+    public function setPhpPath($phpBinary)
     {
-        $this->phpPath = $phpPath;
+        $this->phpBinary = $phpBinary;
     }
 
     public function launch()
@@ -109,7 +110,7 @@ class Payload
             $wrapper = $this->wrapper . ' ';
         }
 
-        $this->process->setCommandLine($wrapper . $this->phpPath . $this->getIniString() . ' ' . escapeshellarg($scriptPath));
+        $this->process->setCommandLine($wrapper . $this->phpBinary . $this->getIniString() . ' ' . escapeshellarg($scriptPath));
         $this->process->run();
         unlink($scriptPath);
 

--- a/lib/Benchmark/Remote/PayloadFactory.php
+++ b/lib/Benchmark/Remote/PayloadFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Benchmark\Remote;
+
+class PayloadFactory
+{
+    public function create($template, array $tokens = [], $phpBinary = null)
+    {
+        return new Payload($template, $tokens, $phpBinary);
+    }
+}

--- a/lib/Console/CharacterReader.php
+++ b/lib/Console/CharacterReader.php
@@ -22,7 +22,8 @@ class CharacterReader
         // we could use extension_loaded but HHVM returns true and
         // still doesn't have this function..
         if (function_exists('readline_callback_handler_install')) {
-            readline_callback_handler_install('', function () { });
+            readline_callback_handler_install('', function () {
+            });
         }
     }
 

--- a/lib/Console/Command/Handler/RunnerHandler.php
+++ b/lib/Console/Command/Handler/RunnerHandler.php
@@ -53,6 +53,11 @@ class RunnerHandler
         $command->addOption('group', [], InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Group to run (can be specified multiple times)');
         $command->addOption('executor', [], InputOption::VALUE_REQUIRED, 'Executor to use', 'microtime');
         $command->addOption('stop-on-error', [], InputOption::VALUE_NONE, 'Stop on the first error encountered.');
+
+        // Launcher options (processed in PhpBench.php before the container is initialized).
+        $command->addOption('php-binary', null, InputOption::VALUE_REQUIRED, 'Alternative PHP binary to use');
+        $command->addOption('php-config', null, InputOption::VALUE_REQUIRED, 'JSON-like object of PHP INI settings');
+        $command->addOption('php-wrapper', null, InputOption::VALUE_REQUIRED, 'Prefix process launch command with this string');
     }
 
     public function runFromInput(InputInterface $input, OutputInterface $output, array $options = [])

--- a/lib/Environment/Provider/Php.php
+++ b/lib/Environment/Provider/Php.php
@@ -11,6 +11,7 @@
 
 namespace PhpBench\Environment\Provider;
 
+use PhpBench\Benchmark\Remote\Launcher;
 use PhpBench\Environment\Information;
 use PhpBench\Environment\ProviderInterface;
 
@@ -19,6 +20,15 @@ use PhpBench\Environment\ProviderInterface;
  */
 class Php implements ProviderInterface
 {
+    private $launcher;
+    private $remoteVersion;
+
+    public function __construct(Launcher $launcher, $remoteVersion = false)
+    {
+        $this->launcher = $launcher;
+        $this->remoteVersion = $remoteVersion;
+    }
+
     public function isApplicable()
     {
         return true;
@@ -28,9 +38,19 @@ class Php implements ProviderInterface
     {
         return new Information(
             'php',
-            [
-                'version' => PHP_VERSION,
-            ]
+            $this->getData()
         );
+    }
+
+    private function getData()
+    {
+        if (false === $this->remoteVersion) {
+            return ['version' => phpversion()];
+        }
+
+        return $this->launcher->payload(
+            __DIR__ . '/template/php.template',
+            []
+        )->launch();
     }
 }

--- a/lib/Environment/Provider/template/php.template
+++ b/lib/Environment/Provider/template/php.template
@@ -1,0 +1,7 @@
+<?php
+
+echo json_encode([
+    'version' => phpversion()
+]);
+
+exit(0);

--- a/lib/Math/Distribution.php
+++ b/lib/Math/Distribution.php
@@ -32,13 +32,27 @@ class Distribution implements \IteratorAggregate
 
         $this->samples = $samples;
         $this->closures = [
-            'min' => function () { return min($this->samples); },
-            'max' => function () { return max($this->samples); },
-            'sum' => function () { return array_sum($this->samples); },
-            'stdev' => function () { return Statistics::stdev($this->samples); },
-            'mean' => function () { return Statistics::mean($this->samples); },
-            'mode' => function () { return Statistics::kdeMode($this->samples); },
-            'variance' => function () { return Statistics::variance($this->samples); },
+            'min' => function () {
+                return min($this->samples);
+            },
+            'max' => function () {
+                return max($this->samples);
+            },
+            'sum' => function () {
+                return array_sum($this->samples);
+            },
+            'stdev' => function () {
+                return Statistics::stdev($this->samples);
+            },
+            'mean' => function () {
+                return Statistics::mean($this->samples);
+            },
+            'mode' => function () {
+                return Statistics::kdeMode($this->samples);
+            },
+            'variance' => function () {
+                return Statistics::variance($this->samples);
+            },
             'rstdev' => function () {
                 $mean = $this->getMean();
 

--- a/lib/Math/Kde.php
+++ b/lib/Math/Kde.php
@@ -164,7 +164,9 @@ class Kde
 
             // numpy sum does nothing with our 2d array in PHP
             // $energy = array_sum(diff * tdiff, axis=0) / 2.0
-            $energy = array_map(function ($v) { return exp(-($v / 2)); }, $multiplied);
+            $energy = array_map(function ($v) {
+                return exp(-($v / 2));
+            }, $multiplied);
 
             if ($bigger) {
                 $sum = $result;
@@ -177,7 +179,9 @@ class Kde
             }
         }
 
-        $result = array_map(function ($v) { return $v / $this->normFactor; }, $result);
+        $result = array_map(function ($v) {
+            return $v / $this->normFactor;
+        }, $result);
 
         return $result;
     }

--- a/tests/System/RunTest.php
+++ b/tests/System/RunTest.php
@@ -441,4 +441,15 @@ class RunTest extends SystemTestCase
         );
         $this->assertExitCode(0, $process);
     }
+
+    /**
+     * It should set the PHP binary, wrapper and config.
+     */
+    public function testPhpEnvOptions()
+    {
+        $process = $this->phpbench(
+            'run benchmarks/set4/NothingBench.php --php-binary=php --php-config="memory_limit: 10M" --php-wrapper="env"'
+        );
+        $this->assertExitCode(0, $process);
+    }
 }

--- a/tests/Unit/Benchmark/Executor/DebugExecutorTest.php
+++ b/tests/Unit/Benchmark/Executor/DebugExecutorTest.php
@@ -54,7 +54,9 @@ class DebugExecutorTest extends \PHPUnit_Framework_TestCase
             }
         }
 
-        $times = array_map(function ($result) { return $result->getTime(); }, $results);
+        $times = array_map(function ($result) {
+            return $result->getTime();
+        }, $results);
 
         $this->assertEquals($expectedTimes, $times);
     }

--- a/tests/Unit/Benchmark/Remote/PayloadFactoryTest.php
+++ b/tests/Unit/Benchmark/Remote/PayloadFactoryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Tests\Unit\Benchmark\Remote;
+
+use PhpBench\Benchmark\Remote\Payload;
+use PhpBench\Benchmark\Remote\PayloadFactory;
+
+class PayloadFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    private $factory;
+
+    public function setUp()
+    {
+        $this->factory = new PayloadFactory();
+    }
+
+    /**
+     * It should create a new payload.
+     */
+    public function testCreate()
+    {
+        $payload = $this->factory->create('template', ['token' => 'one'], '/path/to/php');
+        $this->assertInstanceOf(Payload::class, $payload);
+    }
+}

--- a/tests/Unit/Benchmark/Remote/PayloadTest.php
+++ b/tests/Unit/Benchmark/Remote/PayloadTest.php
@@ -68,6 +68,7 @@ class PayloadTest extends \PHPUnit_Framework_TestCase
         $payload = new Payload(
             __DIR__ . '/template/foo.template',
             [],
+            null,
             $process->reveal()
         );
         $payload->setPhpPath('/foo/bar');
@@ -88,6 +89,7 @@ class PayloadTest extends \PHPUnit_Framework_TestCase
         $payload = new Payload(
             __DIR__ . '/template/foo.template',
             [],
+            null,
             $process->reveal()
         );
         $payload->setPhpConfig([
@@ -112,6 +114,7 @@ class PayloadTest extends \PHPUnit_Framework_TestCase
         $payload = new Payload(
             __DIR__ . '/template/foo.template',
             [],
+            null,
             $process->reveal()
         );
         $payload->setWrapper('bockfire');
@@ -136,6 +139,7 @@ class PayloadTest extends \PHPUnit_Framework_TestCase
         $payload = new Payload(
             __DIR__ . '/template/not-existing-filename.template',
             [],
+            null,
             $process->reveal()
         );
 

--- a/tests/Unit/Benchmark/Remote/ReflectorTest.php
+++ b/tests/Unit/Benchmark/Remote/ReflectorTest.php
@@ -20,7 +20,7 @@ class ReflectorTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $executor = new Launcher(__DIR__ . '/../../../../vendor/autoload.php', null);
+        $executor = new Launcher(null, null, __DIR__ . '/../../../../vendor/autoload.php', null);
         $this->reflector = new Reflector($executor);
     }
 

--- a/tests/Unit/Math/KdeTest.php
+++ b/tests/Unit/Math/KdeTest.php
@@ -27,7 +27,9 @@ class KdeTest extends \PHPUnit_Framework_TestCase
         $result = $kde->evaluate($space);
 
         // round result
-        $result = array_map(function ($v) { return round($v, 8); }, $result);
+        $result = array_map(function ($v) {
+            return round($v, 8);
+        }, $result);
 
         $this->assertEquals($expected, $result);
     }


### PR DESCRIPTION
- Specify PHP binary
- Specify PHP ini settings
- Specify PHP wrapper

CLI:

```bash
$ phpbench run --php-binary=php7.0 --php-wrapper="blackfire run" --php-ini='memory_limit: 500, foobar: "foo"'
```

Or in configuration:

```yaml
{
    "php_binary": "hhvm",
    "php_wrapper": "tideways",
    "php_ini": {
        "memory_limit": 10
    }
}
```