### PR TITLE
Calibration POC

### DIFF
--- a/lib/Benchmark/Metadata/BenchmarkMetadata.php
+++ b/lib/Benchmark/Metadata/BenchmarkMetadata.php
@@ -103,7 +103,7 @@ class BenchmarkMetadata
 
             foreach ($filters as $filter) {
                 if (preg_match(
-                    sprintf('{^.*?%s.*?$}', $filter),
+                    sprintf('{^.*?%s.*?$}', preg_quote($filter)),
                     sprintf('%s::%s', $this->getClass(), $subjectName)
                 )) {
                     $unset = false;

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -110,7 +110,7 @@ class Runner
      * @param string $contextName
      * @param string $path
      */
-    public function run(RunnerContext $context)
+    public function run(RunnerContext $context): Suite
     {
         $executorConfig = $this->executorRegistry->getConfig($context->getExecutor());
         $executor = $this->executorRegistry->getService($executorConfig['executor']);

--- a/lib/Console/Command/CalibrateCommand.php
+++ b/lib/Console/Command/CalibrateCommand.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace PhpBench\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use PhpBench\Storage\DriverInterface;
+use Symfony\Component\Console\Input\InputOption;
+use PhpBench\Registry\Registry;
+use PhpBench\Model\Suite;
+use PhpBench\Model\SuiteCollection;
+use PhpBench\Benchmark\Runner;
+use PhpBench\Model\Benchmark;
+use PhpBench\Model\Variant;
+use PhpBench\Model\Subject;
+use PhpBench\Benchmark\RunnerContext;
+use PhpBench\Model\Result\TimeResult;
+use PhpBench\Model\Result\ComputedResult;
+
+class CalibrateCommand extends Command
+{
+    /**
+     * @var DriverInterface
+     */
+    private $storage;
+
+    /**
+     * @var Runner
+     */
+    private $runner;
+
+    public function __construct(
+        Registry $storage,
+        Runner $runner
+    )
+    {
+        parent::__construct();
+        $this->storage = $storage;
+        $this->runner = $runner;
+    }
+
+    protected function configure()
+    {
+        $this->setName('calibrate');
+        $this->addOption('uuid', null, InputOption::VALUE_REQUIRED, 'UUID of run to calibrate against', 'latest');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $suites = $this->suiteCollection($input)->getSuites();
+
+        foreach ($suites as $suite) {
+            foreach ($suite->getBenchmarks() as $benchmark) {
+                foreach ($benchmark->getSubjects() as $subject) {
+                    foreach ($subject->getVariants() as $variant) {
+                        $context = $this->contextFrom($suite, $benchmark, $subject, $variant);
+                        $actualSuite = $this->runner->run($context);
+                        $this->outputDifference($output, $variant, $actualSuite);
+                    }
+                }
+            }
+        }
+    }
+
+    private function suiteCollection(InputInterface $input): SuiteCollection
+    {
+        return $this->storage->getService()->fetch($input->getOption('uuid'));
+    }
+
+    private function contextFrom(Suite $suite, Benchmark $benchmark, Subject $subject, Variant $variant)
+    {
+        $context = new RunnerContext(getcwd() . '/benchmarks', [
+            'filters' => [ sprintf('%s::%s', $benchmark->getClass(), $subject->getName()) ],
+        ]);
+
+        return $context;
+    }
+
+    private function outputDifference(OutputInterface $output, Variant $referenceVariant, Suite $newSuite)
+    {
+        $reference = $referenceVariant->getStats()->getMean();
+        $actual = $newSuite->getSummary()->getMeanTime();
+        $scaler = $reference / $actual;
+
+        $output->writeln(sprintf(
+            "%s::%s\t <comment>Reference: </>%s<comment> Actual: </>%s <comment>Scaler: </>%s",
+            $referenceVariant->getSubject()->getBenchmark()->getClass(), $referenceVariant->getSubject()->getName(),
+            $reference, $actual, $scaler
+        ));
+    }
+}

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -77,6 +77,7 @@ use PhpBench\Storage\UuidResolver;
 use PhpBench\Util\TimeUnit;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\ExecutableFinder;
+use PhpBench\Console\Command\CalibrateCommand;
 
 class CoreExtension implements ExtensionInterface
 {
@@ -326,6 +327,13 @@ class CoreExtension implements ExtensionInterface
             return new DeleteCommand(
                 $container->get('console.command.handler.suite_collection'),
                 $container->get('storage.driver_registry')
+            );
+        }, ['console.command' => []]);
+
+        $container->register('console.command.calibrate', function (Container $container) {
+            return new CalibrateCommand(
+                $container->get('storage.driver_registry'),
+                $container->get('benchmark.runner')
             );
         }, ['console.command' => []]);
 


### PR DESCRIPTION
POC for calibration.

The `calibrate` command accepts a reference (in this case a UUID, in the future a tag would also be acceptable when that feature lands) of a previous run, and executes the same benchmarks again, reporting the difference and the multiplier required to normalize the results.

```bash
$ ./bin/phpbench calibrate --uuid=133c96132930ab7777959384aaba32260e9da777
\PhpBench\Micro\Math\StatisticsBench::benchVariance      Reference: 6.608 Actual: 6.708 Scaler: 0.98509242695289
\PhpBench\Micro\Math\StatisticsBench::benchStDev         Reference: 7.434 Actual: 7.509 Scaler: 0.99001198561726
```

TODO:

- [ ] What happens if the benchmarks no longer exist?
- [ ] Multiplier configuration and application to (all?) results (or just assertions?)
- [ ] Match iterations to calibration run.
- [ ] Rewrite from scratch with tests.