### PR TITLE
Refactor CartesianParameterIterator: Depend on CartesianIterator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "beberlei/assert": "^2.4|^3.0",
         "doctrine/annotations": "^1.2.7",
         "lstrojny/functional-php": "1.0|^1.2.3",
+        "patchranger/cartesian-iterator": "~0.0.5",
         "phpbench/container": "~1.2",
         "phpbench/dom": "~0.2.0",
         "seld/jsonlint": "^1.0",


### PR DESCRIPTION
Didn't test it thoroughly, did just a few smoke-tests, looks good to me.
The idea is to get rid of self-crafted implementation of Cartesian product, relying on "mine-crafted" (read as "crafted by me") version of CartesianIterator, which in turn relies on standard, built-in [`MultipleIterator`](http://php.net/manual/en/class.multipleiterator.php), look how laconic it is: https://github.com/PatchRanger/cartesian-iterator/blob/master/src/CartesianIterator.php .
Could bring performance boost - but not for sure.