### PR TITLE
Allow results to be overridden.

### DIFF
--- a/extensions/dbal/lib/Storage/Driver/Dbal/Persister.php
+++ b/extensions/dbal/lib/Storage/Driver/Dbal/Persister.php
@@ -102,7 +102,7 @@ class Persister
                             $iterationDatas[] = [
                                 'time' => $iteration->getMetric(TimeResult::class, 'net', null),
                                 'memory' => $iteration->getMetricOrDefault(MemoryResult::class, 'peak', -1),
-                                'reject_count' => $iteration->getMetricOrDefault(RejectionCountResult::class, 'rejection_count', 0),
+                                'reject_count' => $iteration->getMetricOrDefault(RejectionCountResult::class, 'count', 0),
                                 'variant_id' => $variantId,
                             ];
                         }

--- a/extensions/xdebug/lib/Executor/XDebugExecutor.php
+++ b/extensions/xdebug/lib/Executor/XDebugExecutor.php
@@ -17,7 +17,6 @@ use PhpBench\Extensions\XDebug\XDebugUtil;
 use PhpBench\Model\Iteration;
 use PhpBench\Model\Result\MemoryResult;
 use PhpBench\Model\Result\TimeResult;
-use PhpBench\Model\ResultCollection;
 use PhpBench\PhpBench;
 use PhpBench\Registry\Config;
 
@@ -54,8 +53,8 @@ class XDebugExecutor extends BaseExecutor
 
 
         $callback($iteration, $result);
-        $iteration->addResult(new TimeResult($result['time']));
-        $iteration->addResult(MemoryResult::fromArray($result['mem']));
+        $iteration->setResult(new TimeResult($result['time']));
+        $iteration->setResult(MemoryResult::fromArray($result['mem']));
 
         return $result;
     }

