### PR TITLE
Throw exception if trying to resolve latest UUID when no history.

### DIFF
--- a/extensions/xdebug/lib/Command/Handler/OutputDirHandler.php
+++ b/extensions/xdebug/lib/Command/Handler/OutputDirHandler.php
@@ -11,12 +11,12 @@
 
 namespace PhpBench\Extensions\XDebug\Command\Handler;
 
+use PhpBench\PhpBench;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
-use PhpBench\PhpBench;
 
 class OutputDirHandler
 {

--- a/lib/Storage/UuidResolver.php
+++ b/lib/Storage/UuidResolver.php
@@ -39,7 +39,15 @@ class UuidResolver
     {
         $history = $this->driver->getService()->history();
 
-        return $history->current()->getRunId();
+        $current = $history->current();
+
+        if (!$current) {
+            throw new \InvalidArgumentException(
+                'No history present, therefore cannot retrieve latest UUID'
+            );
+        }
+
+        return $current->getRunId();
     }
 
     private function getNthUuid($nth)

--- a/tests/Unit/Storage/UuidResolverTest.php
+++ b/tests/Unit/Storage/UuidResolverTest.php
@@ -82,4 +82,18 @@ class UuidResolverTest extends \PHPUnit_Framework_TestCase
         $uuid = $this->resolver->resolve('latest-2');
         $this->assertEquals(4321, $uuid);
     }
+
+    /**
+     * It should throw an exception if no history is present.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage No history present
+     */
+    public function testNoHistory()
+    {
+        $this->storage->history()->willReturn($this->history->reveal());
+        $this->history->current()->willReturn(false);
+
+        $this->resolver->resolve('latest');
+    }
 }


### PR DESCRIPTION
Fixes #418 