### PR TITLE
Allowing NULL values using ParamProviders

### DIFF
--- a/lib/Benchmark/Remote/Reflector.php
+++ b/lib/Benchmark/Remote/Reflector.php
@@ -99,7 +99,7 @@ class Reflector
         $parameters = new \RecursiveIteratorIterator(new \RecursiveArrayIterator($parameterSets));
         iterator_apply($parameters, function (\Iterator $iterator) {
             $parameter = $iterator->current();
-            if (!is_scalar($parameter)) {
+            if (!is_scalar($parameter) && isset($parameter)) {
                 throw new \InvalidArgumentException(sprintf(
                     'Parameter values must be scalar. Got "%s"',
                     is_object($parameter) ? get_class($parameter) : gettype($parameter)

--- a/lib/Serializer/XmlDecoder.php
+++ b/lib/Serializer/XmlDecoder.php
@@ -182,7 +182,7 @@ class XmlDecoder
                 continue;
             }
 
-            if (($nil = $parameterEl->attributes->getNamedItem('nil')) && $nil.value === 'true') {
+            if ($parameterEl->getAttribute('xsi:nil') === 'true') {
                 $parameters[$name] = null;
                 continue;
             }

--- a/lib/Serializer/XmlDecoder.php
+++ b/lib/Serializer/XmlDecoder.php
@@ -181,7 +181,10 @@ class XmlDecoder
                 $parameters[$name] = $this->getParameters($parameterEl);
                 continue;
             }
-
+            if (($nil=$parameterEl->attributes->getNamedItem('nil')) && $nil.value === 'true') {
+                $parameters[$name] = null;
+                continue;
+            }
             $parameters[$name] = $parameterEl->getAttribute('value');
         }
 

--- a/lib/Serializer/XmlDecoder.php
+++ b/lib/Serializer/XmlDecoder.php
@@ -181,10 +181,12 @@ class XmlDecoder
                 $parameters[$name] = $this->getParameters($parameterEl);
                 continue;
             }
-            if (($nil=$parameterEl->attributes->getNamedItem('nil')) && $nil.value === 'true') {
+
+            if (($nil = $parameterEl->attributes->getNamedItem('nil')) && $nil.value === 'true') {
                 $parameters[$name] = null;
                 continue;
             }
+
             $parameters[$name] = $parameterEl->getAttribute('value');
         }
 

--- a/lib/Serializer/XmlEncoder.php
+++ b/lib/Serializer/XmlEncoder.php
@@ -186,7 +186,6 @@ class XmlEncoder
     {
         $parameterEl = $parentEl->appendElement('parameter');
         $parameterEl->setAttribute('name', $name);
-
         if (is_array($value)) {
             $parameterEl->setAttribute('type', 'collection');
             foreach ($value as $key => $element) {
@@ -195,19 +194,19 @@ class XmlEncoder
 
             return $parameterEl;
         }
-
+        if (is_null($value)) {
+            $parameterEl->setAttribute('xsi:nil', 'true');
+            
+            return $parameterEl;
+        }
+        
         if (is_scalar($value)) {
             $parameterEl->setAttribute('value', $value);
 
             return $parameterEl;
         }
 
-        if (is_null($value)) {
-            $parameterEl->setAttribute('nillable', 'true');
-            $parameterEl->setAttribute('value', '');
-
-            return $parameterEl;
-        }
+        
 
         throw new \InvalidArgumentException(sprintf(
             'Parameters must be either scalars or arrays, got: %s',

--- a/lib/Serializer/XmlEncoder.php
+++ b/lib/Serializer/XmlEncoder.php
@@ -201,7 +201,7 @@ class XmlEncoder
 
             return $parameterEl;
         }
-        
+
         if (is_null($value)) {
             $parameterEl->setAttribute('nillable', 'true');
             $parameterEl->setAttribute('value', '');

--- a/lib/Serializer/XmlEncoder.php
+++ b/lib/Serializer/XmlEncoder.php
@@ -201,7 +201,13 @@ class XmlEncoder
 
             return $parameterEl;
         }
+        
+        if (is_null($value)) {
+            $parameterEl->setAttribute('nillable', 'true');
+            $parameterEl->setAttribute('value', '');
 
+            return $parameterEl;
+        }
         throw new \InvalidArgumentException(sprintf(
             'Parameters must be either scalars or arrays, got: %s',
             is_object($value) ? get_class($value) : gettype($value)

--- a/lib/Serializer/XmlEncoder.php
+++ b/lib/Serializer/XmlEncoder.php
@@ -197,7 +197,7 @@ class XmlEncoder
 
         if (is_null($value)) {
             $parameterEl->setAttribute('xsi:nil', 'true');
-            
+
             return $parameterEl;
         }
 

--- a/lib/Serializer/XmlEncoder.php
+++ b/lib/Serializer/XmlEncoder.php
@@ -194,19 +194,18 @@ class XmlEncoder
 
             return $parameterEl;
         }
+
         if (is_null($value)) {
             $parameterEl->setAttribute('xsi:nil', 'true');
             
             return $parameterEl;
         }
-        
+
         if (is_scalar($value)) {
             $parameterEl->setAttribute('value', $value);
 
             return $parameterEl;
         }
-
-        
 
         throw new \InvalidArgumentException(sprintf(
             'Parameters must be either scalars or arrays, got: %s',

--- a/lib/Serializer/XmlEncoder.php
+++ b/lib/Serializer/XmlEncoder.php
@@ -208,6 +208,7 @@ class XmlEncoder
 
             return $parameterEl;
         }
+
         throw new \InvalidArgumentException(sprintf(
             'Parameters must be either scalars or arrays, got: %s',
             is_object($value) ? get_class($value) : gettype($value)

--- a/tests/Unit/Benchmark/Remote/ReflectorTest.php
+++ b/tests/Unit/Benchmark/Remote/ReflectorTest.php
@@ -95,6 +95,7 @@ class ReflectorTest extends TestCase
         $parameterSets = $this->reflector->getParameterSets(__DIR__ . '/reflector/ExampleClass.php', [
             'provideParamsOne',
             'provideParamsTwo',
+            'provideParamsNull',
         ]);
 
         $this->assertEquals([
@@ -108,6 +109,12 @@ class ReflectorTest extends TestCase
                 [
                     'five' => 'six',
                     'seven' => 'eight',
+                ],
+            ],
+            [
+                [
+                    'nine' => null,
+                    'ten' => null,
                 ],
             ],
         ], $parameterSets);

--- a/tests/Unit/Benchmark/Remote/ReflectorTest.php
+++ b/tests/Unit/Benchmark/Remote/ReflectorTest.php
@@ -45,6 +45,7 @@ class ReflectorTest extends TestCase
             'provideParamsOne',
             'provideParamsTwo',
             'provideParamsNonScalar',
+            'provideParamsNull',
         ], array_keys($reflection->methods));
         $this->assertContains('Method One Comment', $reflection->methods['methodOne']->comment);
     }

--- a/tests/Unit/Benchmark/Remote/reflector/ExampleClass.php
+++ b/tests/Unit/Benchmark/Remote/reflector/ExampleClass.php
@@ -60,4 +60,15 @@ class ExampleClass
             ],
         ];
     }
+
+    public function provideParamsNull()
+    {
+        return [
+            [
+                'nine' => null,
+                'ten' => null,
+            ],
+        ];
+    }
+    
 }

--- a/tests/Unit/Benchmark/Remote/reflector/ExampleClass.php
+++ b/tests/Unit/Benchmark/Remote/reflector/ExampleClass.php
@@ -70,5 +70,4 @@ class ExampleClass
             ],
         ];
     }
