### PR TITLE
Fixed type in json config

### DIFF
--- a/docs/extensions/xdebug.rst
+++ b/docs/extensions/xdebug.rst
@@ -27,9 +27,9 @@ The XDebug extension is bundled with PHPBench, it just needs to be activated:
 .. code-block:: javascript
 
     {
-       "extensions": {
+       "extensions": [
            "PhpBench\\Extensions\\XDebug\\XDebugExtension"
-       }
+       ]
     }
 
 Alternatively you can activate it directly from the CLI using the


### PR DESCRIPTION
There must be an array instead of object