### PR TITLE
Use tags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "beberlei/assert": "^2.4",
         "doctrine/annotations": "^1.2.7",
         "lstrojny/functional-php": "1.0|^1.2.3",
-        "phpbench/container": "~1.0",
+        "phpbench/container": "~1.2",
         "phpbench/dom": "~0.2.0",
         "seld/jsonlint": "^1.0",
         "symfony/console": "^2.6|^3.0|^4.0",

--- a/docs/benchmark-runner.rst
+++ b/docs/benchmark-runner.rst
@@ -205,24 +205,24 @@ implementation and specify a *tag*:
 
 .. code-block:: bash
 
-    $ # .. configure for implementation A
-    $ phpbench run --tag="Impl. A" --dump-file=impl-a.xml
-    $ # .. configure for implementation B
-    $ phpbench run --tag="Impl. B" --dump-file=impl-b.xml
-    $ # .. configure for implementation C
-    $ phpbench run --tag="Impl. C" --dump-file=impl-c.xml
+    # .. configure for implementation A
+    $ phpbench run --tag=impl_a --store
+    # .. configure for implementation B
+    $ phpbench run --tag=impl_b --store
+    # .. configure for implementation C
+    $ phpbench run --tag=impl_c --store
 
 Now you can use the `report` command and specify the `compare` report to
 compare the results for each implementation side-by-side:
 
 .. code-block:: bash
 
-    $ phpbench report --file=impl-a.xml --file=impl-b.xml --file=impl-c.xml --report=compare
-    +---------+------------------+----------+---------+--------+-----------+-----------+-----------+
-    | tag     | benchmark        | subject  | group   | params | t:Impl. A | t:Impl. C | t:Impl. B |
-    +---------+------------------+----------+---------+--------+-----------+-----------+-----------+
-    | Impl. A | HashingBenchmark | benchMd5 | hashing | []     | 2.4448μs  | 4.3039μs  | 1.5003μs  |
-    +---------+------------------+----------+---------+--------+-----------+-----------+-----------+
+    $ phpbench report --uuid=tag:impl_a --uuid=tag:impl_b --uuid=tag:impl_c --report='{extends: compare, compare: tag}'
+    +--------------+----------+--------+--------+------+-----------------+-----------------+-----------------+
+    | benchmark    | subject  | groups | params | revs | tag:impl_a:mean | tag:impl_b:mean | tag:impl_c:mean |
+    +--------------+----------+--------+--------+------+-----------------+-----------------+-----------------+
+    | HashingBench | benchMd5 |        | []     | 1000 | 0.957μs         | 0.939μs         | 0.952μs         |
+    +--------------+----------+--------+--------+------+-----------------+-----------------+-----------------+
 
 Progress Reporters
 ------------------

--- a/docs/benchmark-runner.rst
+++ b/docs/benchmark-runner.rst
@@ -201,16 +201,16 @@ You can compare the results of two or more sets of results using the `compare`
 report.
 
 First you should generate a suite result document for each separate
-implementation and specify a *context*:
+implementation and specify a *tag*:
 
 .. code-block:: bash
 
     $ # .. configure for implementation A
-    $ phpbench run --context="Impl. A" --dump-file=impl-a.xml
+    $ phpbench run --tag="Impl. A" --dump-file=impl-a.xml
     $ # .. configure for implementation B
-    $ phpbench run --context="Impl. B" --dump-file=impl-b.xml
+    $ phpbench run --tag="Impl. B" --dump-file=impl-b.xml
     $ # .. configure for implementation C
-    $ phpbench run --context="Impl. C" --dump-file=impl-c.xml
+    $ phpbench run --tag="Impl. C" --dump-file=impl-c.xml
 
 Now you can use the `report` command and specify the `compare` report to
 compare the results for each implementation side-by-side:
@@ -219,7 +219,7 @@ compare the results for each implementation side-by-side:
 
     $ phpbench report --file=impl-a.xml --file=impl-b.xml --file=impl-c.xml --report=compare
     +---------+------------------+----------+---------+--------+-----------+-----------+-----------+
-    | context | benchmark        | subject  | group   | params | t:Impl. A | t:Impl. C | t:Impl. B |
+    | tag     | benchmark        | subject  | group   | params | t:Impl. A | t:Impl. C | t:Impl. B |
     +---------+------------------+----------+---------+--------+-----------+-----------+-----------+
     | Impl. A | HashingBenchmark | benchMd5 | hashing | []     | 2.4448μs  | 4.3039μs  | 1.5003μs  |
     +---------+------------------+----------+---------+--------+-----------+-----------+-----------+

--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -43,7 +43,7 @@ see what you have got:
     run 875c827946204db23eadd4b10e76b7189e10dde2
     Date:    2016-03-19T09:46:52+01:00
     Branch:  git_log
-    Context: <none>
+    Tag: <none>
     Scale:   1 subjects, 60 iterations, 120 revolutions
     Summary: (best [mean] worst) = 433.467 [988.067] 504.600 (μs)
              ⅀T: 59,284.000μs μRSD/r: 9.911%
@@ -51,7 +51,7 @@ see what you have got:
     run 9d38a760e6ebec0a466c80f148264a7a4bb7a203
     Date:    2016-03-19T09:46:39+01:00
     Branch:  git_log
-    Context: <none>
+    Tag: <none>
     Scale:   1 subjects, 30 iterations, 30 revolutions
     Summary: (best [mean] worst) = 461.800 [935.720] 503.300 (μs)
              ⅀T: 28,071.600μs μRSD/r: 4.582%

--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -31,6 +31,15 @@ when running your benchmarks:
 
     $ phpbench run --store
 
+You can tag runs with the ``--tag`` option to make them easier to reference
+(more on this later):
+
+.. code-block:: bash
+
+    $ phpbench run --store --tag=my_tag_name
+
+Tags must be alpha-numeric and may also contain underscores.
+
 Viewing the History
 -------------------
 
@@ -71,8 +80,14 @@ You may also specify a different report with the ``--report`` option. In order
 to compare two or more reports, you should use the ``report`` command as
 detailed in the following section.
 
-Meta UUIDs
-----------
+Pseudo UUIDs
+------------
+
+UUIDs are difficult to work with. Phpbench allows you to use a number of
+"pseudo" uuids.
+
+``latest``
+~~~~~~~~~~
 
 It is possible to specify "meta" UUIDs, such as ``latest``:
 
@@ -89,6 +104,21 @@ the history from the latest:
 
 Would show the second latest entry. Meta UUIDs can be used anywhere where you
 would normally specify a UUID, including queries.
+
+``tag:``
+~~~~~~~~
+
+Allows you to reference a tagged run. If you store a suite:
+
+.. code-block:: bash
+
+    $ phpbench run --store --tag=my_tag
+
+Then you can reference it with ``tag:my_tag``
+
+.. code-block:: bash
+
+    $ phpbench show tag:my_tag
 
 Querying
 --------

