### PR TITLE
Windows filename handling and commandline escaping

### DIFF
--- a/lib/Benchmark/Remote/Payload.php
+++ b/lib/Benchmark/Remote/Payload.php
@@ -70,6 +70,10 @@ class Payload
      */
     public function __construct($template, array $tokens = [], $phpBinary = PHP_BINARY, Process $process = null)
     {
+        if (PHP_OS === 'WINNT') {
+            $phpBinary = sprintf('"%s"', $phpBinary);
+        }
+
         $this->template = $template;
         $this->process = $process ?: new Process($phpBinary);
         $this->tokens = $tokens;

--- a/lib/Benchmark/Remote/Payload.php
+++ b/lib/Benchmark/Remote/Payload.php
@@ -70,17 +70,13 @@ class Payload
      */
     public function __construct($template, array $tokens = [], $phpBinary = PHP_BINARY, Process $process = null)
     {
-        if (PHP_OS === 'WINNT') {
-            $phpBinary = sprintf('"%s"', $phpBinary);
-        }
-
+        $this->phpBinary = escapeshellarg($phpBinary);
         $this->template = $template;
-        $this->process = $process ?: new Process($phpBinary);
+        $this->process = $process ?: new Process($this->phpBinary);
         $this->tokens = $tokens;
 
         // disable timeout.
         $this->process->setTimeout(null);
-        $this->phpBinary = $phpBinary;
         $this->iniStringBuilder = new IniStringBuilder();
     }
 
@@ -99,7 +95,7 @@ class Payload
 
     public function setPhpPath($phpBinary)
     {
-        $this->phpBinary = $phpBinary;
+        $this->phpBinary = escapeshellarg($phpBinary);
     }
 
     public function disableIni()

--- a/lib/PhpBench.php
+++ b/lib/PhpBench.php
@@ -73,6 +73,10 @@ class PhpBench
             return $path;
         }
 
+        if (PHP_OS === 'WINNT') {
+            return stream_resolve_include_path($path);
+        }
+
         return getcwd() . DIRECTORY_SEPARATOR . $path;
     }
 

--- a/lib/PhpBench.php
+++ b/lib/PhpBench.php
@@ -69,15 +69,7 @@ class PhpBench
      */
     public static function normalizePath($path)
     {
-        if (substr($path, 0, 1) == DIRECTORY_SEPARATOR) {
-            return $path;
-        }
-
-        if (PHP_OS === 'WINNT') {
-            return stream_resolve_include_path($path);
-        }
-
-        return getcwd() . DIRECTORY_SEPARATOR . $path;
+        return stream_resolve_include_path($path);
     }
 
     private static function loadConfig()


### PR DESCRIPTION
Hi,

i discovered two bugs when trying to run phpbench from Windows 10:

1. When resolving the benchmark-directory phpbench prepends the current working directory to relative paths. Whether or not a path is absolute is determined by checking if the first character of the path is a forward slash. On Windows hosts, however, absolute paths start with a drive-name. Therefore the current working directory was prepended for absolute paths as well.

2. On Windows hosts the php-binary usually lives under `C:\Program Files\`. When starting a new process phpbench must account for the space in the filename and wrap the path of the binary in double-quotes.

With these two fixes i was able to run phpbench successfully under my Windows 10 system.