### PR TITLE
Fix: Keep rules sorted in .php_cs.dist

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -13,9 +13,9 @@ return PhpCsFixer\Config::create()
         '@PSR2' => true,
         'binary_operator_spaces' => [ 'align_double_arrow' => false ],
         'concat_space' => false,
-        'phpdoc_indent' => false,
         'method_argument_space' => false,
         'phpdoc_align' => [],
+        'phpdoc_indent' => false,
     ])
     ->setFinder($finder)
     ;


### PR DESCRIPTION
This PR

* [x] keeps rules sorted in `.php_cs.dist`