### PR TITLE
Only allow "merging" of PHP config

### DIFF
--- a/extensions/xdebug/lib/Executor/ProfileExecutor.php
+++ b/extensions/xdebug/lib/Executor/ProfileExecutor.php
@@ -39,7 +39,7 @@ class ProfileExecutor extends BaseExecutor
             'xdebug.profiler_output_name' => $name,
         ];
 
-        $payload->setPhpConfig($phpConfig);
+        $payload->mergePhpConfig($phpConfig);
         $result = $payload->launch();
 
         if (isset($result['buffer']) && $result['buffer']) {

--- a/extensions/xdebug/lib/Executor/TraceExecutor.php
+++ b/extensions/xdebug/lib/Executor/TraceExecutor.php
@@ -71,7 +71,7 @@ class TraceExecutor extends BaseExecutor
             'xdebug.collect_params' => '3',
         ];
 
-        $payload->setPhpConfig($phpConfig);
+        $payload->mergePhpConfig($phpConfig);
 
         $path = $dir . DIRECTORY_SEPARATOR . $name . '.xt';
 

--- a/extensions/xdebug/lib/Executor/XDebugTraceExecutor.php
+++ b/extensions/xdebug/lib/Executor/XDebugTraceExecutor.php
@@ -69,7 +69,7 @@ class XDebugTraceExecutor extends BaseExecutor
             'xdebug.coverage_enable' => '0',
         ];
 
-        $payload->setPhpConfig($phpConfig);
+        $payload->mergePhpConfig($phpConfig);
 
         $path = $dir . DIRECTORY_SEPARATOR . $name . '.xt';
         $result = $payload->launch();

--- a/extensions/xdebug/tests/Unit/Executor/TraceExecutorTest.php
+++ b/extensions/xdebug/tests/Unit/Executor/TraceExecutorTest.php
@@ -93,7 +93,7 @@ class TraceExecutorTest extends TestCase
                 'final' => 10,
             ],
         ]);
