### PR TITLE
Disable php ini

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -233,14 +233,14 @@ The above will allow you to have benchmark class such as:
 Disable the PHP INI file
 ------------------------
 
-PHP extensions, especially XDebug can drastically affect the performance of
-your benchmarks. You can disable XDebug and other dynamically loaded
+PHP extensions, especially XDebug, can drastically affect the performance of
+your benchmark subjects. You can disable XDebug and other dynamically loaded
 extensions by setting ``php_disable_ini`` to ``true``.
 
 .. note:
 
-    PHPBench currently makes use of the ``json`` extension remote
-    processes, so you are required to explicitly enable this as follows.
+    PHPBench currently makes use of the ``json`` extension in remote
+    processes, so you are required to explicitly enable it as follows.
 
 .. code-block:: javascript
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -227,3 +227,26 @@ The above will allow you to have benchmark class such as:
 
     You can also explicitly declare that methods are benchmark subjects by
     using the ``@Subject`` annotation.
+
+.. _configuration_disable_php_ini:
+
+Disable the PHP INI file
+------------------------
+
+PHP extensions, especially XDebug can drastically affect the performance of
+your benchmarks. You can disable XDebug and other dynamically loaded
+extensions by setting ``php_disable_ini`` to ``true``.
+
+.. note:
+
+    PHPBench currently makes use of the ``json`` extension remote
+    processes, so you are required to explicitly enable this as follows.
+
+.. code-block:: javascript
+
+    {
+        "php_disable_ini": true,
+        "php_config": {
+            "extension": [ "json.so" ]
+        }
+    }

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -73,6 +73,12 @@ Create the file ``phpbench.json`` in the projects root directory:
     that matter). You may omit it if you do not need autoloading, or you want
     to include files manually.
 
+.. warning::
+
+    Some PHP extensions such as XDebug will affect the performance of your
+    benchmark subjects and you may want to disable them, see :ref:`Disabling
+    the PHP INI file <configuration_disable_php_ini>`.
+
 Creating and running a benchmark
 --------------------------------
 

--- a/lib/Benchmark/Executor/BaseExecutor.php
+++ b/lib/Benchmark/Executor/BaseExecutor.php
@@ -71,7 +71,7 @@ abstract class BaseExecutor implements ExecutorInterface
 
     public function healthCheck()
     {
-        $result = $this->launcher->payload(__DIR__ . '/template/health_check.template', [])->launch();
+        $this->launcher->payload(__DIR__ . '/template/health_check.template', [])->launch();
     }
 
     /**

--- a/lib/Benchmark/Executor/BaseExecutor.php
+++ b/lib/Benchmark/Executor/BaseExecutor.php
@@ -69,6 +69,11 @@ abstract class BaseExecutor implements ExecutorInterface
         return $this->launch($payload, $iteration, $config);
     }
 
+    public function healthCheck()
+    {
+        $result = $this->launcher->payload(__DIR__ . '/template/health_check.template', [])->launch();
+    }
+
     /**
      * Launch the payload. This method has to return the ResultCollection.
      *

--- a/lib/Benchmark/Executor/template/health_check.template
+++ b/lib/Benchmark/Executor/template/health_check.template
@@ -1,0 +1,9 @@
+<?php
+
+if (false === extension_loaded('json')) {
+    throw new \RuntimeException(
+        'PHPBench currently requires the JSON extension. If you are
+        using the --php-disable-ini feature, you should explicitly load the json
+        extension, e.g. --php-config="extension:json.so"' 
+    );
+}

--- a/lib/Benchmark/ExecutorInterface.php
+++ b/lib/Benchmark/ExecutorInterface.php
@@ -53,4 +53,6 @@ interface ExecutorInterface extends RegistrableInterface
      * @param string[]
      */
     public function executeMethods(BenchmarkMetadata $benchmark, array $methods);
+
+    public function healthCheck();
 }

--- a/lib/Benchmark/Remote/IniStringBuilder.php
+++ b/lib/Benchmark/Remote/IniStringBuilder.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
 namespace PhpBench\Benchmark\Remote;
 
 class IniStringBuilder

