### PR TITLE
Blackfire output log lead to exception

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -182,7 +182,7 @@ You can prefix the benchmarking command line using the ``php_wrapper`` option:
 .. code-block:: javascript
 
     {
-        "php_wrapper": "blackfire run"
+        "php_wrapper": "blackfire run -q"
     }
 
 .. note::


### PR DESCRIPTION
To avoid following error "Could not decode return value from script from template" we must disable any output from blackfire command