-        $this->payload->setPhpConfig([
+        $this->payload->mergePhpConfig([
             'xdebug.trace_output_name' => 'Test::benchFoo.P1',
             'xdebug.trace_output_dir' => 'xdebug',
             'xdebug.trace_format' => '1',

--- a/lib/Benchmark/Executor/MicrotimeExecutor.php
+++ b/lib/Benchmark/Executor/MicrotimeExecutor.php
@@ -35,7 +35,7 @@ class MicrotimeExecutor extends BaseExecutor
             'max_execution_time' => 0,
         ];
 
-        $payload->setPhpConfig($phpConfig);
+        $payload->mergePhpConfig($phpConfig);
         $result = $payload->launch();
 
         if (isset($result['buffer']) && $result['buffer']) {

--- a/lib/Benchmark/Remote/Launcher.php
+++ b/lib/Benchmark/Remote/Launcher.php
@@ -87,7 +87,7 @@ class Launcher
         }
 
         if ($this->phpConfig) {
-            $payload->setPhpConfig($this->phpConfig);
+            $payload->mergePhpConfig($this->phpConfig);
         }
 
         return $payload;

--- a/lib/Benchmark/Remote/Payload.php
+++ b/lib/Benchmark/Remote/Payload.php
@@ -72,9 +72,12 @@ class Payload
         $this->wrapper = $wrapper;
     }
 
-    public function setPhpConfig($phpConfig)
+    public function mergePhpConfig(array $phpConfig)
     {
-        $this->phpConfig = $phpConfig;
+        $this->phpConfig = array_merge(
+            $this->phpConfig,
+            $phpConfig
+        );
     }
 
     public function setPhpPath($phpBinary)
@@ -111,7 +114,9 @@ class Payload
             $wrapper = $this->wrapper . ' ';
         }
 
-        $this->process->setCommandLine($wrapper . $this->phpBinary . $this->getIniString() . ' ' . escapeshellarg($scriptPath));
+        $cmdLine = $wrapper . $this->phpBinary . $this->getIniString() . ' ' . escapeshellarg($scriptPath);
+
+        $this->process->setCommandLine($cmdLine);
         $this->process->run();
         unlink($scriptPath);
 

--- a/phpbench.json.dist
+++ b/phpbench.json.dist
@@ -2,6 +2,9 @@
     "bootstrap": "vendor/autoload.php",
     "path": "benchmarks",
     "storage": "dbal",
+    "php_config": {
+        "memory_limit": "1G"
+    },
     "extensions": [
         "PhpBench\\Extensions\\XDebug\\XDebugExtension",
         "PhpBench\\Extensions\\Dbal\\DbalExtension"

--- a/tests/Unit/Benchmark/BaselineManagerTest.php
+++ b/tests/Unit/Benchmark/BaselineManagerTest.php
@@ -16,7 +16,7 @@ use PhpBench\Benchmark\BaselineManager;
 use PHPUnit\Framework\TestCase;
 
 /**
-    * @\PhpBench\Benchmark\Metadata\Annotations\BeforeMethods({"setUp"})
+ * @\PhpBench\Benchmark\Metadata\Annotations\BeforeMethods({"setUp"})
  */
 class BaselineManagerTest extends TestCase
 {

--- a/tests/Unit/Benchmark/Remote/LauncherTest.php
+++ b/tests/Unit/Benchmark/Remote/LauncherTest.php
@@ -71,7 +71,7 @@ class LauncherTest extends TestCase
         )->willReturn($this->payload->reveal());
 
         $this->payload->setWrapper('wrapper')->shouldBeCalled();
-        $this->payload->setPhpConfig($phpConfig)->shouldBeCalled();
+        $this->payload->mergePhpConfig($phpConfig)->shouldBeCalled();
 
         $launcher->payload(__FILE__, []);
     }

--- a/tests/Unit/Benchmark/Remote/PayloadTest.php
+++ b/tests/Unit/Benchmark/Remote/PayloadTest.php
@@ -66,18 +66,12 @@ class PayloadTest extends TestCase
      */
     public function testBinaryPath()
     {
-        $process = $this->prophesize(Process::class);
-        $payload = new Payload(
-            __DIR__ . '/template/foo.template',
-            [],
-            null,
-            $process->reveal()
-        );
+        $payload = $this->validPayload();
         $payload->setPhpPath('/foo/bar');
-        $process->setCommandLine(Argument::containingString('/foo/bar'))->shouldBeCalled();
-        $process->run()->shouldBeCalled();
-        $process->isSuccessful()->willReturn(true);
-        $process->getOutput()->willReturn('{"foo": "bar"}');
+        $this->process->setCommandLine(Argument::containingString('/foo/bar'))->shouldBeCalled();
+        $this->process->run()->shouldBeCalled();
+        $this->process->isSuccessful()->willReturn(true);
+        $this->process->getOutput()->willReturn('{"foo": "bar"}');
 
         $payload->launch($payload);
     }
@@ -87,22 +81,20 @@ class PayloadTest extends TestCase
      */
     public function testPhpConfig()
     {
-        $process = $this->prophesize(Process::class);
-        $payload = new Payload(
-            __DIR__ . '/template/foo.template',
-            [],
-            null,
-            $process->reveal()
-        );
-        $payload->setPhpConfig([
+        $payload = $this->validPayload();
+
+        $payload->mergePhpConfig([
             'foo' => 'bar',
+        ]);
+        $payload->mergePhpConfig([
             'bar' => 'foo',
         ]);
-        $process->setCommandLine(Argument::containingString('-dfoo=bar'))->shouldBeCalled();
-        $process->setCommandLine(Argument::containingString('-dbar=foo'))->shouldBeCalled();
-        $process->run()->shouldBeCalled();
-        $process->isSuccessful()->willReturn(true);
-        $process->getOutput()->willReturn('{"foo": "bar"}');
+
+        $this->process->setCommandLine(Argument::containingString('-dfoo=bar'))->shouldBeCalled();
+        $this->process->setCommandLine(Argument::containingString('-dbar=foo'))->shouldBeCalled();
+        $this->process->run()->shouldBeCalled();
+        $this->process->isSuccessful()->willReturn(true);
+        $this->process->getOutput()->willReturn('{"foo": "bar"}');
 
         $payload->launch($payload);
     }
@@ -112,19 +104,13 @@ class PayloadTest extends TestCase
      */
     public function testWrap()
     {
-        $process = $this->prophesize(Process::class);
-        $payload = new Payload(
-            __DIR__ . '/template/foo.template',
-            [],
-            null,
-            $process->reveal()
-        );
+        $payload = $this->validPayload();
         $payload->setWrapper('bockfire');
         $payload->setPhpPath('/boo/bar/php');
-        $process->setCommandLine(Argument::containingString('bockfire /boo/bar/php'))->shouldBeCalled();
-        $process->run()->shouldBeCalled();
-        $process->isSuccessful()->willReturn(true);
-        $process->getOutput()->willReturn('{"foo": "bar"}');
+        $this->process->setCommandLine(Argument::containingString('bockfire /boo/bar/php'))->shouldBeCalled();
+        $this->process->run()->shouldBeCalled();
+        $this->process->isSuccessful()->willReturn(true);
+        $this->process->getOutput()->willReturn('{"foo": "bar"}');
 
         $payload->launch($payload);
     }
@@ -146,5 +132,20 @@ class PayloadTest extends TestCase
         );
 
         $payload->launch($payload);
+    }
+
+    private function validPayload()
+    {
+        return $this->validPayloadWithPhpConfig();
+    }
+
+    private function validPayloadWithPhpConfig(array $phpConfig = [])
+    {
+        return new Payload(
+            __DIR__ . '/template/foo.template',
+            [],
+            null,
+            $this->process->reveal()
+        );
     }
 }


### PR DESCRIPTION
Disallow the replacement of the PHP config.

Currently whenever `setPhpConfig` is called on the payload, the configuration is replaced, overwriting any user configuration (either from config or the CLI).

This PR changes the behavior to always merge _onto_ the existing user configuration.

Fixes #481 and partly #488 