### PR TITLE
Use "x times faster than" metric for "diff" column.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ script:
   - php bin/phpbench run --iterations=1 --revs=1 --config=extensions/dbal/benchmarks/phpbench.json --progress=dots
 
 matrix:
+  fast_finish: true
   allow_failures: 
     - php: hhvm
   include:

--- a/docs/report-generators.rst
+++ b/docs/report-generators.rst
@@ -29,7 +29,7 @@ Options:
   based for the given column.
 - **compare_fields**: *(array)* List of fields to compare based on the column
   specified with **compare**.
-- **deviation_col**: *(string)* If the ``diff`` column is given in ``cols``, use
+- **diff_col**: *(string)* If the ``diff`` column is given in ``cols``, use
   this column as the value on which to determine the ``diff`` (default
   ``mean``).
 - **sort**: *(assoc_array)* Sort specification, can specify multiple columns;

--- a/docs/reports.rst
+++ b/docs/reports.rst
@@ -160,23 +160,22 @@ By default the mean is used as the comparison value, you may also select differe
     for the ``compare`` column. In such cases extra columns are added suffixed
     with an index, for example: ``revs:10:mean#1``.
 
+
 Difference Between Rows
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-You can show the percentage of difference from the lowest column value in the table by specifying the ``diff`` column. By
-default this will use the ``mean``, you can specify a different value using the ``deviation_col`` option, e.g. ``deviation_col: "mode"``.
+You can show the percentage of difference from the lowest column value in the table (:math:`($meanOrMode / $min)  - 1) * 100`) by specifying the ``diff`` column. By
+default this will use the ``mean``, you can specify a different value using the ``diff_col`` option, e.g. ``diff_col: "mode"``.
 
 .. code-block:: bash
 
     $ phpbench run --report='generator: "table", cols: ["subject", "revs", "mean", "diff"]'
-
-	+-------------+------+---------+---------+
-	| subject     | revs | mean    | diff    |
-	+-------------+------+---------+---------+
-	| benchMd5    | 100  | 0.400μs | 0.00%   |
-	| benchSha1   | 100  | 0.497μs | +19.52% |
-	| benchSha256 | 100  | 0.886μs | +54.85% |
-	+-------------+------+---------+---------+
+    +---------------+------+---------+--------+
+    | subject       | revs | mean    | diff   |
+    +---------------+------+---------+--------+
+    | benchVariance | 100  | 12.05μs | 0.00%  |
+    | benchStDev    | 100  | 12.53μs | +4.03% |
+    +---------------+------+---------+--------+
 
 Sorting
 ~~~~~~~

--- a/lib/Extension/config/class/main.json
+++ b/lib/Extension/config/class/main.json
@@ -10,6 +10,11 @@
     "percentage": [
         [ "printf", { "format": "%.2f%%" } ]
     ],
+    "deviation": [
+        [ "number", { "decimal_places": 2 }],
+        [ "balance", {} ],
+        [ "printf", { "format": "%s%%" } ]
+    ],
     "diff": [
         [ "number", { "decimal_places": 2 }],
         [ "balance", {} ],

--- a/lib/Report/Generator/TableGenerator.php
+++ b/lib/Report/Generator/TableGenerator.php
@@ -48,7 +48,7 @@ class TableGenerator implements GeneratorInterface, OutputAwareInterface
         'mem_real' => ['mem'],
         'mem_final' => ['mem'],
         'diff' => ['diff'],
-        'comp_deviation' => ['diff'],
+        'comp_deviation' => ['deviation'],
         'comp_z_value' => ['z-value'],
     ];
 
@@ -150,7 +150,7 @@ class TableGenerator implements GeneratorInterface, OutputAwareInterface
                     return $row;
                 }
 
-                $row['diff'] = (100 / $row[$stat]) * ($row[$stat] - $min);
+                $row['diff'] = (($row[$stat] / $min) - 1) * 100;
 
                 return $row;
             });

--- a/tests/Unit/Report/Generator/TableGeneratorTest.php
+++ b/tests/Unit/Report/Generator/TableGeneratorTest.php
@@ -73,7 +73,7 @@ class TableGeneratorTest extends GeneratorTestCase
         $this->assertXPathEval($report, '33.333333333333', 'string(//cell[@name="rstdev"])');
 
         $this->assertXPathEval($report, '0', 'string(//cell[@name="diff"])');
-        $this->assertXPathEval($report, '6.25', 'string(//row[2]//cell[@name="diff"])');
+        $this->assertXPathEval($report, '6.6666666666667', 'string(//row[2]//cell[@name="diff"])');
     }
 
     /**


### PR DESCRIPTION
Currently the diff column uses a strange metric, for example:

```
$diff = (100 / $currentMean) * ($currentMean - $lowestMean);
```

Which gives ... a result where large differences between two numbers
can be expressed as 90% vs 95% reative to a much smaller (-10x) min value.

This PR replaces this with:

```
$diff = $currentMean / $lowestMean;
```

Givng _x_ is _n_ times slower than the lowest _x_.

```
+-----------+----------+----------+----------+----------+--------+-------+
| benchmark | mean     | mode     | worst    | stdev    | rstdev | diff  |
+-----------+----------+----------+----------+----------+--------+-------+
| KdeBench  | 0.5031ms | 0.5277ms | 0.5472ms | 0.0504ms | 10.02% | 1.00x |
| KdeBench  | 0.7134ms | 0.6009ms | 0.9685ms | 0.1476ms | 20.69% | 1.42x |
| KdeBench  | 1.2471ms | 1.0710ms | 1.6556ms | 0.2286ms | 18.33% | 2.48x |
+-----------+----------+----------+----------+----------+--------+-------+
```

Which is more intutiive.

Although maybe the diff algo should be configurable?