--- a/lib/Benchmark/Remote/IniStringBuilder.php
+++ b/lib/Benchmark/Remote/IniStringBuilder.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PhpBench\Benchmark\Remote;
+
+class IniStringBuilder
+{
+    public function build(array $config)
+    {
+        $string = [];
+        foreach ($config as $key => $values) {
+            $values = (array) $values;
+
+            foreach ($values as $value) {
+                $string[] = sprintf('-d%s=%s', $key, $value);
+            }
+        }
+
+        return implode(' ', $string);
+    }
+}

--- a/lib/Benchmark/Remote/Launcher.php
+++ b/lib/Benchmark/Remote/Launcher.php
@@ -47,6 +47,21 @@ class Launcher
     private $phpWrapper;
 
     /**
+     * @var PayloadFactory
+     */
+    private $factory;
+
+    /**
+     * @var ExecutableFinder
+     */
+    private $finder;
+
+    /**
+     * @var bool
+     */
+    private $phpDisableIni;
+
+    /**
      * @param mixed string
      */
     public function __construct(
@@ -55,7 +70,8 @@ class Launcher
         $bootstrap = null,
         $phpBinary = null,
         $phpConfig = [],
-        $phpWrapper = null
+        $phpWrapper = null,
+        $phpDisableIni = false
     ) {
         $this->bootstrap = $bootstrap;
         $this->payloadFactory = $factory ?: new PayloadFactory();
@@ -63,6 +79,8 @@ class Launcher
         $this->phpConfig = $phpConfig;
         $this->phpWrapper = $phpWrapper;
         $this->finder = $finder ?: new ExecutableFinder();
+        $this->factory = $factory;
+        $this->phpDisableIni = $phpDisableIni;
     }
 
     public function payload($template, array $tokens)
@@ -88,6 +106,10 @@ class Launcher
 
         if ($this->phpConfig) {
             $payload->mergePhpConfig($this->phpConfig);
+        }
+
+        if (true === $this->phpDisableIni) {
+            $payload->disableIni();
         }
 
         return $payload;
@@ -120,3 +142,4 @@ class Launcher
         return $phpBinary;
     }
 }
+

