### PR TITLE
Cleaned up test debris

### DIFF
--- a/extensions/xdebug/tests/System/XDebugTestCase.php
+++ b/extensions/xdebug/tests/System/XDebugTestCase.php
@@ -13,7 +13,6 @@
 namespace PhpBench\Extensions\XDebug\Tests\System;
 
 use PhpBench\Tests\System\SystemTestCase;
-use Symfony\Component\Filesystem\Filesystem;
 
 class XDebugTestCase extends SystemTestCase
 {
@@ -23,25 +22,7 @@ class XDebugTestCase extends SystemTestCase
             $this->markTestSkipped('XDebug not enabled.');
         }
 
-        $this->clean();
-    }
-
-    public function tearDown()
-    {
-        $this->clean();
-    }
-
-    private function clean()
-    {
-        if (file_exists($profileDir = $this->getWorkingDir('xdebug'))) {
-            $filesystem = new Filesystem();
-            $filesystem->remove($profileDir);
-        }
-
-        if (file_exists($profileDir = $this->getWorkingDir('foobar'))) {
-            $filesystem = new Filesystem();
-            $filesystem->remove($profileDir);
-        }
+        parent::setUp();
     }
 
     public function phpbench($command, $workingDir = '.')

--- a/tests/System/env/config_dist/phpbench.json.dist
+++ b/tests/System/env/config_dist/phpbench.json.dist
@@ -1,4 +1,4 @@
 {
-    "bootstrap": "../../../../../vendor/autoload.php",
+    "bootstrap": "../../bootstrap/foobar.bootstrap",
     "path": "."
 }

--- a/tests/System/env/config_valid/phpbench.json
+++ b/tests/System/env/config_valid/phpbench.json
@@ -1,4 +1,4 @@
 {
-    "bootstrap": "../../../../vendor/autoload.php",
+    "bootstrap": "../..//bootstrap/foobar.bootstrap",
     "path": "../../benchmarks/set1"
 }


### PR DESCRIPTION
Use a workspace directory instead of arbitrarily cleaning up the repository.