-    
 }

--- a/tests/Unit/Serializer/XmlTestCase.php
+++ b/tests/Unit/Serializer/XmlTestCase.php
@@ -167,7 +167,7 @@ class XmlTestCase extends TestCase
           <parameter name="bar" type="collection">
             <parameter name="baz" value="bon"/>
           </parameter>
-          <parameter name="baz" xsi:nil="true" value=""/>
+          <parameter name="baz" xsi:nil="true"/>
           <iteration time-net="10" mem-peak="100" mem-real="110" mem-final="109" comp-z-value="0" comp-deviation="0"/>
           <stats max="0.1" mean="0.1" min="0.1" mode="0.1" rstdev="0" stdev="0" sum="0.1" variance="0"/>
         </variant>

--- a/tests/Unit/Serializer/XmlTestCase.php
+++ b/tests/Unit/Serializer/XmlTestCase.php
@@ -148,6 +148,7 @@ class XmlTestCase extends TestCase
                         'bar' => [
                             'baz' => 'bon',
                         ],
+                        'baz' => null,
                     ],
                 ],
                 <<<'EOT'
@@ -166,6 +167,7 @@ class XmlTestCase extends TestCase
           <parameter name="bar" type="collection">
             <parameter name="baz" value="bon"/>
           </parameter>
+          <parameter name="baz" xsi:nil="true" value=""/>
           <iteration time-net="10" mem-peak="100" mem-real="110" mem-final="109" comp-z-value="0" comp-deviation="0"/>
           <stats max="0.1" mean="0.1" min="0.1" mode="0.1" rstdev="0" stdev="0" sum="0.1" variance="0"/>
         </variant>


### PR DESCRIPTION
While first attempt to bench something using the @ParamProviders annotation...I got InvalidArgumentException messages such as : 
    Parameter values must be scalar. Got "NULL" 
    Parameters must be either scalars or arrays, got: NULL

But I want my bench method to have null values into array of parameters

So I change few lines into the code and all went as excpected.

I have not check further impact in my modifications but I really need this feature.