--- a/lib/Benchmark/Remote/Launcher.php
+++ b/lib/Benchmark/Remote/Launcher.php
@@ -14,6 +14,7 @@ namespace PhpBench\Benchmark\Remote;
 
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\PhpExecutableFinder;
+use PhpBench\Benchmark\Remote\Payload;
 
 /**
  * Build and execute tokenized scripts in separate processes.
@@ -83,7 +84,7 @@ class Launcher
         $this->phpDisableIni = $phpDisableIni;
     }
 
-    public function payload($template, array $tokens)
+    public function payload($template, array $tokens): Payload
     {
         $tokens['bootstrap'] = '';
         if (null !== $this->bootstrap) {

--- a/lib/Benchmark/Remote/Launcher.php
+++ b/lib/Benchmark/Remote/Launcher.php
@@ -14,7 +14,6 @@ namespace PhpBench\Benchmark\Remote;
 
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\PhpExecutableFinder;
-use PhpBench\Benchmark\Remote\Payload;
 
 /**
  * Build and execute tokenized scripts in separate processes.
@@ -143,4 +142,3 @@ class Launcher
         return $phpBinary;
     }
 }
-

--- a/lib/Benchmark/Remote/Payload.php
+++ b/lib/Benchmark/Remote/Payload.php
@@ -51,6 +51,11 @@ class Payload
     private $process;
 
     /**
+     * @var bool
+     */
+    private $disableIni = false;
+
+    /**
      * Create a new Payload object with the given script template.
      * The template must be the path to a script template.
      *
@@ -65,6 +70,7 @@ class Payload
         // disable timeout.
         $this->process->setTimeout(null);
         $this->phpBinary = $phpBinary;
+        $this->iniStringBuilder = new IniStringBuilder();
     }
 
     public function setWrapper($wrapper)
@@ -85,40 +91,22 @@ class Payload
         $this->phpBinary = $phpBinary;
     }
 
+    public function disableIni()
+    {
+        $this->disableIni = true;
+    }
+
     public function launch()
     {
-        if (!file_exists($this->template)) {
-            throw new \RuntimeException(sprintf(
-                'Could not find script template "%s"',
-                $this->template
-            ));
-        }
+        $script = $this->readFile();
+        $script = $this->replaceTokens($script);
+        $scriptPath = $this->writeTempFile($script);
+        $commandLine = $this->buildCommandLine($scriptPath);
 
-        $tokenSubs = [];
-        foreach ($this->tokens as $key => $value) {
-            $tokenSubs['{{ ' . $key . ' }}'] = $value;
-        }
-
-        $templateBody = file_get_contents($this->template);
-        $script = str_replace(
-            array_keys($tokenSubs),
-            array_values($tokenSubs),
-            $templateBody
-        );
-
-        $scriptPath = tempnam(sys_get_temp_dir(), 'PhpBench');
-        file_put_contents($scriptPath, $script);
-
-        $wrapper = '';
-        if ($this->wrapper) {
-            $wrapper = $this->wrapper . ' ';
-        }
-
-        $cmdLine = $wrapper . $this->phpBinary . $this->getIniString() . ' ' . escapeshellarg($scriptPath);
-
-        $this->process->setCommandLine($cmdLine);
+        $this->process->setCommandLine($commandLine);
         $this->process->run();
-        unlink($scriptPath);
+
+        $this->removeTmpFile($scriptPath);
 
         if (false === $this->process->isSuccessful()) {
             throw new ScriptErrorException(sprintf(
@@ -128,18 +116,7 @@ class Payload
             ));
         }
 
-        $output = $this->process->getOutput();
-        $result = json_decode($output, true);
-
-        if (null === $result) {
-            throw new \RuntimeException(sprintf(
-                'Could not decode return value from script from template "%s" (should be a JSON encoded string): %s',
-                $this->template,
-                $output
-            ));
-        }
-
-        return $result;
+        return $this->decodeResults();
     }
 
     private function getIniString()
@@ -148,11 +125,72 @@ class Payload
             return '';
         }
 
-        $string = [];
-        foreach ($this->phpConfig as $key => $value) {
-            $string[] = sprintf('-d%s=%s', $key, $value);
+        return $this->iniStringBuilder->build($this->phpConfig);
+    }
+
+    private function replaceTokens(string $templateBody): string
+    {
+        $tokenSubs = [];
+        foreach ($this->tokens as $key => $value) {
+            $tokenSubs['{{ ' . $key . ' }}'] = $value;
         }
 
-        return ' ' . implode(' ', $string) . ' ';
+        return str_replace(
+            array_keys($tokenSubs),
+            array_values($tokenSubs),
+            $templateBody
+        );
+    }
+
+    private function readFile(): string
+    {
+        if (!file_exists($this->template)) {
+            throw new \RuntimeException(sprintf(
+                'Could not find script template "%s"',
+                $this->template
+            ));
+        }
+
+        return file_get_contents($this->template);
+    }
+
+    private function writeTempFile(string $script): string
+    {
+        $scriptPath = tempnam(sys_get_temp_dir(), 'PhpBench');
+        file_put_contents($scriptPath, $script);
+
+        return $scriptPath;
+    }
+
+    private function buildCommandLine(string $scriptPath)
+    {
+        $wrapper = '';
+        if ($this->wrapper) {
+            $wrapper = $this->wrapper . ' ';
+        }
+
+        return $wrapper . $this->phpBinary . $this->getIniString() . ' ' . escapeshellarg($scriptPath);
+    }
+
+    private function removeTmpFile(string $scriptPath)
+    {
+        unlink($scriptPath);
+    }
+
+    private function decodeResults()
+    {
+        $output = $this->process->getOutput();
+        $result = json_decode($output, true);
+
+        if (false !== $result) {
+            return $result;
+        }
+
+        throw new \RuntimeException(sprintf(
+            'Could not decode return value from script from template "%s" (should be a JSON encoded string): %s',
+            $this->template,
+            $output
+        ));
     }
 }
+

--- a/lib/Benchmark/Remote/Payload.php
+++ b/lib/Benchmark/Remote/Payload.php
@@ -204,4 +204,3 @@ class Payload
         ));
     }
 }
-

--- a/lib/Benchmark/Remote/Payload.php
+++ b/lib/Benchmark/Remote/Payload.php
@@ -20,6 +20,8 @@ use Symfony\Component\Process\Process;
  */
 class Payload
 {
+    const FLAG_DISABLE_INI = '-n';
+
     /**
      * Path to script template.
      */
@@ -164,12 +166,21 @@ class Payload
 
     private function buildCommandLine(string $scriptPath)
     {
-        $wrapper = '';
+        $arguments = [];
         if ($this->wrapper) {
-            $wrapper = $this->wrapper . ' ';
+            $arguments[] = $this->wrapper;
         }
 
-        return $wrapper . $this->phpBinary . $this->getIniString() . ' ' . escapeshellarg($scriptPath);
+        $arguments[] = $this->phpBinary;
+
+        if (true === $this->disableIni) {
+            $arguments[] = self::FLAG_DISABLE_INI;
+        }
+
+        $arguments[] = $this->getIniString();
+        $arguments[] = escapeshellarg($scriptPath);
+
+        return implode(' ', $arguments);
     }
 
     private function removeTmpFile(string $scriptPath)

--- a/lib/Benchmark/Remote/PayloadFactory.php
+++ b/lib/Benchmark/Remote/PayloadFactory.php
@@ -14,7 +14,7 @@ namespace PhpBench\Benchmark\Remote;
 
 class PayloadFactory
 {
-    public function create($template, array $tokens = [], $phpBinary = null)
+    public function create($template, array $tokens = [], $phpBinary = null): Payload
     {
         return new Payload($template, $tokens, $phpBinary);
     }

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -82,6 +82,7 @@ class Runner
     {
         $executorConfig = $this->executorRegistry->getConfig($context->getExecutor());
         $executor = $this->executorRegistry->getService($executorConfig['executor']);
+        $executor->healthCheck();
 
         // build the collection of benchmarks to be executed.
         $benchmarkMetadatas = $this->benchmarkFinder->findBenchmarks($context->getPath(), $context->getFilters(), $context->getGroups());

--- a/lib/Console/Command/Handler/RunnerHandler.php
+++ b/lib/Console/Command/Handler/RunnerHandler.php
@@ -59,6 +59,7 @@ class RunnerHandler
         $command->addOption('php-binary', null, InputOption::VALUE_REQUIRED, 'Alternative PHP binary to use');
         $command->addOption('php-config', null, InputOption::VALUE_REQUIRED, 'JSON-like object of PHP INI settings');
         $command->addOption('php-wrapper', null, InputOption::VALUE_REQUIRED, 'Prefix process launch command with this string');
+        $command->addOption('php-disable-ini', null, InputOption::VALUE_NONE, 'Do not load the PHP INI file');
     }
 
     public function runFromInput(InputInterface $input, OutputInterface $output, array $options = [])

--- a/lib/Environment/Provider/Php.php
+++ b/lib/Environment/Provider/Php.php
@@ -22,12 +22,10 @@ use PhpBench\Environment\ProviderInterface;
 class Php implements ProviderInterface
 {
     private $launcher;
-    private $remoteVersion;
 
-    public function __construct(Launcher $launcher, $remoteVersion = false)
+    public function __construct(Launcher $launcher)
     {
         $this->launcher = $launcher;
-        $this->remoteVersion = $remoteVersion;
     }
 
     public function isApplicable()
@@ -45,13 +43,6 @@ class Php implements ProviderInterface
 
     private function getData()
     {
-        if (false === $this->remoteVersion) {
-            return [
-                'version' => phpversion(),
-                'xdebug' => in_array('xdebug', get_loaded_extensions()),
-            ];
-        }
-
         return $this->launcher->payload(
             __DIR__ . '/template/php.template',
             []

--- a/lib/Environment/Provider/template/php.template
+++ b/lib/Environment/Provider/template/php.template
@@ -4,6 +4,7 @@ echo json_encode([
     'xdebug' => in_array('xdebug', get_loaded_extensions()),
     'version' => phpversion(),
     'ini' => php_ini_loaded_file(),
+    'extensions' => implode(', ', get_loaded_extensions()),
 ]);
 
 exit(0);

--- a/lib/Environment/Provider/template/php.template
+++ b/lib/Environment/Provider/template/php.template
@@ -2,7 +2,8 @@
 
 echo json_encode([
     'xdebug' => in_array('xdebug', get_loaded_extensions()),
-    'version' => phpversion()
+    'version' => phpversion(),
+    'ini' => php_ini_loaded_file(),
 ]);
 
 exit(0);

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -101,6 +101,7 @@ class CoreExtension implements ExtensionInterface
             'php_config' => [],
             'php_binary' => null,
             'php_wrapper' => null,
+            'php_disable_ini' => false,
             'annotation_import_use' => false,
         ];
     }
@@ -174,7 +175,8 @@ class CoreExtension implements ExtensionInterface
                 $container->hasParameter('bootstrap') ? $container->getParameter('bootstrap') : null,
                 $container->hasParameter('php_binary') ? $container->getParameter('php_binary') : null,
                 $container->hasParameter('php_config') ? $container->getParameter('php_config') : null,
-                $container->hasParameter('php_wrapper') ? $container->getParameter('php_wrapper') : null
+                $container->hasParameter('php_wrapper') ? $container->getParameter('php_wrapper') : null,
+                $container->hasParameter('php_disable_ini') ? $container->getParameter('php_disable_ini') : false
             );
         });
 