--- a/extensions/dbal/lib/Storage/Driver/Dbal/HistoryIterator.php
+++ b/extensions/dbal/lib/Storage/Driver/Dbal/HistoryIterator.php
@@ -44,7 +44,7 @@ class HistoryIterator implements HistoryIteratorInterface
         $entry = new HistoryEntry(
             $current['run_uuid'],
             new \DateTime($current['run_date']),
-            $current['context'],
+            $current['tag'],
             $current['vcs_branch'],
             $current['nb_subjects'],
             $current['nb_iterations'],

--- a/extensions/dbal/lib/Storage/Driver/Dbal/Loader.php
+++ b/extensions/dbal/lib/Storage/Driver/Dbal/Loader.php
@@ -145,7 +145,7 @@ class Loader
         }
 
         $suite = new Suite(
-            $row['run.context'],
+            $row['run.tag'],
             new \DateTime($row['run.date']),
             null,
             [],

--- a/extensions/dbal/lib/Storage/Driver/Dbal/Persister.php
+++ b/extensions/dbal/lib/Storage/Driver/Dbal/Persister.php
@@ -37,7 +37,6 @@ class Persister
             $id = $this->insertUpdate($conn, 'run', [
                 'uuid' => $suite->getUuid(),
                 'tag' => $suite->getTag(),
-                'tag' => $suite->getTag(),
                 'date' => $suite->getDate()->format('Y-m-d H:i:s'),
                 'nb_subjects' => $summary->getNbSubjects(),
                 'nb_iterations' => $summary->getNbIterations(),

--- a/extensions/dbal/lib/Storage/Driver/Dbal/Persister.php
+++ b/extensions/dbal/lib/Storage/Driver/Dbal/Persister.php
@@ -37,6 +37,7 @@ class Persister
             $id = $this->insertUpdate($conn, 'run', [
                 'uuid' => $suite->getUuid(),
                 'tag' => $suite->getTag(),
+                'tag' => $suite->getTag(),
                 'date' => $suite->getDate()->format('Y-m-d H:i:s'),
                 'nb_subjects' => $summary->getNbSubjects(),
                 'nb_iterations' => $summary->getNbIterations(),

--- a/extensions/dbal/lib/Storage/Driver/Dbal/Persister.php
+++ b/extensions/dbal/lib/Storage/Driver/Dbal/Persister.php
@@ -36,7 +36,7 @@ class Persister
             $summary = $suite->getSummary();
             $id = $this->insertUpdate($conn, 'run', [
                 'uuid' => $suite->getUuid(),
-                'context' => $suite->getContextName(),
+                'tag' => $suite->getTag(),
                 'date' => $suite->getDate()->format('Y-m-d H:i:s'),
                 'nb_subjects' => $summary->getNbSubjects(),
                 'nb_iterations' => $summary->getNbIterations(),

--- a/extensions/dbal/lib/Storage/Driver/Dbal/Repository.php
+++ b/extensions/dbal/lib/Storage/Driver/Dbal/Repository.php
@@ -127,7 +127,7 @@ EOT;
 SELECT 
     run.uuid AS run_uuid, 
     run.date AS run_date,
-    run.context AS context,
+    run.tag AS tag,
     environment.value AS vcs_branch,
     run.nb_subjects AS nb_subjects,
     run.nb_iterations AS nb_iterations,

--- a/extensions/dbal/lib/Storage/Driver/Dbal/Schema.php
+++ b/extensions/dbal/lib/Storage/Driver/Dbal/Schema.php
@@ -40,7 +40,7 @@ class Schema extends BaseSchema
         $table = $this->createTable('run');
         $table->addColumn('id', 'integer', ['autoincrement' => true]);
         $table->addColumn('uuid', 'string');
-        $table->addColumn('context', 'string', ['notnull' => false]);
+        $table->addColumn('tag', 'string', ['notnull' => false]);
         $table->addColumn('date', 'datetime');
         $table->addColumn('nb_subjects', 'integer');
         $table->addColumn('nb_iterations', 'integer');

--- a/extensions/dbal/lib/Storage/Driver/Dbal/Visitor/SqlVisitor.php
+++ b/extensions/dbal/lib/Storage/Driver/Dbal/Visitor/SqlVisitor.php
@@ -83,7 +83,7 @@ class SqlVisitor
         $select = [
             'run.id',
             'run.uuid',
-            'run.context',
+            'run.tag',
             'run.date',
             'subject.benchmark',
             'subject.name',

--- a/extensions/dbal/lib/Storage/Driver/Dbal/Visitor/TokenValueVisitor.php
+++ b/extensions/dbal/lib/Storage/Driver/Dbal/Visitor/TokenValueVisitor.php
@@ -16,7 +16,7 @@ use PhpBench\Expression\Constraint\Comparison;
 use PhpBench\Expression\Constraint\Composite;
 use PhpBench\Expression\Constraint\Constraint;
 use PhpBench\Extensions\Dbal\Storage\Driver\Dbal\Repository;
-use PhpBench\Storage\UuidResolver;
+use PhpBench\Storage\UuidResolverInterface;
 
 /**
  * Resolves token values, for example "latest" will be resolved to the latest
@@ -29,7 +29,7 @@ class TokenValueVisitor
      */
     private $uuidResolver;
 
-    public function __construct(UuidResolver $uuidResolver)
+    public function __construct(UuidResolverInterface $uuidResolver)
     {
         $this->uuidResolver = $uuidResolver;
     }

--- a/extensions/dbal/tests/Functional/Storage/Driver/Dbal/HistoryIteratorTest.php
+++ b/extensions/dbal/tests/Functional/Storage/Driver/Dbal/HistoryIteratorTest.php
@@ -76,7 +76,7 @@ class HistoryIteratorTest extends DbalTestCase
         $this->assertInstanceOf('PhpBench\Storage\HistoryEntry', $current);
         $this->assertEquals('2016-01-01', $current->getDate()->format('Y-m-d'));
         $this->assertEquals('branch_1', $current->getVcsBranch());
-        $this->assertEquals('one', $current->getContext());
+        $this->assertEquals('one', $current->getTag());
         $this->assertEquals(1, $current->getRunId());
 
         $this->iterator->next();
@@ -84,7 +84,7 @@ class HistoryIteratorTest extends DbalTestCase
         $this->assertInstanceOf('PhpBench\Storage\HistoryEntry', $current);
         $this->assertEquals('2015-01-01', $current->getDate()->format('Y-m-d'));
         $this->assertEquals('branch_2', $current->getVcsBranch());
-        $this->assertEquals('two', $current->getContext());
+        $this->assertEquals('two', $current->getTag());
         $this->assertEquals(2, $current->getRunId());
     }
 }

--- a/extensions/dbal/tests/Functional/Storage/Driver/Dbal/RepositoryTest.php
+++ b/extensions/dbal/tests/Functional/Storage/Driver/Dbal/RepositoryTest.php
@@ -71,7 +71,7 @@ class RepositoryTest extends DbalTestCase
         $this->assertEquals([
             [
                 'run_date' => '2016-01-01 00:00:00',
-                'context' => 'one',
+                'tag' => 'one',
                 'vcs_branch' => 'branch_1',
                 'run_uuid' => 1,
                 'nb_subjects' => '1',
@@ -85,7 +85,7 @@ class RepositoryTest extends DbalTestCase
             ],
             [
                 'run_date' => '2015-01-01 00:00:00',
-                'context' => 'two',
+                'tag' => 'two',
                 'vcs_branch' => 'branch_2',
                 'run_uuid' => 2,
                 'nb_subjects' => '1',

--- a/extensions/dbal/tests/Unit/Storage/Driver/Dbal/Visitor/TokenValueVisitorTest.php
+++ b/extensions/dbal/tests/Unit/Storage/Driver/Dbal/Visitor/TokenValueVisitorTest.php
@@ -14,8 +14,8 @@ namespace PhpBench\Tests\Unit\Storage\Driver\Dbal\Visitor;
 
 use PhpBench\Expression\Parser;
 use PhpBench\Extensions\Dbal\Storage\Driver\Dbal\Visitor\TokenValueVisitor;
-use PhpBench\Storage\UuidResolver;
 use PHPUnit\Framework\TestCase;
+use PhpBench\Storage\UuidResolverInterface;
 
 class TokenValueVisitorTest extends TestCase
 {
@@ -24,7 +24,7 @@ class TokenValueVisitorTest extends TestCase
 
     public function setUp()
     {
-        $this->uuidResolver = $this->prophesize(UuidResolver::class);
+        $this->uuidResolver = $this->prophesize(UuidResolverInterface::class);
         $this->visitor = new TokenValueVisitor($this->uuidResolver->reveal());
         $this->parser = new Parser();
     }

--- a/extensions/dbal/tests/Unit/Storage/Driver/Dbal/Visitor/TokenValueVisitorTest.php
+++ b/extensions/dbal/tests/Unit/Storage/Driver/Dbal/Visitor/TokenValueVisitorTest.php
@@ -14,8 +14,8 @@ namespace PhpBench\Tests\Unit\Storage\Driver\Dbal\Visitor;
 
 use PhpBench\Expression\Parser;
 use PhpBench\Extensions\Dbal\Storage\Driver\Dbal\Visitor\TokenValueVisitor;
-use PHPUnit\Framework\TestCase;
 use PhpBench\Storage\UuidResolverInterface;
+use PHPUnit\Framework\TestCase;
 
 class TokenValueVisitorTest extends TestCase
 {

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -107,19 +107,19 @@ class Runner
      *
      * The $name argument will set the "name" attribute on the "suite" element.
      *
-     * @param string $contextName
+     * @param string $tagName
      * @param string $path
      */
-    public function run($path, RunnerConfig $context)
+    public function run($path, RunnerConfig $tag)
     {
-        $executorConfig = $this->executorRegistry->getConfig($context->getExecutor());
+        $executorConfig = $this->executorRegistry->getConfig($tag->getExecutor());
         $executor = $this->executorRegistry->getService($executorConfig['executor']);
         $executor->healthCheck();
 
         // build the collection of benchmarks to be executed.
-        $benchmarkMetadatas = $this->benchmarkFinder->findBenchmarks($path, $context->getFilters(), $context->getGroups());
+        $benchmarkMetadatas = $this->benchmarkFinder->findBenchmarks($path, $tag->getFilters(), $tag->getGroups());
         $suite = new Suite(
-            $context->getContextName(),
+            $tag->getTag(),
             new \DateTime(),
             $this->configPath
         );
@@ -132,7 +132,7 @@ class Runner
             /* @var BenchmarkMetadata */
             foreach ($benchmarkMetadatas as $benchmarkMetadata) {
                 $benchmark = $suite->createBenchmark($benchmarkMetadata->getClass());
-                $this->runBenchmark($executor, $context, $benchmark, $benchmarkMetadata);
+                $this->runBenchmark($executor, $tag, $benchmark, $benchmarkMetadata);
             }
         } catch (StopOnErrorException $e) {
         }
@@ -146,7 +146,7 @@ class Runner
 
     private function runBenchmark(
         ExecutorInterface $executor,
-        RunnerConfig $context,
+        RunnerConfig $config,
         Benchmark $benchmark,
         BenchmarkMetadata $benchmarkMetadata
     ) {
@@ -168,14 +168,14 @@ class Runner
         foreach ($subjectMetadatas as $subjectMetadata) {
 
             // override parameters
-            $subjectMetadata->setIterations($context->getIterations($subjectMetadata->getIterations()));
-            $subjectMetadata->setRevs($context->getRevolutions($subjectMetadata->getRevs()));
-            $subjectMetadata->setWarmup($context->getWarmup($subjectMetadata->getWarmup()));
-            $subjectMetadata->setSleep($context->getSleep($subjectMetadata->getSleep()));
-            $subjectMetadata->setRetryThreshold($context->getRetryThreshold($this->retryThreshold));
+            $subjectMetadata->setIterations($config->getIterations($subjectMetadata->getIterations()));
+            $subjectMetadata->setRevs($config->getRevolutions($subjectMetadata->getRevs()));
+            $subjectMetadata->setWarmup($config->getWarmup($subjectMetadata->getWarmup()));
+            $subjectMetadata->setSleep($config->getSleep($subjectMetadata->getSleep()));
+            $subjectMetadata->setRetryThreshold($config->getRetryThreshold($this->retryThreshold));
 
-            if ($context->getAssertions()) {
-                $subjectMetadata->setAssertions($this->assertionProcessor->assertionsFromRawCliConfig($context->getAssertions()));
+            if ($config->getAssertions()) {
+                $subjectMetadata->setAssertions($this->assertionProcessor->assertionsFromRawCliConfig($config->getAssertions()));
             }
 
             $benchmark->createSubjectFromMetadata($subjectMetadata);
@@ -186,7 +186,7 @@ class Runner
             $subjectMetadata = $subjectMetadatas[$index];
 
             $this->logger->subjectStart($subject);
-            $this->runSubject($executor, $context, $subject, $subjectMetadata);
+            $this->runSubject($executor, $config, $subject, $subjectMetadata);
             $this->logger->subjectEnd($subject);
         }
         $this->logger->benchmarkEnd($benchmark);
@@ -196,9 +196,9 @@ class Runner
         }
     }
 
-    private function runSubject(ExecutorInterface $executor, RunnerConfig $context, Subject $subject, SubjectMetadata $subjectMetadata)
+    private function runSubject(ExecutorInterface $executor, RunnerConfig $tag, Subject $subject, SubjectMetadata $subjectMetadata)
     {
-        $parameterSets = $context->getParameterSets($subjectMetadata->getParameterSets());
+        $parameterSets = $tag->getParameterSets($subjectMetadata->getParameterSets());
         $paramsIterator = new CartesianParameterIterator($parameterSets);
 
         // create the variants.
@@ -215,7 +215,7 @@ class Runner
 
         // run the variants.
         foreach ($subject->getVariants() as $variant) {
-            $this->runVariant($executor, $context, $subjectMetadata, $variant);
+            $this->runVariant($executor, $tag, $subjectMetadata, $variant);
         }
 
         return $subject;
@@ -223,11 +223,11 @@ class Runner
 
     private function runVariant(
         ExecutorInterface $executor,
-        RunnerConfig $context,
+        RunnerConfig $tag,
         SubjectMetadata $subjectMetadata,
         Variant $variant
     ) {
-        $executorConfig = $this->executorRegistry->getConfig($context->getExecutor());
+        $executorConfig = $this->executorRegistry->getConfig($tag->getExecutor());
         $this->logger->variantStart($variant);
         $rejectCount = [];
 
@@ -240,7 +240,7 @@ class Runner
             $variant->setException($e);
             $this->logger->variantEnd($variant);
 
-            if ($context->getStopOnError()) {
+            if ($tag->getStopOnError()) {
                 throw new StopOnErrorException();
             }
 

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -106,20 +106,17 @@ class Runner
      * Run all benchmarks (or all applicable benchmarks) in the given path.
      *
      * The $name argument will set the "name" attribute on the "suite" element.
-     *
-     * @param string $tagName
-     * @param string $path
      */
-    public function run($path, RunnerConfig $tag)
+    public function run($path, RunnerConfig $config)
     {
-        $executorConfig = $this->executorRegistry->getConfig($tag->getExecutor());
+        $executorConfig = $this->executorRegistry->getConfig($config->getExecutor());
         $executor = $this->executorRegistry->getService($executorConfig['executor']);
         $executor->healthCheck();
 
         // build the collection of benchmarks to be executed.
-        $benchmarkMetadatas = $this->benchmarkFinder->findBenchmarks($path, $tag->getFilters(), $tag->getGroups());
+        $benchmarkMetadatas = $this->benchmarkFinder->findBenchmarks($path, $config->getFilters(), $config->getGroups());
         $suite = new Suite(
-            $tag->getTag(),
+            $config->getTag(),
             new \DateTime(),
             $this->configPath
         );
@@ -132,7 +129,7 @@ class Runner
             /* @var BenchmarkMetadata */
             foreach ($benchmarkMetadatas as $benchmarkMetadata) {
                 $benchmark = $suite->createBenchmark($benchmarkMetadata->getClass());
-                $this->runBenchmark($executor, $tag, $benchmark, $benchmarkMetadata);
+                $this->runBenchmark($executor, $config, $benchmark, $benchmarkMetadata);
             }
         } catch (StopOnErrorException $e) {
         }

--- a/lib/Benchmark/RunnerConfig.php
+++ b/lib/Benchmark/RunnerConfig.php
@@ -27,7 +27,7 @@ class RunnerConfig
     /**
      * @var string
      */
-    private $contextName;
+    private $tag;
 
     /**
      * @var array
@@ -117,9 +117,9 @@ class RunnerConfig
      *
      * @return string
      */
-    public function getContextName()
+    public function getTag()
     {
-        return $this->contextName;
+        return $this->tag;
     }
 
     /**
@@ -274,10 +274,10 @@ class RunnerConfig
         return $new;
     }
 
-    public function withContextName(string $contextName = null): self
+    public function withTag(string $tag = null): self
     {
         $new = clone $this;
-        $new->contextName = $contextName;
+        $new->tag = $tag;
 
         return $new;
     }

--- a/lib/Console/Command/Handler/SuiteCollectionHandler.php
+++ b/lib/Console/Command/Handler/SuiteCollectionHandler.php
@@ -16,10 +16,10 @@ use PhpBench\Expression\Parser;
 use PhpBench\Model\SuiteCollection;
 use PhpBench\Registry\Registry;
 use PhpBench\Serializer\XmlDecoder;
-use PhpBench\Storage\UuidResolver;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use PhpBench\Storage\UuidResolverInterface;
 
 class SuiteCollectionHandler
 {
@@ -32,7 +32,7 @@ class SuiteCollectionHandler
         XmlDecoder $xmlDecoder,
         Parser $parser,
         Registry $storage,
-        UuidResolver $uuidResolver
+        UuidResolverInterface $uuidResolver
     ) {
         $this->xmlDecoder = $xmlDecoder;
         $this->parser = $parser;

--- a/lib/Console/Command/Handler/SuiteCollectionHandler.php
+++ b/lib/Console/Command/Handler/SuiteCollectionHandler.php
@@ -16,10 +16,10 @@ use PhpBench\Expression\Parser;
 use PhpBench\Model\SuiteCollection;
 use PhpBench\Registry\Registry;
 use PhpBench\Serializer\XmlDecoder;
+use PhpBench\Storage\UuidResolverInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use PhpBench\Storage\UuidResolverInterface;
 
 class SuiteCollectionHandler
 {

--- a/lib/Console/Command/LogCommand.php
+++ b/lib/Console/Command/LogCommand.php
@@ -83,7 +83,7 @@ EOT
             $lines[] = sprintf('<comment>run %s</>', $entry->getRunId());
             $lines[] = sprintf('Date:    ' . $entry->getDate()->format('c'));
             $lines[] = sprintf('Branch:  ' . $entry->getVcsBranch());
-            $lines[] = sprintf('Tag: ' . ($entry->getTag() ?: '<none>'));
+            $lines[] = sprintf('Tag:     ' . ($entry->getTag() ?: '<none>'));
             $lines[] = sprintf('Scale:   ' . '%d subjects, %d iterations, %d revolutions', $entry->getNbSubjects(), $entry->getNbIterations(), $entry->getNbRevolutions());
 
             $lines[] = sprintf(

--- a/lib/Console/Command/LogCommand.php
+++ b/lib/Console/Command/LogCommand.php
@@ -83,7 +83,7 @@ EOT
             $lines[] = sprintf('<comment>run %s</>', $entry->getRunId());
             $lines[] = sprintf('Date:    ' . $entry->getDate()->format('c'));
             $lines[] = sprintf('Branch:  ' . $entry->getVcsBranch());
-            $lines[] = sprintf('Context: ' . ($entry->getContext() ?: '<none>'));
+            $lines[] = sprintf('Tag: ' . ($entry->getTag() ?: '<none>'));
             $lines[] = sprintf('Scale:   ' . '%d subjects, %d iterations, %d revolutions', $entry->getNbSubjects(), $entry->getNbIterations(), $entry->getNbRevolutions());
 
             $lines[] = sprintf(

--- a/lib/Console/Command/RunCommand.php
+++ b/lib/Console/Command/RunCommand.php
@@ -20,11 +20,11 @@ use PhpBench\Console\Command\Handler\TimeUnitHandler;
 use PhpBench\Model\SuiteCollection;
 use PhpBench\PhpBench;
 use PhpBench\Registry\Registry;
+use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use RuntimeException;
 
 class RunCommand extends Command
 {

--- a/lib/Console/Command/RunCommand.php
+++ b/lib/Console/Command/RunCommand.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use RuntimeException;
 
 class RunCommand extends Command
 {
@@ -55,12 +56,7 @@ class RunCommand extends Command
      */
     private $storage;
 
-    public function __construct(
-        RunnerHandler $runnerHandler,
-        ReportHandler $reportHandler,
-        TimeUnitHandler $timeUnitHandler,
-        DumpHandler $dumpHandler,
-        Registry $storage
+    public function __construct(RunnerHandler $runnerHandler, ReportHandler $reportHandler, TimeUnitHandler $timeUnitHandler, DumpHandler $dumpHandler, Registry $storage
     ) {
         parent::__construct();
         $this->runnerHandler = $runnerHandler;
@@ -91,7 +87,8 @@ EOT
         $this->addOption('warmup', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Override number of warmup revolutions on all benchmarks');
         $this->addOption('retry-threshold', 'r', InputOption::VALUE_REQUIRED, 'Set target allowable deviation', null);
         $this->addOption('sleep', null, InputOption::VALUE_REQUIRED, 'Number of microseconds to sleep between iterations');
-        $this->addOption('context', null, InputOption::VALUE_REQUIRED, 'Context label to apply to the suite result (useful when comparing reports)');
+        $this->addOption('context', null, InputOption::VALUE_REQUIRED, 'DEPRECATED! Use tag instead.');
+        $this->addOption('tag', null, InputOption::VALUE_REQUIRED, 'Tag to apply to stored result (useful when comparing reports)');
         $this->addOption('store', null, InputOption::VALUE_NONE, 'Persist the results');
         $this->addOption('tolerate-failure', null, InputOption::VALUE_NONE, 'Return 0 exit code even when failures occur');
     }
@@ -102,7 +99,7 @@ EOT
         $this->reportHandler->validateReportsFromInput($input);
 
         $config = RunnerConfig::create()
-            ->withContextName($input->getOption('context'))
+            ->withTag($this->resolveTag($input))
             ->withRetryThreshold($input->getOption('retry-threshold'))
             ->withSleep($input->getOption('sleep'))
             ->withIterations($input->getOption('iterations'))
@@ -137,5 +134,23 @@ EOT
         }
 
         return 0;
+    }
+
+    private function resolveTag(InputInterface $input)
+    {
+        $tag = $input->getOption('tag');
+        $context = $input->getOption('context');
+
+        if ($tag && $context) {
+            throw new RuntimeException(
+                'Options `tag` and `context` are synonyms (and context is deprecated), you cannot use them both'
+            );
+        }
+
+        if ($context) {
+            return $context;
+        }
+
+        return $tag;
     }
 }

--- a/lib/Console/Command/ShowCommand.php
+++ b/lib/Console/Command/ShowCommand.php
@@ -16,11 +16,11 @@ use PhpBench\Console\Command\Handler\DumpHandler;
 use PhpBench\Console\Command\Handler\ReportHandler;
 use PhpBench\Console\Command\Handler\TimeUnitHandler;
 use PhpBench\Registry\Registry;
+use PhpBench\Storage\UuidResolverInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use PhpBench\Storage\UuidResolverInterface;
 
 /**
  * Command to show/report on a specific run.

--- a/lib/Console/Command/ShowCommand.php
+++ b/lib/Console/Command/ShowCommand.php
@@ -16,11 +16,11 @@ use PhpBench\Console\Command\Handler\DumpHandler;
 use PhpBench\Console\Command\Handler\ReportHandler;
 use PhpBench\Console\Command\Handler\TimeUnitHandler;
 use PhpBench\Registry\Registry;
-use PhpBench\Storage\UuidResolver;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use PhpBench\Storage\UuidResolverInterface;
 
 /**
  * Command to show/report on a specific run.
@@ -38,7 +38,7 @@ class ShowCommand extends Command
         ReportHandler $reportHandler,
         TimeUnitHandler $timeUnitHandler,
         DumpHandler $dumpHandler,
-        UuidResolver $uuidResolver
+        UuidResolverInterface $uuidResolver
     ) {
         parent::__construct();
         $this->storage = $storage;

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -73,11 +73,11 @@ use PhpBench\Serializer\XmlDecoder;
 use PhpBench\Serializer\XmlEncoder;
 use PhpBench\Storage;
 use PhpBench\Storage\Driver\Xml\XmlDriver;
+use PhpBench\Storage\UuidResolver\ChainResolver;
 use PhpBench\Storage\UuidResolver\LatestResolver;
 use PhpBench\Util\TimeUnit;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\ExecutableFinder;
-use PhpBench\Storage\UuidResolver\ChainResolver;
 
 class CoreExtension implements ExtensionInterface
 {
@@ -593,6 +593,7 @@ class CoreExtension implements ExtensionInterface
             foreach (array_keys($container->getServiceIdsForTag('uuid_resolver')) as $serviceId) {
                 $resolvers[] = $container->get($serviceId);
             }
+
             return new ChainResolver($resolvers);
         });
 

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -73,13 +73,13 @@ use PhpBench\Serializer\XmlDecoder;
 use PhpBench\Serializer\XmlEncoder;
 use PhpBench\Storage;
 use PhpBench\Storage\Driver\Xml\XmlDriver;
+use PhpBench\Storage\StorageRegistry;
 use PhpBench\Storage\UuidResolver\ChainResolver;
 use PhpBench\Storage\UuidResolver\LatestResolver;
+use PhpBench\Storage\UuidResolver\TagResolver;
 use PhpBench\Util\TimeUnit;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\ExecutableFinder;
-use PhpBench\Storage\StorageRegistry;
-use PhpBench\Storage\UuidResolver\TagResolver;
 
 class CoreExtension implements ExtensionInterface
 {

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -73,7 +73,7 @@ use PhpBench\Serializer\XmlDecoder;
 use PhpBench\Serializer\XmlEncoder;
 use PhpBench\Storage;
 use PhpBench\Storage\Driver\Xml\XmlDriver;
-use PhpBench\Storage\UuidResolver;
+use PhpBench\Storage\UuidResolver\LatestResolver;
 use PhpBench\Util\TimeUnit;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\ExecutableFinder;
@@ -588,7 +588,7 @@ class CoreExtension implements ExtensionInterface
         }, ['storage_driver' => ['name' => 'xml']]);
 
         $container->register('storage.uuid_resolver', function (Container $container) {
-            return new UuidResolver(
+            return new LatestResolver(
                 $container->get('storage.driver_registry')
             );
         });

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -78,6 +78,8 @@ use PhpBench\Storage\UuidResolver\LatestResolver;
 use PhpBench\Util\TimeUnit;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\ExecutableFinder;
+use PhpBench\Storage\StorageRegistry;
+use PhpBench\Storage\UuidResolver\TagResolver;
 
 class CoreExtension implements ExtensionInterface
 {
@@ -564,7 +566,7 @@ class CoreExtension implements ExtensionInterface
     private function registerStorage(Container $container)
     {
         $container->register('storage.driver_registry', function (Container $container) {
-            $registry = new Registry('storage', $container, $container->getParameter('storage'));
+            $registry = new StorageRegistry($container, $container->getParameter('storage'));
             foreach ($container->getServiceIdsForTag('storage_driver') as $serviceId => $attributes) {
                 $registry->registerService($attributes['name'], $serviceId);
             }
@@ -599,6 +601,12 @@ class CoreExtension implements ExtensionInterface
 
         $container->register('storage.uuid_resolver.latest', function (Container $container) {
             return new LatestResolver(
+                $container->get('storage.driver_registry')
+            );
+        }, ['uuid_resolver' => []]);
+
+        $container->register('storage.uuid_resolver.tag', function (Container $container) {
+            return new TagResolver(
                 $container->get('storage.driver_registry')
             );
         }, ['uuid_resolver' => []]);

--- a/lib/Extension/config/report/generators.php
+++ b/lib/Extension/config/report/generators.php
@@ -28,9 +28,9 @@ return [
     ],
     'compare' => [
         'generator' => 'table',
-        'cols' => ['benchmark', 'subject', ],
+        'cols' => ['benchmark', 'subject', 'groups', 'params', 'revs'],
         'compare' => 'suite',
-        'break' => [],
+        'break' => ['benchmark', 'subject'],
     ],
     'env' => [
         'generator' => 'env',

--- a/lib/Extension/config/report/generators.php
+++ b/lib/Extension/config/report/generators.php
@@ -28,9 +28,9 @@ return [
     ],
     'compare' => [
         'generator' => 'table',
-        'cols' => ['benchmark', 'subject', 'groups', 'params', 'revs'],
+        'cols' => ['benchmark', 'subject', ],
         'compare' => 'suite',
-        'break' => ['benchmark', 'subject'],
+        'break' => [],
     ],
     'env' => [
         'generator' => 'env',

--- a/lib/Extension/config/report/generators.php
+++ b/lib/Extension/config/report/generators.php
@@ -30,7 +30,7 @@ return [
         'generator' => 'table',
         'cols' => ['benchmark', 'subject', 'groups', 'params', 'revs'],
         'compare' => 'suite',
-        'break' => ['benchmark', 'subject'],
+        'break' => [],
     ],
     'env' => [
         'generator' => 'env',

--- a/lib/Model/Suite.php
+++ b/lib/Model/Suite.php
@@ -15,6 +15,7 @@ namespace PhpBench\Model;
 use PhpBench\Assertion\AssertionFailures;
 use PhpBench\Assertion\AssertionWarnings;
 use PhpBench\Environment\Information;
+use PhpBench\Model\Tag;
 
 /**
  * Represents a Suite.
@@ -47,7 +48,7 @@ class Suite implements \IteratorAggregate
         array $envInformations = [],
         $uuid = null
     ) {
-        $this->tag = $tag;
+        $this->tag = $tag ? new Tag($tag) : null;
         $this->date = $date;
         $this->configPath = $configPath;
         $this->envInformations = $envInformations;

--- a/lib/Model/Suite.php
+++ b/lib/Model/Suite.php
@@ -23,7 +23,7 @@ use PhpBench\Environment\Information;
  */
 class Suite implements \IteratorAggregate
 {
-    private $contextName;
+    private $tag;
     private $date;
     private $configPath;
     private $envInformations = [];
@@ -34,20 +34,20 @@ class Suite implements \IteratorAggregate
      * __construct.
      *
      * @param array $benchmarks
-     * @param string $contextName
+     * @param string $tag
      * @param \DateTime $date
      * @param string $configPath
      * @param Information[] $envInformations
      */
     public function __construct(
-        $contextName,
+        $tag,
         \DateTime $date,
         $configPath = null,
         array $benchmarks = [],
         array $envInformations = [],
         $uuid = null
     ) {
-        $this->contextName = $contextName;
+        $this->tag = $tag;
         $this->date = $date;
         $this->configPath = $configPath;
         $this->envInformations = $envInformations;
@@ -80,9 +80,9 @@ class Suite implements \IteratorAggregate
         return new \ArrayIterator($this->benchmarks);
     }
 
-    public function getContextName()
+    public function getTag()
     {
-        return $this->contextName;
+        return $this->tag;
     }
 
     public function getDate()

--- a/lib/Model/Suite.php
+++ b/lib/Model/Suite.php
@@ -15,7 +15,6 @@ namespace PhpBench\Model;
 use PhpBench\Assertion\AssertionFailures;
 use PhpBench\Assertion\AssertionWarnings;
 use PhpBench\Environment\Information;
-use PhpBench\Model\Tag;
 
 /**
  * Represents a Suite.

--- a/lib/Model/Tag.php
+++ b/lib/Model/Tag.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
 namespace PhpBench\Model;
 
 use InvalidArgumentException;

--- a/lib/Model/Tag.php
+++ b/lib/Model/Tag.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace PhpBench\Model;
+
+use InvalidArgumentException;
+
+final class Tag
+{
+    /**
+     * @var string
+     */
+    private $tag;
+
+    public function __construct(string $tag)
+    {
+        if (!preg_match('{^[a-zA-Z_]+$}', $tag)) {
+            throw new InvalidArgumentException(sprintf(
+                'Tags can only contain alpha-numeric characters and _, got "%s"',
+                $tag
+            ));
+        }
+        $this->tag = $tag;
+    }
+
+    public function __toString()
+    {
+        return $this->tag;
+    }
+}

--- a/lib/Report/Generator/TableGenerator.php
+++ b/lib/Report/Generator/TableGenerator.php
@@ -68,7 +68,7 @@ class TableGenerator implements GeneratorInterface, OutputAwareInterface
         $options->setDefaults([
             'title' => null,
             'description' => null,
-            'cols' => ['benchmark', 'subject', 'groups', 'params', 'revs', 'its', 'mem_peak', 'best', 'mean', 'mode', 'worst', 'stdev', 'rstdev', 'diff'],
+            'cols' => ['benchmark', 'subject', 'tag', 'groups', 'params', 'revs', 'its', 'mem_peak', 'best', 'mean', 'mode', 'worst', 'stdev', 'rstdev', 'diff'],
             'break' => ['suite', 'date', 'stime'],
             'compare' => null,
             'compare_fields' => ['mean'],
@@ -327,8 +327,11 @@ class TableGenerator implements GeneratorInterface, OutputAwareInterface
                         $firstRow[$name] = $row[$compareField];
                         $colNames[$name] = $name;
 
-                        // we invent a new col name here, use the compare field's class.
-                        $this->classMap[$name] = $this->classMap[$compareField];
+                        // TODO: This probably means the field is non-comparable, could handle this earlier..
+                        if (isset($this->classMap[$compareField])) {
+                            // we invent a new col name here, use the compare field's class.
+                            $this->classMap[$name] = $this->classMap[$compareField];
+                        }
                     }
                 }
 

--- a/lib/Report/Generator/TableGenerator.php
+++ b/lib/Report/Generator/TableGenerator.php
@@ -375,6 +375,7 @@ class TableGenerator implements GeneratorInterface, OutputAwareInterface
                     foreach ($subject->getVariants() as $variant) {
                         $row = new Row([
                             'suite' => $suite->getUuid(),
+                            'tag' => $suite->getTag(),
                             'date' => $suite->getDate()->format('Y-m-d'),
                             'stime' => $suite->getDate()->format('H:i:s'),
                             'benchmark' => $this->getClassShortName($benchmark->getClass()),

--- a/lib/Serializer/XmlDecoder.php
+++ b/lib/Serializer/XmlDecoder.php
@@ -77,7 +77,7 @@ class XmlDecoder
     private function processSuite(\DOMElement $suiteEl)
     {
         $suite = new Suite(
-            $suiteEl->getAttribute('context'),
+            $suiteEl->getAttribute('tag'),
             new \DateTime($suiteEl->getAttribute('date')),
             $suiteEl->getAttribute('config-path'),
             [],

--- a/lib/Serializer/XmlEncoder.php
+++ b/lib/Serializer/XmlEncoder.php
@@ -42,6 +42,9 @@ class XmlEncoder
         foreach ($suiteCollection->getSuites() as $suite) {
             $suiteEl = $rootEl->appendElement('suite');
             $suiteEl->setAttribute('tag', $suite->getTag());
+
+            // @deprecated context is deprecated and replaced by `tag`, to be
+            //             removed in version 1.0
             $suiteEl->setAttribute('context', $suite->getTag());
             $suiteEl->setAttribute('date', $suite->getDate()->format('c'));
             $suiteEl->setAttribute('config-path', $suite->getConfigPath());

--- a/lib/Serializer/XmlEncoder.php
+++ b/lib/Serializer/XmlEncoder.php
@@ -41,7 +41,8 @@ class XmlEncoder
 
         foreach ($suiteCollection->getSuites() as $suite) {
             $suiteEl = $rootEl->appendElement('suite');
-            $suiteEl->setAttribute('context', $suite->getContextName());
+            $suiteEl->setAttribute('tag', $suite->getTag());
+            $suiteEl->setAttribute('context', $suite->getTag());
             $suiteEl->setAttribute('date', $suite->getDate()->format('c'));
             $suiteEl->setAttribute('config-path', $suite->getConfigPath());
             $suiteEl->setAttribute('uuid', $suite->getUuid());

--- a/lib/Storage/Driver/Xml/HistoryIterator.php
+++ b/lib/Storage/Driver/Xml/HistoryIterator.php
@@ -225,7 +225,7 @@ class HistoryIterator implements HistoryIteratorInterface
         $entry = new HistoryEntry(
             $suite->getUuid(),
             $suite->getDate(),
-            $suite->getContextName(),
+            $suite->getTag(),
             $vcsBranch,
             $summary->getNbSubjects(),
             $summary->getNbIterations(),

--- a/lib/Storage/HistoryEntry.php
+++ b/lib/Storage/HistoryEntry.php
@@ -19,7 +19,7 @@ class HistoryEntry
 {
     private $runId;
     private $date;
-    private $context;
+    private $tag;
     private $branch;
 
     private $nbSubjects;
@@ -35,7 +35,7 @@ class HistoryEntry
     public function __construct(
         $runId,
         \DateTime $date,
-        $context,
+        $tag,
         $branch,
         $nbSubjects,
         $nbIterations,
@@ -48,7 +48,7 @@ class HistoryEntry
     ) {
         $this->runId = $runId;
         $this->date = $date;
-        $this->context = $context;
+        $this->tag = $tag;
         $this->branch = $branch;
         $this->nbSubjects = $nbSubjects;
         $this->nbIterations = $nbIterations;
@@ -70,9 +70,9 @@ class HistoryEntry
         return $this->date;
     }
 
-    public function getContext()
+    public function getTag()
     {
-        return $this->context;
+        return $this->tag;
     }
 
     public function getNbSubjects()

--- a/lib/Storage/StorageRegistry.php
+++ b/lib/Storage/StorageRegistry.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PhpBench\Storage;
+
+use PhpBench\Registry\Registry;
+use Psr\Container\ContainerInterface;
+use PhpBench\Storage\DriverInterface;
+
+/**
+ * @method DriverInterface getService()
+ */
+class StorageRegistry extends Registry
+{
+    public function __construct(ContainerInterface $container, string $default)
+    {
+        parent::__construct('storage', $container, $default);
+    }
+}

--- a/lib/Storage/StorageRegistry.php
+++ b/lib/Storage/StorageRegistry.php
@@ -1,10 +1,19 @@
 <?php
 
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
 namespace PhpBench\Storage;
 
 use PhpBench\Registry\Registry;
 use Psr\Container\ContainerInterface;
-use PhpBench\Storage\DriverInterface;
 
 /**
  * @method DriverInterface getService()

--- a/lib/Storage/UuidResolver/ChainResolver.php
+++ b/lib/Storage/UuidResolver/ChainResolver.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
 namespace PhpBench\Storage\UuidResolver;
 
 use PhpBench\Storage\UuidResolverInterface;

--- a/lib/Storage/UuidResolver/ChainResolver.php
+++ b/lib/Storage/UuidResolver/ChainResolver.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace PhpBench\Storage\UuidResolver;
+
+use PhpBench\Storage\UuidResolverInterface;
+
+class ChainResolver implements UuidResolverInterface
+{
+    /**
+     * @var array
+     */
+    private $resolvers = [];
+
+    public function __construct(array $resolvers)
+    {
+        $this->resolvers = $resolvers;
+    }
+
+    public function supports(string $reference): bool
+    {
+        return true;
+    }
+
+    public function resolve(string $reference): string
+    {
+        /** @var UuidResolverInterface $resolver */
+        foreach ($this->resolvers as $resolver) {
+            if ($resolver->supports($reference)) {
+                return $resolver->resolve($reference);
+            }
+        }
+
+        return $reference;
+    }
+}

--- a/lib/Storage/UuidResolver/TagResolver.php
+++ b/lib/Storage/UuidResolver/TagResolver.php
@@ -1,12 +1,21 @@
 <?php
 
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
 namespace PhpBench\Storage\UuidResolver;
 
-use PhpBench\Storage\UuidResolverInterface;
-use PhpBench\Registry\Registry;
-use PhpBench\Storage\StorageRegistry;
-use PhpBench\Storage\HistoryEntry;
 use InvalidArgumentException;
+use PhpBench\Storage\HistoryEntry;
+use PhpBench\Storage\StorageRegistry;
+use PhpBench\Storage\UuidResolverInterface;
 
 class TagResolver implements UuidResolverInterface
 {

--- a/lib/Storage/UuidResolver/TagResolver.php
+++ b/lib/Storage/UuidResolver/TagResolver.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace PhpBench\Storage\UuidResolver;
+
+use PhpBench\Storage\UuidResolverInterface;
+use PhpBench\Registry\Registry;
+use PhpBench\Storage\StorageRegistry;
+use PhpBench\Storage\HistoryEntry;
+use InvalidArgumentException;
+
+class TagResolver implements UuidResolverInterface
+{
+    /**
+     * @var StorageRegistry
+     */
+    private $storageRegistry;
+
+    public function __construct(StorageRegistry $storageRegistry)
+    {
+        $this->storageRegistry = $storageRegistry;
+    }
+
+    public function supports(string $reference): bool
+    {
+        if (0 === strpos($reference, 'tag:')) {
+            if (strlen($reference) === 4) {
+                return false;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function resolve(string $reference): string
+    {
+        $history = $this->storageRegistry->getService()->history();
+        $tag = substr($reference, 4);
+
+        /** @var HistoryEntry $entry */
+        foreach ($history as $entry) {
+            if (strtolower($tag) === strtolower($entry->getTag())) {
+                return $entry->getRunId();
+            }
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            'Could not find tag "%s"', $tag
+        ));
+    }
+}

--- a/lib/Storage/UuidResolverInterface.php
+++ b/lib/Storage/UuidResolverInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace PhpBench\Storage;
+
+interface UuidResolverInterface
+{
+    public function supports(string $reference): bool;
+
+    public function resolve(string $reference): string;
+}

--- a/lib/Storage/UuidResolverInterface.php
+++ b/lib/Storage/UuidResolverInterface.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
 namespace PhpBench\Storage;
 
 interface UuidResolverInterface

--- a/tests/Unit/Benchmark/RunnerConfigTest.php
+++ b/tests/Unit/Benchmark/RunnerConfigTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 
 class RunnerConfigTest extends TestCase
 {
-    const TEST_CONTEXT_NAME = 'context_name';
+    const TEST_TAG_NAME = 'tag_name';
     const TEST_FILTERS = ['filter_one', 'filter_two'];
     const TEST_ITERATIONS = [5];
     const TEST_REVOLUTIONS = [6];
@@ -58,7 +58,7 @@ class RunnerConfigTest extends TestCase
     public function testBuild()
     {
         $config = RunnerConfig::create()
-            ->withContextName(self::TEST_CONTEXT_NAME)
+            ->withTag(self::TEST_TAG_NAME)
             ->withFilters(self::TEST_FILTERS)
             ->withIterations(self::TEST_ITERATIONS)
             ->withRevolutions(self::TEST_REVOLUTIONS)
@@ -73,7 +73,7 @@ class RunnerConfigTest extends TestCase
             ->withAssertions(self::TEST_ASSERTIONS)
             ->withRetryThreshold(self::TEST_RETRY_THRESHOLD);
 
-        $this->assertEquals(self::TEST_CONTEXT_NAME, $config->getContextName());
+        $this->assertEquals(self::TEST_TAG_NAME, $config->getTag());
         $this->assertEquals(self::TEST_FILTERS, $config->getFilters());
         $this->assertEquals(self::TEST_ITERATIONS, $config->getIterations());
         $this->assertEquals(self::TEST_REVOLUTIONS, $config->getRevolutions());

--- a/tests/Unit/Benchmark/RunnerTest.php
+++ b/tests/Unit/Benchmark/RunnerTest.php
@@ -152,7 +152,7 @@ class RunnerTest extends TestCase
         ->shouldBeCalledTimes(count($revs) * array_sum($iterations))
         ->will($this->loadIterationResultCallback());
 
-        $suite = $this->runner->run(self::TEST_PATH, RunnerConfig::create()->withContextName('context'));
+        $suite = $this->runner->run(self::TEST_PATH, RunnerConfig::create()->withTag('context'));
 
         $this->assertInstanceOf('PhpBench\Model\Suite', $suite);
         $this->assertNoErrors($suite);

--- a/tests/Unit/Console/Command/LogCommandTest.php
+++ b/tests/Unit/Console/Command/LogCommandTest.php
@@ -111,7 +111,7 @@ class LogCommandTest extends TestCase
 run 1
 Date:    2016-01-01T00:00:00+02:00
 Branch:  branch1
-Tag: foo
+Tag:     foo
 Scale:   10 subjects, 20 iterations, 40 revolutions
 Summary: (best [mean] worst) = 0.500 [1.250] 2.000 (s)
          ⅀T: 100 μRSD/r: 0.750%
@@ -119,7 +119,7 @@ Summary: (best [mean] worst) = 0.500 [1.250] 2.000 (s)
 run 2
 Date:    2016-01-01T00:00:00+02:00
 Branch:  branch2
-Tag: foo
+Tag:     foo
 Scale:   10 subjects, 20 iterations, 40 revolutions
 Summary: (best [mean] worst) = 0.500 [1.250] 2.000 (s)
          ⅀T: 100 μRSD/r: 0.750%
@@ -127,7 +127,7 @@ Summary: (best [mean] worst) = 0.500 [1.250] 2.000 (s)
 run 3
 Date:    2016-01-01T00:00:00+01:00
 Branch:  branch3
-Tag: foo
+Tag:     foo
 Scale:   10 subjects, 20 iterations, 40 revolutions
 Summary: (best [mean] worst) = 0.500 [1.250] 2.000 (s)
          ⅀T: 100 μRSD/r: 0.750%
@@ -168,7 +168,7 @@ EOT;
 run 1
 Date:    2016-01-01T00:00:00+01:00
 Branch:  branch1
-Tag: foo
+Tag:     foo
 Scale:   10 subjects, 20 iterations, 40 revolutions
 Summary: (best [mean] worst) = 0.500 [1.250] 2.000 (s)
          ⅀T: 100 μRSD/r: 0.750%
@@ -176,13 +176,13 @@ Summary: (best [mean] worst) = 0.500 [1.250] 2.000 (s)
 run 2
 Date:    2016-01-01T00:00:00+01:00
 Branch:  branch2
-Tag: foo
+Tag:     foo
 Scale:   10 subjects, 20 iterations, 40 revolutions
 lines 0-13 any key to continue, <q> to quit
 run 3
 Date:    2016-01-01T00:00:00+01:00
 Branch:  branch3
-Tag: foo
+Tag:     foo
 Scale:   10 subjects, 20 iterations, 40 revolutions
 Summary: (best [mean] worst) = 0.500 [1.250] 2.000 (s)
          ⅀T: 100 μRSD/r: 0.750%
@@ -223,7 +223,7 @@ EOT;
 run 1
 Date:    2016-01-01T00:00:00+01:00
 Branch:  branch1
-Tag: foo
+Tag:     foo
 Scale:   10 subjects, 20 iterations, 40 revolutions
 Summary: (best [mean] worst) = 0.500 [1.250] 2.000 (s)
          ⅀T: 100 μRSD/r: 0.750%
@@ -231,7 +231,7 @@ Summary: (best [mean] worst) = 0.500 [1.250] 2.000 (s)
 run 2
 Date:    2016-01-01T00:00:00+01:00
 Branch:  branch2
-Tag: foo
+Tag:     foo
 Scale:   10 subjects, 20 iterations, 40 revolutions
 lines 0-13 any key to continue, <q> to quit
 EOT;

--- a/tests/Unit/Console/Command/LogCommandTest.php
+++ b/tests/Unit/Console/Command/LogCommandTest.php
@@ -111,7 +111,7 @@ class LogCommandTest extends TestCase
 run 1
 Date:    2016-01-01T00:00:00+02:00
 Branch:  branch1
-Context: foo
+Tag: foo
 Scale:   10 subjects, 20 iterations, 40 revolutions
 Summary: (best [mean] worst) = 0.500 [1.250] 2.000 (s)
          ⅀T: 100 μRSD/r: 0.750%
@@ -119,7 +119,7 @@ Summary: (best [mean] worst) = 0.500 [1.250] 2.000 (s)
 run 2
 Date:    2016-01-01T00:00:00+02:00
 Branch:  branch2
-Context: foo
+Tag: foo
 Scale:   10 subjects, 20 iterations, 40 revolutions
 Summary: (best [mean] worst) = 0.500 [1.250] 2.000 (s)
          ⅀T: 100 μRSD/r: 0.750%
@@ -127,7 +127,7 @@ Summary: (best [mean] worst) = 0.500 [1.250] 2.000 (s)
 run 3
 Date:    2016-01-01T00:00:00+01:00
 Branch:  branch3
-Context: foo
+Tag: foo
 Scale:   10 subjects, 20 iterations, 40 revolutions
 Summary: (best [mean] worst) = 0.500 [1.250] 2.000 (s)
          ⅀T: 100 μRSD/r: 0.750%
@@ -168,7 +168,7 @@ EOT;
 run 1
 Date:    2016-01-01T00:00:00+01:00
 Branch:  branch1
-Context: foo
+Tag: foo
 Scale:   10 subjects, 20 iterations, 40 revolutions
 Summary: (best [mean] worst) = 0.500 [1.250] 2.000 (s)
          ⅀T: 100 μRSD/r: 0.750%
@@ -176,13 +176,13 @@ Summary: (best [mean] worst) = 0.500 [1.250] 2.000 (s)
 run 2
 Date:    2016-01-01T00:00:00+01:00
 Branch:  branch2
-Context: foo
+Tag: foo
 Scale:   10 subjects, 20 iterations, 40 revolutions
 lines 0-13 any key to continue, <q> to quit
 run 3
 Date:    2016-01-01T00:00:00+01:00
 Branch:  branch3
-Context: foo
+Tag: foo
 Scale:   10 subjects, 20 iterations, 40 revolutions
 Summary: (best [mean] worst) = 0.500 [1.250] 2.000 (s)
          ⅀T: 100 μRSD/r: 0.750%
@@ -223,7 +223,7 @@ EOT;
 run 1
 Date:    2016-01-01T00:00:00+01:00
 Branch:  branch1
-Context: foo
+Tag: foo
 Scale:   10 subjects, 20 iterations, 40 revolutions
 Summary: (best [mean] worst) = 0.500 [1.250] 2.000 (s)
          ⅀T: 100 μRSD/r: 0.750%
@@ -231,7 +231,7 @@ Summary: (best [mean] worst) = 0.500 [1.250] 2.000 (s)
 run 2
 Date:    2016-01-01T00:00:00+01:00
 Branch:  branch2
-Context: foo
+Tag: foo
 Scale:   10 subjects, 20 iterations, 40 revolutions
 lines 0-13 any key to continue, <q> to quit
 EOT;

--- a/tests/Unit/Model/TagTest.php
+++ b/tests/Unit/Model/TagTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PhpBench\Tests\Unit\Model;
+
+use PHPUnit\Framework\TestCase;
+use PhpBench\Model\Tag;
+use InvalidArgumentException;
+
+class TagTest extends TestCase
+{
+    public function testExceptionNonAlphaNumericUnderscore()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Tag('hello-world');
+    }
+}

--- a/tests/Unit/Model/TagTest.php
+++ b/tests/Unit/Model/TagTest.php
@@ -1,10 +1,20 @@
 <?php
 
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
 namespace PhpBench\Tests\Unit\Model;
 
-use PHPUnit\Framework\TestCase;
-use PhpBench\Model\Tag;
 use InvalidArgumentException;
+use PhpBench\Model\Tag;
+use PHPUnit\Framework\TestCase;
 
 class TagTest extends TestCase
 {

--- a/tests/Unit/Report/Generator/TableGeneratorTest.php
+++ b/tests/Unit/Report/Generator/TableGeneratorTest.php
@@ -526,7 +526,7 @@ EOT
             ]
         );
 
-        $this->assertXPathCount($report, 14, '//col');
+        $this->assertXPathCount($report, 15, '//col');
         $this->assertXPathEval($report, 'Column one', 'string(//table/cols/col[1]/@label)');
         $this->assertXPathEval($report, 'Column two', 'string(//table/cols/col[2]/@label)');
         $this->assertXPathEval($report, 'groups', 'string(//table/cols/col[3]/@label)');

--- a/tests/Unit/Report/Generator/TableGeneratorTest.php
+++ b/tests/Unit/Report/Generator/TableGeneratorTest.php
@@ -271,7 +271,7 @@ class TableGeneratorTest extends GeneratorTestCase
                     'break' => [],
                 ],
                 [
-                    11 => '//row[1]/cell',
+                    12 => '//row[1]/cell',
                     1 => '//table',
                     4 => '//cell[@name="git_branch:foobar:mem_peak"]',
                     4 => '//cell[@name="git_branch:foobar:mean"]',
@@ -324,7 +324,7 @@ class TableGeneratorTest extends GeneratorTestCase
             'break' => [],
         ]);
 
-        $this->assertXPathCount($report, 9, '//row[1]/cell');
+        $this->assertXPathCount($report, 10, '//row[1]/cell');
         $this->assertXPathCount($report, 1, '//cell[@name="revs:5:mean"]');
         $this->assertXPathCount($report, 1, '//cell[@name="revs:5:mean#1"]');
         $this->assertXPathCount($report, 1, '//cell[@name="revs:5:mean#2"]');

--- a/tests/Unit/Report/Generator/TableGeneratorTest.php
+++ b/tests/Unit/Report/Generator/TableGeneratorTest.php
@@ -529,8 +529,9 @@ EOT
         $this->assertXPathCount($report, 15, '//col');
         $this->assertXPathEval($report, 'Column one', 'string(//table/cols/col[1]/@label)');
         $this->assertXPathEval($report, 'Column two', 'string(//table/cols/col[2]/@label)');
-        $this->assertXPathEval($report, 'groups', 'string(//table/cols/col[3]/@label)');
-        $this->assertXPathEval($report, 'Parameters', 'string(//table/cols/col[4]/@label)');
+        $this->assertXPathEval($report, 'tag', 'string(//table/cols/col[3]/@label)');
+        $this->assertXPathEval($report, 'groups', 'string(//table/cols/col[4]/@label)');
+        $this->assertXPathEval($report, 'Parameters', 'string(//table/cols/col[5]/@label)');
     }
 
     private function generate(SuiteCollection $collection, array $config = [])

--- a/tests/Unit/Serializer/XmlTestCase.php
+++ b/tests/Unit/Serializer/XmlTestCase.php
@@ -58,7 +58,7 @@ class XmlTestCase extends TestCase
         $this->suiteCollection->getSuites()->willReturn([$this->suite->reveal()]);
         $this->suite->getUuid()->willReturn(1234);
         $this->suite->getDate()->willReturn(new \DateTime('2015-01-01T00:00:00+00:00'));
-        $this->suite->getContextName()->willReturn('test');
+        $this->suite->getTag()->willReturn('test');
         $this->suite->getConfigPath()->willReturn('/path/to/config.json');
         $this->suite->getEnvInformations()->willReturn([
             $this->env1,
@@ -153,7 +153,7 @@ class XmlTestCase extends TestCase
                 <<<'EOT'
 <?xml version="1.0"?>
 <phpbench version="PHPBENCH_VERSION">
-  <suite context="test" date="2015-01-01T00:00:00+00:00" config-path="/path/to/config.json" uuid="1234">
+  <suite tag="test" context="test" date="2015-01-01T00:00:00+00:00" config-path="/path/to/config.json" uuid="1234">
     <env>
       <info1 foo="bar"/>
     </env>
@@ -184,7 +184,7 @@ EOT
                 <<<'EOT'
 <?xml version="1.0"?>
 <phpbench version="PHPBENCH_VERSION">
-  <suite context="test" date="2015-01-01T00:00:00+00:00" config-path="/path/to/config.json" uuid="1234">
+  <suite tag="test" context="test" date="2015-01-01T00:00:00+00:00" config-path="/path/to/config.json" uuid="1234">
     <env>
       <info1 foo="bar"/>
     </env>
@@ -207,7 +207,7 @@ EOT
                 <<<'EOT'
 <?xml version="1.0"?>
 <phpbench version="PHPBENCH_VERSION">
-  <suite context="test" date="2015-01-01T00:00:00+00:00" config-path="/path/to/config.json" uuid="1234">
+  <suite tag="test" context="test" date="2015-01-01T00:00:00+00:00" config-path="/path/to/config.json" uuid="1234">
     <env>
       <info1 foo="bar"/>
     </env>

--- a/tests/Unit/Storage/Driver/Xml/HistoryIteratorTest.php
+++ b/tests/Unit/Storage/Driver/Xml/HistoryIteratorTest.php
@@ -127,7 +127,7 @@ class HistoryIteratorTest extends TestCase
         $collection->getSuites()->willReturn([$suite->reveal()]);
         $suite->getUuid()->willReturn($uuid);
         $suite->getDate()->willReturn($date);
-        $suite->getContextName()->willReturn('foo');
+        $suite->getTag()->willReturn('foo');
         $suite->getEnvInformations()->willReturn([
             'vcs' => [
                 'branch' => 'foo_branch',

--- a/tests/Unit/Storage/UuidResolver/ChainResolverTest.php
+++ b/tests/Unit/Storage/UuidResolver/ChainResolverTest.php
@@ -1,10 +1,20 @@
 <?php
 
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
 namespace PhpBench\Tests\Unit\Storage\UuidResolver;
 
-use PHPUnit\Framework\TestCase;
 use PhpBench\Storage\UuidResolver\ChainResolver;
 use PhpBench\Storage\UuidResolverInterface;
+use PHPUnit\Framework\TestCase;
 
 class ChainResolverTest extends TestCase
 {
@@ -29,7 +39,7 @@ class ChainResolverTest extends TestCase
 
     public function testChainResolve()
     {
-        $chainResolver = new ChainResolver([ $this->resolver->reveal() ]);
+        $chainResolver = new ChainResolver([$this->resolver->reveal()]);
         $this->resolver->supports(self::TEST_REFERENCE)->willReturn(true);
         $this->resolver->resolve(self::TEST_REFERENCE)->willReturn(self::TEST_UUID);
 
@@ -40,7 +50,7 @@ class ChainResolverTest extends TestCase
 
     public function testChainResolveNoSupport()
     {
-        $chainResolver = new ChainResolver([ $this->resolver->reveal() ]);
+        $chainResolver = new ChainResolver([$this->resolver->reveal()]);
         $this->resolver->supports(self::TEST_REFERENCE)->willReturn(false);
         $this->resolver->resolve(self::TEST_REFERENCE)->shouldNotBeCalled();
 

--- a/tests/Unit/Storage/UuidResolver/LatestResolverTest.php
+++ b/tests/Unit/Storage/UuidResolver/LatestResolverTest.php
@@ -10,16 +10,17 @@
  *
  */
 
-namespace PhpBench\Tests\Unit\Storage;
+namespace PhpBench\Tests\Unit\Storage\UuidResolver;
 
 use PhpBench\Registry\Registry;
 use PhpBench\Storage\DriverInterface;
 use PhpBench\Storage\HistoryEntry;
 use PhpBench\Storage\HistoryIteratorInterface;
-use PhpBench\Storage\UuidResolver;
+use PhpBench\Storage\UuidResolver\LatestResolver;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
-class UuidResolverTest extends TestCase
+class LatestResolverTest extends TestCase
 {
     private $resolver;
     private $storage;
@@ -36,7 +37,7 @@ class UuidResolverTest extends TestCase
         $this->historyEntry = $this->prophesize(HistoryEntry::class);
         $this->historyEntry1 = $this->prophesize(HistoryEntry::class);
 
-        $this->resolver = new UuidResolver(
+        $this->resolver = new LatestResolver(
             $registry->reveal()
         );
     }
@@ -54,15 +55,10 @@ class UuidResolverTest extends TestCase
         $this->assertEquals(1234, $uuid);
     }
 
-    /**
-     * It should return the given UUID it is not a token.
-     */
-    public function testResolveLatestNotKeyword()
+    public function testResolveCantResolve()
     {
-        $this->storage->history()->shouldNotBeCalled();
-
-        $uuid = $this->resolver->resolve(1234);
-        $this->assertEquals(1234, $uuid);
+        $this->expectException(RuntimeException::class);
+        $this->resolver->resolve('nutbar');
     }
 
     /**

--- a/tests/Unit/Storage/UuidResolver/TagResolverTest.php
+++ b/tests/Unit/Storage/UuidResolver/TagResolverTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace PhpBench\Tests\Unit\Storage\UuidResolver;
+
+use PHPUnit\Framework\TestCase;
+use PhpBench\Storage\UuidResolver\TagResolver;
+use PhpBench\Storage\DriverInterface;
+use PhpBench\Storage\HistoryIteratorInterface;
+use PhpBench\Storage\HistoryEntry;
+use PhpBench\Storage\StorageRegistry;
+use RuntimeException;
+use InvalidArgumentException;
+
+class TagResolverTest extends TestCase
+{
+    /**
+     * @var ObjectProphecy
+     */
+    private $storage;
+
+    /**
+     * @var ObjectProphecy
+     */
+    private $history;
+
+    /**
+     * @var ObjectProphecy
+     */
+    private $historyEntry;
+
+    /**
+     * @var ObjectProphecy
+     */
+    private $historyEntry1;
+
+    /**
+     * @var TagResolver
+     */
+    private $resolver;
+
+    public function setUp()
+    {
+        $this->storage = $this->prophesize(DriverInterface::class);
+        $this->history = $this->prophesize(HistoryIteratorInterface::class);
+        $this->historyEntry = $this->prophesize(HistoryEntry::class);
+        $this->historyEntry1 = $this->prophesize(HistoryEntry::class);
+        $registry = $this->prophesize(StorageRegistry::class);
+        $registry->getService()->willReturn($this->storage->reveal());
+        $this->storage->history()->willReturn($this->history->reveal());
+
+        $this->resolver = new TagResolver($registry->reveal());
+    }
+
+    public function testSupportsReferencesWithTagPrefix()
+    {
+        $this->assertTrue($this->resolver->supports('tag:asdf'));
+        $this->assertFalse($this->resolver->supports('tag:'));
+        $this->assertFalse($this->resolver->supports('test'));
+    }
+
+    public function testThrowsExceptionWhenNoTagFound()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->history->rewind()->shouldBeCalled();
+        $this->history->valid()->willReturn(false);
+        $this->resolver->resolve('tag:foobar');
+    }
+
+    public function testReturnsUuidForLatestTag()
+    {
+        $this->history->rewind()->shouldBeCalled();
+        $this->history->valid()->willReturn(true);
+        $this->history->current()->willReturn($this->historyEntry->reveal());
+
+        $this->historyEntry->getTag()->willReturn('foobar');
+        $this->historyEntry->getRunId()->willReturn(1234);
+
+        $uuid = $this->resolver->resolve('tag:foobar');
+        $this->assertEquals(1234, $uuid);
+    }
+}

--- a/tests/Unit/Storage/UuidResolver/TagResolverTest.php
+++ b/tests/Unit/Storage/UuidResolver/TagResolverTest.php
@@ -79,4 +79,32 @@ class TagResolverTest extends TestCase
         $uuid = $this->resolver->resolve('tag:foobar');
         $this->assertEquals(1234, $uuid);
     }
+
+    public function testReturnsUuidForTagWithMatchingTagAtOffset()
+    {
+        $this->history->rewind()->shouldBeCalled();
+        $this->history->valid()->willReturn(true, true, true, false);
+        $this->history->next()->shouldBeCalledTimes(2);
+        $this->history->current()->willReturn($this->historyEntry->reveal());
+
+        $this->historyEntry->getTag()->willReturn('foobar');
+        $this->historyEntry->getRunId()->willReturn(1234);
+
+        $uuid = $this->resolver->resolve('tag:foobar-2');
+        $this->assertEquals(1234, $uuid);
+    }
+
+    public function testReturnsUuidForFirstTagAtOffset()
+    {
+        $this->history->rewind()->shouldBeCalled();
+        $this->history->valid()->willReturn(true, true, true, true, false);
+        $this->history->next()->shouldBeCalledTimes(3);
+        $this->history->current()->willReturn($this->historyEntry->reveal());
+
+        $this->historyEntry->getTag()->willReturn(null, 'foobar');
+        $this->historyEntry->getRunId()->willReturn(1234);
+
+        $uuid = $this->resolver->resolve('tag:foobar-2');
+        $this->assertEquals(1234, $uuid);
+    }
 }

--- a/tests/Unit/Storage/UuidResolver/TagResolverTest.php
+++ b/tests/Unit/Storage/UuidResolver/TagResolverTest.php
@@ -1,15 +1,24 @@
 <?php
 
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
 namespace PhpBench\Tests\Unit\Storage\UuidResolver;
 
-use PHPUnit\Framework\TestCase;
-use PhpBench\Storage\UuidResolver\TagResolver;
-use PhpBench\Storage\DriverInterface;
-use PhpBench\Storage\HistoryIteratorInterface;
-use PhpBench\Storage\HistoryEntry;
-use PhpBench\Storage\StorageRegistry;
-use RuntimeException;
 use InvalidArgumentException;
+use PhpBench\Storage\DriverInterface;
+use PhpBench\Storage\HistoryEntry;
+use PhpBench\Storage\HistoryIteratorInterface;
+use PhpBench\Storage\StorageRegistry;
+use PhpBench\Storage\UuidResolver\TagResolver;
+use PHPUnit\Framework\TestCase;
 
 class TagResolverTest extends TestCase
 {


### PR DESCRIPTION
Deprecate the existing `context` option and replace it with `tag`.

```bash
$ phpbench run --tag=impl_a --store
$ phpbench run --tag=impl_b --store
$ phpbench run --tag=impl_c --store
$ phpbench report --uuid=tag:impl_a --uuid=tag:impl_b --uuid=tag:impl_c --report='{extends: compare, compare: tag, break:[]}'

+--------------+----------+--------+--------+------+-----------------+-----------------+-----------------+
| benchmark    | subject  | groups | params | revs | tag:impl_a:mean | tag:impl_b:mean | tag:impl_c:mean |
+--------------+----------+--------+--------+------+-----------------+-----------------+-----------------+
| HashingBench | benchMd5 |        | []     | 1000 | 0.957μs         | 0.939μs         | 0.952μs         |
+--------------+----------+--------+--------+------+-----------------+-----------------+-----------------+
```