### PR TITLE
Fix: Remove unnecessary parentheses

### DIFF
--- a/bin/phpbench
+++ b/bin/phpbench
@@ -1,4 +1,4 @@
 #!/usr/bin/env php
 <?php
 
-require(__DIR__ . '/phpbench.php');
+require __DIR__ . '/phpbench.php';


### PR DESCRIPTION
This PR

* [x] remove unnecessary parentheses when using `require`