@@ -484,7 +486,7 @@ class CoreExtension implements ExtensionInterface
         $container->register('environment.provider.php', function (Container $container) {
             return new Provider\Php(
                 $container->get('benchmark.remote.launcher'),
-                $container->getParameter('php_binary') !== PHP_BINARY && $container->getParameter('php_binary') !== null
+                true // always use remote env information
             );
         }, ['environment_provider' => []]);
 

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -485,8 +485,7 @@ class CoreExtension implements ExtensionInterface
 
         $container->register('environment.provider.php', function (Container $container) {
             return new Provider\Php(
-                $container->get('benchmark.remote.launcher'),
-                true // always use remote env information
+                $container->get('benchmark.remote.launcher')
             );
         }, ['environment_provider' => []]);
 

--- a/lib/PhpBench.php
+++ b/lib/PhpBench.php
@@ -113,6 +113,10 @@ class PhpBench
                 $value = $jsonParser->decode($value);
                 $configOverride['php_config'] = $value;
             }
+
+            if ($arg == '--php-disable-ini') {
+                $configOverride['php_disable_ini'] = true;
+            }
         }
 
         if (empty($configPaths)) {

--- a/tests/System/RunTest.php
+++ b/tests/System/RunTest.php
@@ -471,4 +471,16 @@ class RunTest extends SystemTestCase
         );
         $this->assertExitCode(0, $process);
     }
