### PR TITLE
Adjust lstrojny/functional-php dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "seld/jsonlint": "^1.0",
         "justinrainbow/json-schema": "^1.6",
         "doctrine/annotations": "^1.2.7",
-        "lstrojny/functional-php": ">=1.0 <1.2.0",
+        "lstrojny/functional-php": "1.0|^1.2.3",
         "beberlei/assert": "^2.4",
         "ext-dom": "*",
         "ext-json": "*",


### PR DESCRIPTION
Allow this dependency to be updated while avoiding a compatibility issue with
HHVM present in lstrojny/functional-php:1.2.1. This issue is fixed in 1.2.3.