### PR TITLE
Fix: Case mismatch in method call or class name

### DIFF
--- a/lib/Report/Generator/Table/Sort.php
+++ b/lib/Report/Generator/Table/Sort.php
@@ -35,8 +35,8 @@ class Sort
         $array2 = array_slice($array, $halfway);
 
         // Recurse to sort the two halves
-        self::mergesort($array1, $callback);
-        self::mergesort($array2, $callback);
+        self::mergeSort($array1, $callback);
+        self::mergeSort($array2, $callback);
 
         // If all of $array1 is <= all of $array2, just append them.
         if (call_user_func($callback, end($array1), $array2[0]) < 1) {

--- a/lib/Report/Renderer/XsltRenderer.php
+++ b/lib/Report/Renderer/XsltRenderer.php
@@ -97,7 +97,7 @@ class XsltRenderer implements RendererInterface, OutputAwareInterface
 
         $stylesheetDom = new \DOMDocument('1.0');
         $stylesheetDom->load($template);
-        $xsltProcessor = new \XsltProcessor();
+        $xsltProcessor = new \XSLTProcessor();
         $xsltProcessor->importStylesheet($stylesheetDom);
         $xsltProcessor->setParameter(null, 'title', $config['title']);
         $xsltProcessor->setParameter(null, 'phpbench-version', PhpBench::VERSION);

--- a/tests/System/SystemTestCase.php
+++ b/tests/System/SystemTestCase.php
@@ -105,7 +105,7 @@ class SystemTestCase extends TestCase
     protected function assertXPathExpression($expected, $xmlString, $expression)
     {
         $dom = new \DOMDocument();
-        $result = @$dom->loadXml($xmlString);
+        $result = @$dom->loadXML($xmlString);
 
         if (false === $result) {
             throw new \RuntimeException(sprintf(

--- a/tests/Unit/Report/Generator/Table/SortTest.php
+++ b/tests/Unit/Report/Generator/Table/SortTest.php
@@ -38,7 +38,7 @@ class SortTest extends TestCase
             ['col1' => 20, 'col2' => 10],
         ];
 
-        Sort::mergesort($array, function ($row1, $row2) {
+        Sort::mergeSort($array, function ($row1, $row2) {
             return strcmp($row1['col1'], $row2['col1']);
         });
 

--- a/tests/Unit/Report/Renderer/AbstractRendererCase.php
+++ b/tests/Unit/Report/Renderer/AbstractRendererCase.php
@@ -49,7 +49,7 @@ abstract class AbstractRendererCase extends TestCase
     </report>
 </reports>
 EOT;
-        $document->loadXml($report);
+        $document->loadXML($report);
 
         return $document;
     }

--- a/tests/Unit/Serializer/XmlDecoderTest.php
+++ b/tests/Unit/Serializer/XmlDecoderTest.php
@@ -49,7 +49,7 @@ class XmlDecoderTest extends XmlTestCase
     public function testDecodeUnknownResultClass()
     {
         $dom = new Document(1.0);
-        $dom->loadXml(<<<EOT
+        $dom->loadXML(<<<EOT
 <phpbench>
   <suite>
     <result key="foo" class="FooVendor\FooResult"/>
@@ -70,7 +70,7 @@ EOT
     public function testDecodeUnknownResultKey()
     {
         $dom = new Document(1.0);
-        $dom->loadXml(<<<EOT
+        $dom->loadXML(<<<EOT
 <phpbench>
   <suite>
       <benchmark class="\PhpBench\Micro\Math\KdeBench">
@@ -97,7 +97,7 @@ EOT
     public function testInvalidAttribute()
     {
         $dom = new Document(1.0);
-        $dom->loadXml(<<<EOT
+        $dom->loadXML(<<<EOT
 <phpbench>
   <suite>
       <benchmark class="\PhpBench\Micro\Math\KdeBench">


### PR DESCRIPTION
This PR

* [x] fixes case mismatches in method calls or class names