+
+    /**
+     * It should disable the PHP ini file
+     */
+    public function testPhpDisableIni()
+    {
+        $process = $this->phpbench(
+            'run benchmarks/set4/NothingBench.php --php-disable-ini --php-config="extension:json.so" --report=env'
+        );
+        $this->assertExitCode(0, $process);
+        $this->assertRegExp('{ini\s+\| no}', $process->getOutput());
+    }
 }

--- a/tests/System/RunTest.php
+++ b/tests/System/RunTest.php
@@ -473,7 +473,7 @@ class RunTest extends SystemTestCase
     }
 
     /**
-     * It should disable the PHP ini file
+     * It should disable the PHP ini file.
      */
     public function testPhpDisableIni()
     {

--- a/tests/Unit/Benchmark/Remote/IniStringBuilderTest.php
+++ b/tests/Unit/Benchmark/Remote/IniStringBuilderTest.php
@@ -1,9 +1,19 @@
 <?php
 
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
 namespace PhpBench\Tests\Unit\Benchmark\Remote;
 
-use PHPUnit\Framework\TestCase;
 use PhpBench\Benchmark\Remote\IniStringBuilder;
+use PHPUnit\Framework\TestCase;
 
 class IniStringBuilderTest extends TestCase
 {
@@ -31,7 +41,7 @@ class IniStringBuilderTest extends TestCase
         return [
             [
                 [
-                    'a' => 'b'
+                    'a' => 'b',
                 ],
                 '-da=b',
             ],
@@ -44,11 +54,10 @@ class IniStringBuilderTest extends TestCase
             ],
             [
                 [
-                    'a' => ['b','c','d'],
+                    'a' => ['b', 'c', 'd'],
                 ],
                 '-da=b -da=c -da=d',
             ],
         ];
     }
 }
-