--- a/lib/Benchmark/Executor/DebugExecutor.php
+++ b/lib/Benchmark/Executor/DebugExecutor.php
@@ -24,7 +24,8 @@ use PhpBench\Registry\Config;
  */
 class DebugExecutor extends BaseExecutor
 {
-    private $collectionTimes = [];
+    private $variantTimes = [];
+    private $index = 0;
 
     /**
      * {@inheritdoc}
@@ -33,23 +34,26 @@ class DebugExecutor extends BaseExecutor
     {
         // add 100 bytes of memory.
         $memory = 100;
-        $iteration->addResult(new MemoryResult($memory, $memory, $memory));
+        $iteration->setResult(new MemoryResult($memory, $memory, $memory));
 
         if (!$config['times']) {
-            $iteration->addResult(new TimeResult(0));
+            $iteration->setResult(new TimeResult(0));
 
             return;
         }
 
-        $collectionHash = spl_object_hash($iteration->getVariant());
+        $variantHash = spl_object_hash($iteration->getVariant());
 
-        if (isset($this->collectionTimes[$collectionHash])) {
-            $time = $this->collectionTimes[$collectionHash];
-        } else {
-            $index = count($this->collectionTimes) % count($config['times']);
-            $time = $config['times'][$index];
-            $this->collectionTimes[$collectionHash] = $time;
+        if (!isset($this->variantTimes[$variantHash])) {
+            $this->variantTimes[$variantHash] = $config['times'];
         }
+
+        if (!isset($this->variantTimes[$variantHash][$this->index])) {
+            $this->index = 0;
+        }
+
+        $time = $this->variantTimes[$variantHash][$this->index];
+        $this->index++;
 
         if ($config['spread']) {
             $index = $iteration->getIndex() % count($config['spread']);
@@ -57,7 +61,7 @@ class DebugExecutor extends BaseExecutor
             $time = $time + $spreadDiff;
         }
 
-        $iteration->addResult(new TimeResult($time));
+        $iteration->setResult(new TimeResult($time));
     }
 
     /**

--- a/lib/Benchmark/Executor/MicrotimeExecutor.php
+++ b/lib/Benchmark/Executor/MicrotimeExecutor.php
@@ -43,8 +43,8 @@ class MicrotimeExecutor extends BaseExecutor
             ));
         }
 
-        $iteration->addResult(new TimeResult($result['time']));
-        $iteration->addResult(MemoryResult::fromArray($result['mem']));
+        $iteration->setResult(new TimeResult($result['time']));
+        $iteration->setResult(MemoryResult::fromArray($result['mem']));
     }
 
     /**

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -219,7 +219,7 @@ class Runner
             }
             $variant->computeStats();
             $this->logger->variantEnd($variant);
-            $reject->replaceResult(new RejectionCountResult($rejectCount[spl_object_hash($reject)]));
+            $reject->setResult(new RejectionCountResult($rejectCount[spl_object_hash($reject)]));
         }
     }
 

--- a/lib/Model/Result/RejectionCountResult.php
+++ b/lib/Model/Result/RejectionCountResult.php
@@ -24,7 +24,7 @@ class RejectionCountResult implements ResultInterface
     public static function fromArray(array $values)
     {
         return new self(
-            (int) $values['rejection_count']
+            (int) $values['count']
         );
     }
 
@@ -46,12 +46,12 @@ class RejectionCountResult implements ResultInterface
     public function getMetrics()
     {
         return [
-            'rejection_count' => $this->rejectCount,
+            'count' => $this->rejectCount,
         ];
     }
 
     public function getKey()
     {
-        return 'rejection_count';
+        return 'reject';
     }
 }

--- a/lib/Model/ResultCollection.php
+++ b/lib/Model/ResultCollection.php
@@ -24,7 +24,7 @@ class ResultCollection
     public function __construct(array $results = [])
     {
         foreach ($results as $result) {
-            $this->addResult($result);
+            $this->setResult($result);
         }
     }
 
@@ -35,29 +35,10 @@ class ResultCollection
      *
      * @param ResultInterface
      */
-    public function addResult(ResultInterface $result)
+    public function setResult(ResultInterface $result)
     {
         $class = get_class($result);
-
-        if (isset($this->results[$class])) {
-            throw new \InvalidArgumentException(sprintf(
-                'Result of class "%s" has already been set.',
-                $class
-            ));
-        }
-
         $this->results[$class] = $result;
-    }
-
-    /**
-     * Replace any result of the class of the given object with the given
-     * object.
-     *
-     * @param ResultInterface $result
-     */
-    public function replaceResult(ResultInterface $result)
-    {
-        $this->results[get_class($result)] = $result;
     }
 
     /**

--- a/lib/Model/Variant.php
+++ b/lib/Model/Variant.php
@@ -222,7 +222,7 @@ class Variant implements \IteratorAggregate, \ArrayAccess, \Countable
                 }
             }
 
-            $iteration->replaceResult(new ComputedResult($zValue, $deviation));
+            $iteration->setResult(new ComputedResult($zValue, $deviation));
         }
 
         $this->computed = true;

--- a/lib/Serializer/XmlDecoder.php
+++ b/lib/Serializer/XmlDecoder.php
@@ -235,7 +235,7 @@ class XmlDecoder
 
             $iteration = $variant->createIteration();
             foreach ($results as $resultKey => $resultData) {
-                $iteration->addResult(call_user_func_array([
+                $iteration->setResult(call_user_func_array([
                     $resultClasses[$resultKey],
                     'fromArray',
                 ], [$resultData]));

--- a/tests/System/RunTest.php
+++ b/tests/System/RunTest.php
@@ -355,11 +355,17 @@ class RunTest extends SystemTestCase
      */
     public function testRetryThreshold()
     {
+        // use the debug executor, providing 3 groups of 4 iterations. the
+        // first two are out of bounds the third is constant.
         $process = $this->phpbench(
-            'run benchmarks/set4/NothingBench.php --retry-threshold=50'
+            'run benchmarks/set4/NothingBench.php ' .
+            '--executor=\'{"executor": "debug", "times": [10, 100, 10, 100, 50, 500, 50, 500, 1, 1, 1, 1]}\' '.
+            '--retry-threshold=1 --iterations=2 '.
+            '--dump'
         );
-
         $this->assertExitCode(0, $process);
+        $output = $process->getOutput();
+        $this->assertContains(' reject-count="4"', $output);
     }
 
     /**

--- a/tests/Unit/Benchmark/Executor/DebugExecutorTest.php
+++ b/tests/Unit/Benchmark/Executor/DebugExecutorTest.php
@@ -41,15 +41,15 @@ class DebugExecutorTest extends \PHPUnit_Framework_TestCase
     {
         $actualTimes = [];
         for ($i = 0; $i < $nbCollections; $i++) {
-            $collection = $this->prophesize(Variant::class);
+            $variant = $this->prophesize(Variant::class);
             for ($ii = 0; $ii < $nbIterations; $ii++) {
                 $iteration = $this->prophesize(Iteration::class);
-                $iteration->getVariant()->willReturn($collection->reveal());
+                $iteration->getVariant()->willReturn($variant->reveal());
                 $iteration->getIndex()->willReturn($ii);
-                $iteration->addResult(Argument::type(TimeResult::class))->will(function ($args) use (&$actualTimes) {
+                $iteration->setResult(Argument::type(TimeResult::class))->will(function ($args) use (&$actualTimes) {
                     $actualTimes[] = $args[0]->getNet();
                 });
-                $iteration->addResult(Argument::type(MemoryResult::class))->shouldBeCalled();
+                $iteration->setResult(Argument::type(MemoryResult::class))->shouldBeCalled();
 
                 $this->executor->execute(
                     $this->subjectMetadata->reveal(),
@@ -87,28 +87,28 @@ class DebugExecutorTest extends \PHPUnit_Framework_TestCase
                 [],
                 2,
                 4,
-                [10, 10, 10, 10, 20, 20, 20, 20],
+                [10, 20, 30, 40, 10, 20, 30, 40],
             ],
             [
                 [1, 2],
                 [],
                 4,
                 2,
-                [1, 1, 2, 2, 1, 1, 2, 2],
+                [1, 2, 1, 2, 1, 2, 1, 2],
             ],
             [
                 [1, 2],
                 [0, 1],
                 4,
                 2,
-                [1, 2, 2, 3, 1, 2, 2, 3],
+                [1, 3, 1, 3, 1, 3, 1, 3],
             ],
             [
                 [1, 2],
                 [0, 1],
                 4,
                 2,
-                [1, 2, 2, 3, 1, 2, 2, 3],
+                [1, 3, 1, 3, 1, 3, 1, 3],
             ],
         ];
     }

--- a/tests/Unit/Benchmark/Executor/MicrotimeExecutorTest.php
+++ b/tests/Unit/Benchmark/Executor/MicrotimeExecutorTest.php
@@ -100,8 +100,8 @@ class MicrotimeExecutorTest extends \PHPUnit_Framework_TestCase
         $this->variant->getRevolutions()->willReturn(10);
         $this->variant->getWarmup()->willReturn(1);
 
-        $this->iteration->addResult(Argument::type(TimeResult::class))->shouldBeCalled();
-        $this->iteration->addResult(Argument::type(MemoryResult::class))->shouldBeCalled();
+        $this->iteration->setResult(Argument::type(TimeResult::class))->shouldBeCalled();
+        $this->iteration->setResult(Argument::type(MemoryResult::class))->shouldBeCalled();
 
         $this->executor->execute(
             $this->metadata->reveal(),
@@ -149,8 +149,8 @@ class MicrotimeExecutorTest extends \PHPUnit_Framework_TestCase
         $this->variant->getRevolutions()->willReturn(1);
         $this->variant->getWarmup()->willReturn(0);
 
-        $this->iteration->addResult(Argument::type(TimeResult::class))->shouldBeCalled();
-        $this->iteration->addResult(Argument::type(MemoryResult::class))->shouldBeCalled();
+        $this->iteration->setResult(Argument::type(TimeResult::class))->shouldBeCalled();
+        $this->iteration->setResult(Argument::type(MemoryResult::class))->shouldBeCalled();
 
         $this->executor->execute($this->metadata->reveal(), $this->iteration->reveal(), new Config('test', []));
 
@@ -169,8 +169,8 @@ class MicrotimeExecutorTest extends \PHPUnit_Framework_TestCase
         $this->variant->getRevolutions()->willReturn(1);
         $this->variant->getWarmup()->willReturn(0);
 
-        $this->iteration->addResult(Argument::type(TimeResult::class))->shouldBeCalled();
-        $this->iteration->addResult(Argument::type(MemoryResult::class))->shouldBeCalled();
+        $this->iteration->setResult(Argument::type(TimeResult::class))->shouldBeCalled();
+        $this->iteration->setResult(Argument::type(MemoryResult::class))->shouldBeCalled();
 
         $this->executor->execute($this->metadata->reveal(), $this->iteration->reveal(), new Config('test', []));
 
@@ -193,8 +193,8 @@ class MicrotimeExecutorTest extends \PHPUnit_Framework_TestCase
         $this->variant->getRevolutions()->willReturn(1);
         $this->variant->getWarmup()->willReturn(0);
 
-        $this->iteration->addResult(Argument::type(TimeResult::class))->shouldBeCalled();
-        $this->iteration->addResult(Argument::type(MemoryResult::class))->shouldBeCalled();
+        $this->iteration->setResult(Argument::type(TimeResult::class))->shouldBeCalled();
+        $this->iteration->setResult(Argument::type(MemoryResult::class))->shouldBeCalled();
 
         $this->executor->execute($this->metadata->reveal(), $this->iteration->reveal(), new Config('test', []));
         $this->assertTrue(file_exists($this->paramFile));
@@ -222,8 +222,8 @@ class MicrotimeExecutorTest extends \PHPUnit_Framework_TestCase
         $this->variant->getRevolutions()->willReturn(1);
         $this->variant->getWarmup()->willReturn(0);
 
-        $this->iteration->addResult(Argument::type(TimeResult::class))->shouldBeCalled();
-        $this->iteration->addResult(Argument::type(MemoryResult::class))->shouldBeCalled();
+        $this->iteration->setResult(Argument::type(TimeResult::class))->shouldBeCalled();
+        $this->iteration->setResult(Argument::type(MemoryResult::class))->shouldBeCalled();
 
         $this->executor->execute($this->metadata->reveal(), $this->iteration->reveal(), new Config('test', []));
 

--- a/tests/Unit/Benchmark/RunnerTest.php
+++ b/tests/Unit/Benchmark/RunnerTest.php
@@ -411,11 +411,11 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    private function loadIterationResultCallback()
+    private function loadIterationResultCallback(array $times = ['10'])
     {
         return function ($args) {
-            $args[1]->addResult(new TimeResult(10));
-            $args[1]->addResult(new MemoryResult(10, 10, 10));
+            $args[1]->setResult(new TimeResult(10));
+            $args[1]->setResult(new MemoryResult(10, 10, 10));
         };
     }
 }

--- a/tests/Unit/Model/ResultCollectionTest.php
+++ b/tests/Unit/Model/ResultCollectionTest.php
@@ -46,23 +46,11 @@ class ResultCollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testAddResult()
     {
-        $this->collection->addResult($this->timeResult);
+        $this->collection->setResult($this->timeResult);
         $this->assertEquals(
             $this->timeResult,
             $this->collection->getResult(TimeResult::class)
         );
-    }
-
-    /**
-     * It should throw an exception if two results of the same class are added.
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Result of class "PhpBench\Model\Result\TimeResult" has already been set.
-     */
-    public function testAddTwoResultsSameClass()
-    {
-        $this->collection->addResult($this->timeResult);
-        $this->collection->addResult($this->timeResult);
     }
 
     /**
@@ -81,7 +69,7 @@ class ResultCollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetNamedMetric()
     {
-        $this->collection->addResult($this->timeResult);
+        $this->collection->setResult($this->timeResult);
         $this->assertEquals(1, $this->collection->getMetric(TimeResult::class, 'net'));
     }
 
@@ -93,7 +81,7 @@ class ResultCollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testNamedMetricDoesNotExist()
     {
-        $this->collection->addResult($this->timeResult);
+        $this->collection->setResult($this->timeResult);
         $this->assertEquals(1, $this->collection->getMetric(TimeResult::class, 'foobar'));
     }
 
@@ -103,7 +91,7 @@ class ResultCollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetMetricOrDefault()
     {
-        $this->collection->addResult($this->timeResult);
+        $this->collection->setResult($this->timeResult);
         $this->assertEquals(100, $this->collection->getMetricOrDefault('UnknownClass', 'barbar', 100));
     }
 }

--- a/tests/Unit/Progress/Logger/BlinkenLoggerTest.php
+++ b/tests/Unit/Progress/Logger/BlinkenLoggerTest.php
@@ -110,7 +110,7 @@ class BlinkenLoggerTest extends \PHPUnit_Framework_TestCase
     {
         foreach ($this->variant as $iteration) {
             foreach (TestUtil::createResults(10, 10) as $result) {
-                $iteration->addResult($result);
+                $iteration->setResult($result);
             }
         }
         $this->variant->computeStats();

--- a/tests/Unit/Progress/Logger/HistogramLoggerTest.php
+++ b/tests/Unit/Progress/Logger/HistogramLoggerTest.php
@@ -115,7 +115,7 @@ class HistogramLoggerTest extends \PHPUnit_Framework_TestCase
     {
         foreach ($this->variant as $iteration) {
             foreach (TestUtil::createResults(10, 10) as $result) {
-                $iteration->addResult($result);
+                $iteration->setResult($result);
             }
         }
         $this->variant->computeStats();


### PR DESCRIPTION
- The current behavior breaks the retry threshold feature which relies
  upon overwriting previously set results.
- Replaces `replaceResult` and `addResult` with `setResult`.
- Improves the debug executor so that we can test the retry-threshold feature.

Fixes #423