### PR TITLE
Fix: Case mismatch

### DIFF
--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -170,7 +170,7 @@ class Runner
             // override parameters
             $subjectMetadata->setIterations($context->getIterations($subjectMetadata->getIterations()));
             $subjectMetadata->setRevs($context->getRevolutions($subjectMetadata->getRevs()));
-            $subjectMetadata->setWarmup($context->getWarmup($subjectMetadata->getWarmUp()));
+            $subjectMetadata->setWarmup($context->getWarmup($subjectMetadata->getWarmup()));
             $subjectMetadata->setSleep($context->getSleep($subjectMetadata->getSleep()));
             $subjectMetadata->setRetryThreshold($context->getRetryThreshold($this->retryThreshold));
 

--- a/tests/Unit/Model/SuiteTest.php
+++ b/tests/Unit/Model/SuiteTest.php
@@ -104,7 +104,7 @@ class SuiteTest extends TestCase
         $this->subject1->getVariants()->willReturn([$this->variant1->reveal()]);
         $this->variant1->hasErrorStack()->willReturn(true);
         $this->variant1->count()->willReturn(1);
-        $this->variant1->getSubject()->wilLReturn($this->subject1->reveal());
+        $this->variant1->getSubject()->willReturn($this->subject1->reveal());
         $this->variant1->getRevolutions()->willReturn(10);
         $this->variant1->getRejectCount()->willReturn(0);
         $this->variant1->getRejectCount()->willReturn(0);

--- a/tests/Unit/Model/SummaryTest.php
+++ b/tests/Unit/Model/SummaryTest.php
@@ -41,9 +41,9 @@ class SummaryTest extends TestCase
         $this->bench1->getSubjects()->willReturn([$this->subject1->reveal()]);
         $this->subject1->getVariants()->willReturn([$this->variant1->reveal()]);
         $this->variant1->getStats()->willReturn($this->stats->reveal());
-        $this->variant1->count()->wilLReturn(4);
-        $this->variant1->getRejectCount()->wilLReturn(11);
-        $this->variant1->hasErrorStack()->wilLReturn(false);
+        $this->variant1->count()->willReturn(4);
+        $this->variant1->getRejectCount()->willReturn(11);
+        $this->variant1->hasErrorStack()->willReturn(false);
         $this->variant1->getRevolutions()->willReturn(10);
         $this->variant1->getSubject()->willReturn($this->subject1->reveal());
         $this->variant1->getFailures()->willReturn(new AssertionFailures($this->variant1->reveal()));

--- a/tests/Unit/Registry/ConfigurableRegistryTest.php
+++ b/tests/Unit/Registry/ConfigurableRegistryTest.php
@@ -91,7 +91,7 @@ class ConfigurableRegistryTest extends RegistryTest
             'three' => 'four',
             'two' => 'three',
             'four' => 'five',
-        ], $result->getarraycopy());
+        ], $result->getArrayCopy());
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] fixes case mismatches when invoking methods