### PR TITLE
Fix: Install dependencies in install section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,11 @@ cache:
 before_install:
     - composer validate
 
-before_script:
+install:
     - if [ -n "${SYMFONY_VERSION}" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --no-update; fi;
     - composer update ${COMPOSER_FLAGS} --prefer-dist
+
+before_script:
     - export TZ=Europe/Paris
 
 script:


### PR DESCRIPTION
This PR

* [x] uses the `install` section for installing dependencies on Travis CI

💁‍♂️ For reference, see https://docs.travis-ci.com/user/customizing-the-build#The-Build-Lifecycle.