--- a/tests/Unit/Benchmark/Remote/IniStringBuilderTest.php
+++ b/tests/Unit/Benchmark/Remote/IniStringBuilderTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace PhpBench\Tests\Unit\Benchmark\Remote;
+
+use PHPUnit\Framework\TestCase;
+use PhpBench\Benchmark\Remote\IniStringBuilder;
+
+class IniStringBuilderTest extends TestCase
+{
+    /**
+     * @var IniStringBuilder
+     */
+    private $builder;
+
+    public function setUp()
+    {
+        $this->builder = new IniStringBuilder();
+    }
+
+    /**
+     * @dataProvider provideBuild
+     */
+    public function testBuild(array $example, string $expectedIniString)
+    {
+        $iniString = $this->builder->build($example);
+        $this->assertEquals($expectedIniString, $iniString);
+    }
+
+    public function provideBuild()
+    {
+        return [
+            [
+                [
+                    'a' => 'b'
+                ],
+                '-da=b',
+            ],
+            [
+                [
+                    'a' => 'b',
+                    'b' => 'a',
+                ],
+                '-da=b -db=a',
+            ],
+            [
+                [
+                    'a' => ['b','c','d'],
+                ],
+                '-da=b -da=c -da=d',
+            ],
+        ];
+    }
+}
+

--- a/tests/Unit/Benchmark/RunnerTest.php
+++ b/tests/Unit/Benchmark/RunnerTest.php
@@ -42,6 +42,7 @@ class RunnerTest extends TestCase
             $this->benchmark->reveal(),
         ]);
         $this->executor = $this->prophesize(ExecutorInterface::class);
+        $this->executor->healthCheck()->shouldBeCalled();
         $this->executorRegistry = $this->prophesize(ConfigurableRegistry::class);
         $this->executorConfig = new Config('test', ['executor' => 'microtime']);
         $this->envSupplier = $this->prophesize(Supplier::class);

--- a/tests/Unit/Environment/Provider/PhpTest.php
+++ b/tests/Unit/Environment/Provider/PhpTest.php
@@ -16,7 +16,6 @@ use PhpBench\Benchmark\Remote\Launcher;
 use PhpBench\Benchmark\Remote\Payload;
 use PhpBench\Environment\Provider;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 
 class PhpTest extends TestCase
 {
@@ -47,7 +46,7 @@ class PhpTest extends TestCase
     }
 
     /**
-     * It should provide the path to the PHP ini file
+     * It should provide the path to the PHP ini file.
      */
     public function testPhpIni()
     {

--- a/tests/Unit/Environment/Provider/PhpTest.php
+++ b/tests/Unit/Environment/Provider/PhpTest.php
@@ -47,23 +47,18 @@ class PhpTest extends TestCase
     }
 
     /**
-     * It should get the version from the remote process if the configured
-     * PHP binary is different from the one being used to execute PhpBench.
+     * It should provide the path to the PHP ini file
      */
-    public function testRemote()
+    public function testPhpIni()
     {
-        $this->launcher->payload(Argument::type('string'), [])->willReturn($this->payload->reveal());
-        $this->payload->launch()->willReturn(['version' => 'success', 'xdebug' => true]);
-        $info = $this->createProvider(true)->getInformation();
-        $this->assertEquals('success', $info['version']);
-        $this->assertTrue($info['xdebug']);
+        $info = $this->createProvider()->getInformation();
+        $this->assertEquals(php_ini_loaded_file(), $info['ini']);
     }
 
-    private function createProvider($remote = false)
+    private function createProvider()
     {
         return new Provider\Php(
-            $this->launcher->reveal(),
-            $remote
+            new Launcher()
         );
     }
 }


### PR DESCRIPTION
Added option to disable PHP ini:

- [x] Added `--php-disable-ini`
- [x] Added list of loaded extensions and path to INI to the PHP env provider.
- [x] Fixed the `php-config` option to allow multiple values, (e.g. `extension: [ json.so, phar.so ]`).

**NOTE**: Unforfortunately PHPBench currently requires the JSON extension to be loaded in the remote process - it has to be explicitly enabled, we could automatically enable it, but this might causes WTFs. Currently we just throw a helpful exception.

I think in the future we should change this and the remote processes should just return formatted plain text.

![tmp](https://user-images.githubusercontent.com/530801/31583040-5826edf6-b193-11e7-9c05-4f6410ee7a67.png)

So a configuration might look like this:

```javascript
{
    "bootstrap": "vendor/autoload.php",
    "path": "benchmarks",
    "php_disable_ini": true,
    "php_config": {
        "extension": [ "json.so" ]
    }
}
```