### PR TITLE
Optimization flags added for the application

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,5 @@ before_install:
     -in .travis/secrets.tar.enc -out .travis/secrets.tar -d
 
 after_success:
-    - if [[ $EXECUTE_DEPLOYMENT == 'true' && $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then composer install --no-dev ; fi
+    - if [[ $EXECUTE_DEPLOYMENT == 'true' && $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then composer install --no-dev -oa ; fi
     - if [[ $EXECUTE_DEPLOYMENT == 'true' && $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then ./.travis/deploy.sh ; fi


### PR DESCRIPTION
This modification adds the following flags for the CLI application:

- `o`: Optimize autoloader
- `a`: Autoload classes from the classmap only

See https://getcomposer.org/doc/articles/autoloader-optimization.md for additional information.