### PR TITLE
Compatible to phpunit7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "doctrine/dbal": "^2.4",
         "padraic/phar-updater": "^1.0",
         "phpstan/phpstan": "^0.8.5",
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^6.5 | ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/System/ArchiveTest.php
+++ b/tests/System/ArchiveTest.php
@@ -19,8 +19,8 @@ class ArchiveTest extends SystemTestCase
      */
     public function testArchive()
     {
-        $this->createResult(null, ' --store');
-        $this->createResult(null, ' --store');
+        $this->getResult(null, ' --store');
+        $this->getResult(null, ' --store');
         $process = $this->phpbench(
             'archive'
         );

--- a/tests/System/DeleteTest.php
+++ b/tests/System/DeleteTest.php
@@ -19,8 +19,8 @@ class DeleteTest extends SystemTestCase
      */
     public function testLog()
     {
-        $result = $this->createResult(null, ' --store');
-        $uuid = $result->evaluate('string(./suite/@uuid)');
+        $document = $this->getResult(null, ' --store');
+        $uuid = $document->evaluate('string(./suite/@uuid)');
 
         $process = $this->phpbench(
             'delete --uuid=' . $uuid

--- a/tests/System/LogTest.php
+++ b/tests/System/LogTest.php
@@ -19,7 +19,7 @@ class LogTest extends SystemTestCase
      */
     public function testLog()
     {
-        $this->createResult(null, ' --store');
+        $this->getResult(null, ' --store');
         $process = $this->phpbench(
             'log'
         );

--- a/tests/System/ReportOutputTest.php
+++ b/tests/System/ReportOutputTest.php
@@ -22,7 +22,7 @@ class ReportOutputTest extends SystemTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->createResult();
+        $this->getResult();
     }
 
     /**

--- a/tests/System/ReportTest.php
+++ b/tests/System/ReportTest.php
@@ -19,7 +19,7 @@ class ReportTest extends SystemTestCase
      */
     public function testGenerateReport()
     {
-        $this->createResult();
+        $this->getResult();
         $process = $this->phpbench(
             'report --file=' . $this->fname . ' --report=default'
         );
@@ -33,8 +33,8 @@ class ReportTest extends SystemTestCase
      */
     public function testGenerateReportFromUuid()
     {
-        $dom = $this->createResult(null, ' --store');
-        $uuid = $dom->evaluate('string(./suite/@uuid)');
+        $document = $this->getResult(null, ' --store');
+        $uuid = $document->evaluate('string(./suite/@uuid)');
         $process = $this->phpbench(
             'report --uuid=' . $uuid . ' --report=default'
         );
@@ -48,7 +48,7 @@ class ReportTest extends SystemTestCase
      */
     public function testTimeUnitOverride()
     {
-        $this->createResult();
+        $this->getResult();
         $process = $this->phpbench(
             'report --file=' . $this->fname . ' --report=default --time-unit=seconds --mode=throughput --precision=6'
         );
@@ -83,7 +83,7 @@ class ReportTest extends SystemTestCase
      */
     public function testOutputs($output)
     {
-        $this->createResult();
+        $this->getResult();
         $process = $this->phpbench(
             'report --file=' . $this->fname .' --output=' . $output . ' --report=default'
         );
@@ -106,7 +106,7 @@ class ReportTest extends SystemTestCase
      */
     public function testGenerators($config)
     {
-        $this->createResult();
+        $this->getResult();
         $process = $this->phpbench(
             'report --file=' . $this->fname .' --report=\'' . json_encode($config) . '\''
         );

--- a/tests/System/ShowTest.php
+++ b/tests/System/ShowTest.php
@@ -19,7 +19,7 @@ class ShowTest extends SystemTestCase
      */
     public function testDefaultReport()
     {
-        $document = $this->createResult(null, ' --store');
+        $document = $this->getResult(null, ' --store');
         $uuid = $document->evaluate('string(./suite/@uuid)');
         $process = $this->phpbench(
             'show ' . $uuid
@@ -42,7 +42,7 @@ EOT
      */
     public function testSpecificReport()
     {
-        $document = $this->createResult(null, ' --store');
+        $document = $this->getResult(null, ' --store');
         $uuid = $document->evaluate('string(./suite/@uuid)');
         $process = $this->phpbench(
             'show ' . $uuid . ' --report=default'

--- a/tests/System/SystemTestCase.php
+++ b/tests/System/SystemTestCase.php
@@ -35,7 +35,7 @@ class SystemTestCase extends TestCase
         $this->filesystem->mirror(__DIR__ . '/bootstrap', $this->workspaceDir . '/bootstrap');
     }
 
-    public function createResult($benchmark = null, $extraCmd = '')
+    public function getResult($benchmark = null, $extraCmd = '')
     {
         $benchmark = $benchmark ?: 'benchmarks/set4';
 
@@ -49,7 +49,6 @@ class SystemTestCase extends TestCase
 
         $document = new Document();
         $document->load($this->fname);
-
         return $document;
     }
 


### PR DESCRIPTION
# Background
As of PHPUnit7, `createResult()` is declared with the `TestResult` type, which causes Fatal error.

https://github.com/sebastianbergmann/phpunit/blob/7.0.3/src/Framework/TestCase.php#L1592
```php
    protected function createResult(): TestResult
    {
        return new TestResult;
    }
```

In order to avoid this,  the method name should be renamed.
