### PR TITLE
Allow sorting and limiting function trace

### DIFF
--- a/benchmarks/Micro/Math/StatisticsBench.php
+++ b/benchmarks/Micro/Math/StatisticsBench.php
@@ -27,6 +27,9 @@ class StatisticsBench
         Statistics::variance([]);
     }
 
+    /**
+     * @Subject()
+     */
     public function benchVariance()
     {
         Statistics::variance([

--- a/extensions/xdebug/lib/Command/TraceCommand.php
+++ b/extensions/xdebug/lib/Command/TraceCommand.php
@@ -55,6 +55,7 @@ EOT
         $this->addOption('no-benchmark-filter', null, InputOption::VALUE_NONE, 'Do not filter functions surrounding the benchmark');
         $this->addOption('trace-filter', null, InputOption::VALUE_REQUIRED, 'Regex function name filter');
         $this->addOption('show-args', null, InputOption::VALUE_NONE, 'Show function arguments');
+        $this->addOption('top', null, InputOption::VALUE_REQUIRED, 'Sort by inclusive time descending and limit results to given number of entries');
     }
 
     /**
@@ -65,6 +66,7 @@ EOT
         $outputDir = $this->outputDirHandler->handleOutputDir($input, $output);
         $this->output = $output;
         $dump = $input->getOption('dump');
+        $top = $input->getOption('top');
 
         $suite = $this->runnerHandler->runFromInput($input, $output, [
             'executor' => [
@@ -86,6 +88,7 @@ EOT
             'filter_benchmark' => !$input->getOption('no-benchmark-filter'),
             'show_args' => $input->getOption('show-args'),
             'filter' => $input->getOption('trace-filter'),
+            'top' => $top
         ]);
     }
 


### PR DESCRIPTION
Allows the function trace to be sorted by inclusive time.

**TODO**:
- [ ] Reuse the existing report framework.
- [ ] Storage? Traces are generally huge, especially in XML - but generating traces can take long periods of time, making analysis more difficult.
