### PR TITLE
Bumped minimum requirement to 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - hhvm
@@ -30,7 +29,7 @@ matrix:
   allow_failures: 
     - php: hhvm
   include:
-    - php: 5.5
+    - php: 5.6
       env:
       - COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.0

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^5.5|^7.0",
+        "php": "^5.6|^7.0",
         "phpbench/dom": "~0.2.0",
         "phpbench/container": "~1.0",
         "symfony/console": "^2.4|^3.0",


### PR DESCRIPTION
5.5 is no longer supported and functional-php requires at least 5.6

Fixes #441