### PR TITLE
Fix: Actually use JSON in configuration example

### DIFF
--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -18,7 +18,7 @@ by default, this can be changed in the configuration as follows:
 .. code-block:: javascript
 
     {
-        'xml_storage_path' => '_storage'
+        "xml_storage_path": "_storage"
     }
 
 Storing Results


### PR DESCRIPTION
This PR

* [x] actually uses JSON in a configuration example