### PR TITLE
Enhancement: Update phpstan/phpstan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
         - composer install
 
       script:
-        - ./vendor/bin/phpstan analyze -c phpstan.neon
+        - ./vendor/bin/phpstan analyse -c phpstan.neon
 
     - &TEST
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
         - composer install
 
       script:
-        - ./vendor/bin/phpstan analyze --level=4 -c phpstan.neon
+        - ./vendor/bin/phpstan analyze -c phpstan.neon
 
     - &TEST
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
         - composer install
 
       script:
-        - ./vendor/bin/phpstan analyze --level=4 -c phpstan.neon lib/
+        - ./vendor/bin/phpstan analyze --level=4 -c phpstan.neon
 
     - &TEST
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "doctrine/dbal": "^2.4",
         "friendsofphp/php-cs-fixer": "^2.13.1",
         "padraic/phar-updater": "^1.0",
-        "phpstan/phpstan": "^0.8.5",
+        "phpstan/phpstan": "^0.10.7",
         "phpunit/phpunit": "^6.5 || ^7.0"
     },
     "suggest": {

--- a/lib/Assertion/AsserterRegistry.php
+++ b/lib/Assertion/AsserterRegistry.php
@@ -16,7 +16,7 @@ use PhpBench\DependencyInjection\Container;
 use PhpBench\Registry\Registry;
 
 /**
- * @method \PhpBench\Assertion\Asserter getService()
+ * @method \PhpBench\Assertion\Asserter getService(string $name)
  */
 class AsserterRegistry extends Registry
 {

--- a/lib/Benchmark/BaselineManager.php
+++ b/lib/Benchmark/BaselineManager.php
@@ -37,10 +37,10 @@ class BaselineManager
      * Throws an invalid argument exception if the name has
      * already been registered.
      *
-     * @param string
-     * @param mixed
+     * @param string $name
+     * @param mixed $callable
      *
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     public function addBaselineCallable($name, $callable)
     {

--- a/lib/Benchmark/BenchmarkFinder.php
+++ b/lib/Benchmark/BenchmarkFinder.php
@@ -28,9 +28,6 @@ class BenchmarkFinder
      */
     private $factory;
 
-    /**
-     * @param Factory $factory
-     */
     public function __construct(MetadataFactory $factory)
     {
         $this->factory = $factory;

--- a/lib/Benchmark/Executor/BaseExecutor.php
+++ b/lib/Benchmark/Executor/BaseExecutor.php
@@ -39,11 +39,6 @@ abstract class BaseExecutor implements ExecutorInterface
      */
     private $launcher;
 
-    /**
-     * @param Launcher $launcher
-     * @param string $configPath
-     * @param string $bootstrap
-     */
     public function __construct(Launcher $launcher)
     {
         $this->launcher = $launcher;

--- a/lib/Benchmark/ExecutorInterface.php
+++ b/lib/Benchmark/ExecutorInterface.php
@@ -44,7 +44,7 @@ interface ExecutorInterface extends RegistrableInterface
      *
      * Methods called here cannot establish a runtime state.
      *
-     * @param string[]
+     * @param string[] $methods
      */
     public function executeMethods(BenchmarkMetadata $benchmark, array $methods);
 

--- a/lib/Benchmark/Metadata/BenchmarkMetadata.php
+++ b/lib/Benchmark/Metadata/BenchmarkMetadata.php
@@ -48,9 +48,8 @@ class BenchmarkMetadata
     private $executorMetadata;
 
     /**
-     * @param mixed $path
-     * @param mixed $class
-     * @param Subject[] $subjects
+     * @param string $path
+     * @param string $class
      */
     public function __construct($path, $class)
     {
@@ -99,7 +98,7 @@ class BenchmarkMetadata
     /**
      * Remove all subjects whose name is not in the given list.
      *
-     * @param array $subjectNames
+     * @param string[] $filters
      */
     public function filterSubjectNames(array $filters)
     {
@@ -126,7 +125,7 @@ class BenchmarkMetadata
     /**
      * Remove all the subjects which are not contained in the given list of groups.
      *
-     * @param string[]
+     * @param string[] $groups
      */
     public function filterSubjectGroups(array $groups)
     {

--- a/lib/Benchmark/Metadata/DriverInterface.php
+++ b/lib/Benchmark/Metadata/DriverInterface.php
@@ -12,7 +12,6 @@
 
 namespace PhpBench\Benchmark\Metadata;
 
-use PhpBench\Benchmark\Remote\ReflectionClass;
 use PhpBench\Benchmark\Remote\ReflectionHierarchy;
 
 /**
@@ -23,7 +22,7 @@ interface DriverInterface
     /**
      * Return the metadata for the given class FQN.
      *
-     * @param ReflectionClass[] $reflections
+     * @param ReflectionHierarchy $classHierarchy
      *
      * @return BenchmarkMetadata
      */

--- a/lib/Benchmark/Metadata/MetadataFactory.php
+++ b/lib/Benchmark/Metadata/MetadataFactory.php
@@ -54,7 +54,13 @@ class MetadataFactory
             return null;
         }
 
-        if ($hierarchy->getTop() && true === $hierarchy->getTop()->abstract) {
+        try {
+            $top = $hierarchy->getTop();
+        } catch (\InvalidArgumentException $exception) {
+            return null;
+        }
+
+        if (true === $top->abstract) {
             return null;
         }
 

--- a/lib/Benchmark/Remote/Launcher.php
+++ b/lib/Benchmark/Remote/Launcher.php
@@ -62,7 +62,13 @@ class Launcher
     private $phpDisableIni;
 
     /**
-     * @param mixed string
+     * @param PayloadFactory|null $factory
+     * @param ExecutableFinder|null $finder
+     * @param string|null $bootstrap
+     * @param string|null $phpBinary
+     * @param array $phpConfig
+     * @param null|string $phpWrapper
+     * @param bool $phpDisableIni
      */
     public function __construct(
         PayloadFactory $factory = null,
@@ -132,6 +138,7 @@ class Launcher
         }
 
         // otherwise try and find it in PATH etc.
+        /** @var string|null $phpBinary */
         $phpBinary = $this->finder->find($this->phpBinary);
 
         if (null === $phpBinary) {

--- a/lib/Benchmark/Remote/Reflector.php
+++ b/lib/Benchmark/Remote/Reflector.php
@@ -18,7 +18,7 @@ namespace PhpBench\Benchmark\Remote;
 class Reflector
 {
     /**
-     * @param Launcher
+     * @var Launcher
      */
     private $launcher;
 

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -96,7 +96,7 @@ class Runner
     /**
      * Set the progress logger to use.
      *
-     * @param LoggerInterface
+     * @param LoggerInterface $logger
      */
     public function setProgressLogger(LoggerInterface $logger)
     {
@@ -181,6 +181,7 @@ class Runner
             $executorConfig = $this->executorRegistry->getConfig($config->getExecutor());
 
             if ($executorMetadata = $subjectMetadata->getExecutor()) {
+                /** @var ExecutorInterface $executor */
                 $executor = $this->executorRegistry->getService($executorMetadata->getName());
                 $executorConfig = $this->executorRegistry->getConfig($executorMetadata->getRegistryConfig());
             }

--- a/lib/Benchmark/RunnerConfig.php
+++ b/lib/Benchmark/RunnerConfig.php
@@ -124,8 +124,6 @@ class RunnerConfig
 
     /**
      * Whitelist of subject method names.
-     *
-     * @param string[] $subjects
      */
     public function getFilters(): array
     {
@@ -181,7 +179,7 @@ class RunnerConfig
     /**
      * Override the sleep interval (in microseconds).
      *
-     * @param int $sleep
+     * @param mixed $default
      */
     public function getSleep($default = null)
     {

--- a/lib/Console/Command/LogCommand.php
+++ b/lib/Console/Command/LogCommand.php
@@ -12,6 +12,7 @@
 
 namespace PhpBench\Console\Command;
 
+use PhpBench\Console\Application;
 use PhpBench\Console\CharacterReader;
 use PhpBench\Console\Command\Handler\TimeUnitHandler;
 use PhpBench\Registry\Registry;
@@ -70,7 +71,10 @@ EOT
         // value of 100.
         $height = 100;
 
-        if ($application = $this->getApplication()) {
+        /** @var Application|null $application */
+        $application = $this->getApplication();
+
+        if ($application) {
             $height = (new Terminal())->getHeight();
             $height = $height ?: 100;
         }

--- a/lib/Console/Command/RunCommand.php
+++ b/lib/Console/Command/RunCommand.php
@@ -20,6 +20,7 @@ use PhpBench\Console\Command\Handler\TimeUnitHandler;
 use PhpBench\Model\SuiteCollection;
 use PhpBench\PhpBench;
 use PhpBench\Registry\Registry;
+use PhpBench\Storage\DriverInterface;
 use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -113,7 +114,11 @@ EOT
 
         if (true === $input->getOption('store')) {
             $output->write('Storing results ... ');
-            $message = $this->storage->getService()->store($collection);
+
+            /** @var DriverInterface $driver */
+            $driver = $this->storage->getService();
+
+            $message = $driver->store($collection);
 
             $output->writeln('OK');
             $output->writeln(sprintf('Run: %s', $suite->getUuid()));

--- a/lib/Environment/Information.php
+++ b/lib/Environment/Information.php
@@ -22,11 +22,8 @@ class Information implements \ArrayAccess, \IteratorAggregate
     private $information;
 
     /**
-     * __construct.
-     *
-     * @param string $system
-     * @param stirng $version
-     * @param string $branch
+     * @param string $name
+     * @param array $information
      */
     public function __construct($name, array $information)
     {

--- a/lib/Environment/Supplier.php
+++ b/lib/Environment/Supplier.php
@@ -30,7 +30,7 @@ class Supplier
     /**
      * Add a provider.
      *
-     * @param ProviderInterface
+     * @param ProviderInterface $provider
      */
     public function addProvider(ProviderInterface $provider)
     {

--- a/lib/Math/Statistics.php
+++ b/lib/Math/Statistics.php
@@ -20,7 +20,7 @@ class Statistics
     /**
      * Return the standard deviation of a given population.
      *
-     * @param \DOMNodeList $nodeList
+     * @param array $values
      * @param bool $sample
      *
      * @return float

--- a/lib/Model/Benchmark.php
+++ b/lib/Model/Benchmark.php
@@ -35,9 +35,8 @@ class Benchmark implements \IteratorAggregate
     private $suite;
 
     /**
-     * @param mixed $path
-     * @param mixed $class
-     * @param Subject[] $subjects
+     * @param Suite $suite
+     * @param string $class
      */
     public function __construct(Suite $suite, $class)
     {

--- a/lib/Model/Iteration.php
+++ b/lib/Model/Iteration.php
@@ -22,7 +22,8 @@ class Iteration extends ResultCollection
 
     /**
      * @param int $index
-     * @param int $revolutions
+     * @param Variant $variant
+     * @param array $results
      */
     public function __construct(
         $index,

--- a/lib/Model/Result/MemoryResult.php
+++ b/lib/Model/Result/MemoryResult.php
@@ -37,9 +37,9 @@ class MemoryResult implements ResultInterface
     }
 
     /**
-     * @param int $current
-     * @param int $real
      * @param int $peak
+     * @param int $real
+     * @param int $final
      */
     public function __construct($peak, $real, $final)
     {

--- a/lib/Model/ResultCollection.php
+++ b/lib/Model/ResultCollection.php
@@ -34,7 +34,7 @@ class ResultCollection
      *
      * Only one result per class is permitted.
      *
-     * @param ResultInterface
+     * @param ResultInterface $result
      */
     public function setResult(ResultInterface $result)
     {

--- a/lib/Model/ResultInterface.php
+++ b/lib/Model/ResultInterface.php
@@ -23,7 +23,7 @@ interface ResultInterface
     /**
      * Return a new instance based using the given array values.
      *
-     * @param array $array
+     * @param array $values
      *
      * @return ResultInterface
      */

--- a/lib/Model/Subject.php
+++ b/lib/Model/Subject.php
@@ -12,7 +12,6 @@
 
 namespace PhpBench\Model;
 
-use PhpBench\Benchmark\Metadata\BenchmarkMetadata;
 use PhpBench\Util\TimeUnit;
 
 /**
@@ -79,7 +78,7 @@ class Subject
     private $executor;
 
     /**
-     * @param BenchmarkMetadata $benchmark
+     * @param Benchmark $benchmark
      * @param string $name
      */
     public function __construct(Benchmark $benchmark, $name)

--- a/lib/Model/Variant.php
+++ b/lib/Model/Variant.php
@@ -121,8 +121,7 @@ class Variant implements \IteratorAggregate, \ArrayAccess, \Countable
     /**
      * Create and add a new iteration.
      *
-     * @param int $time
-     * @param int $memory
+     * @param array $results
      *
      * @return Iteration
      */
@@ -368,7 +367,7 @@ class Variant implements \IteratorAggregate, \ArrayAccess, \Countable
      * After an exception is encountered the results from this iteration
      * set are invalid.
      *
-     * @param \Exception $e
+     * @param \Exception $exception
      */
     public function setException(\Exception $exception)
     {
@@ -409,7 +408,7 @@ class Variant implements \IteratorAggregate, \ArrayAccess, \Countable
     /**
      * Create and set the error stack from a list of Error instances.
      *
-     * @param Error[]
+     * @param Error[] $errors
      */
     public function createErrorStack(array $errors)
     {

--- a/lib/Progress/Logger/BlinkenLogger.php
+++ b/lib/Progress/Logger/BlinkenLogger.php
@@ -29,7 +29,7 @@ class BlinkenLogger extends AnsiLogger
     /**
      * Track rejected iterations.
      *
-     * @var int[]
+     * @var bool[]
      */
     private $rejects = [];
 

--- a/lib/Progress/LoggerInterface.php
+++ b/lib/Progress/LoggerInterface.php
@@ -38,14 +38,14 @@ interface LoggerInterface extends OutputAwareInterface
     /**
      * Log the end of a benchmarking subject.
      *
-     * @param Subject $case
+     * @param Subject $subject
      */
     public function subjectEnd(Subject $subject);
 
     /**
      * Log the end of a benchmarking subject.
      *
-     * @param Subject $case
+     * @param Subject $subject
      */
     public function subjectStart(Subject $subject);
 

--- a/lib/Registry/ConfigurableRegistry.php
+++ b/lib/Registry/ConfigurableRegistry.php
@@ -104,8 +104,7 @@ class ConfigurableRegistry extends Registry
      * Recursively merge configs (having the "extends" key) which extend
      * another report.
      *
-     * @param array $config
-     * @param string $getMethod
+     * @param string $name
      *
      * @return array
      */
@@ -141,6 +140,7 @@ class ConfigurableRegistry extends Registry
             ));
         }
 
+        /** @var RegistrableInterface $service */
         $service = $this->getService($config[$this->serviceType]);
 
         $options = new OptionsResolver();
@@ -164,9 +164,9 @@ class ConfigurableRegistry extends Registry
      * table
      * ````
      *
-     * @param array $rawConfigs
+     * @param string $rawConfig
      *
-     * @return array
+     * @return string
      */
     private function processRawCliConfig($rawConfig)
     {

--- a/lib/Report/Generator/Table/Row.php
+++ b/lib/Report/Generator/Table/Row.php
@@ -71,7 +71,7 @@ class Row extends \ArrayObject
     /**
      * Set the format parameters.
      *
-     * @param array
+     * @param array $formatParams
      */
     public function setFormatParams($formatParams)
     {

--- a/lib/Report/Generator/Table/Sort.php
+++ b/lib/Report/Generator/Table/Sort.php
@@ -19,8 +19,8 @@ class Sort
      *
      * http://at2.php.net/manual/en/function.usort.php#38827
      *
-     * @param array
-     * @param \Closure Sorting callback
+     * @param array $array
+     * @param \Closure $callback Sorting callback
      */
     public static function mergeSort(&$array, \Closure $callback)
     {

--- a/lib/Report/Generator/TableGenerator.php
+++ b/lib/Report/Generator/TableGenerator.php
@@ -242,7 +242,7 @@ class TableGenerator implements GeneratorInterface, OutputAwareInterface
      * Remove unwanted columns from the tables.
      *
      * @param array $tables
-     * @param array $config
+     * @param Config $config
      *
      * @return array
      */

--- a/lib/Report/GeneratorInterface.php
+++ b/lib/Report/GeneratorInterface.php
@@ -23,7 +23,7 @@ interface GeneratorInterface extends RegistrableInterface
      * Generate the report document from the suite result document.
      *
      * @param SuiteCollection $collection
-     * @param array $config
+     * @param Config $config
      *
      * @return Document
      */

--- a/lib/Report/Renderer/ConsoleRenderer.php
+++ b/lib/Report/Renderer/ConsoleRenderer.php
@@ -53,8 +53,8 @@ class ConsoleRenderer implements RendererInterface, OutputAwareInterface
     /**
      * Render the table.
      *
-     * @param mixed $tableDom
-     * @param mixed $config
+     * @param Document $reportDom
+     * @param Config $config
      */
     public function render(Document $reportDom, Config $config)
     {
@@ -142,7 +142,7 @@ class ConsoleRenderer implements RendererInterface, OutputAwareInterface
     /**
      * Adds some output formatters.
      *
-     * @param OutputFormatterInterface
+     * @param OutputFormatterInterface $formatter
      */
     private function configureFormatters(OutputFormatterInterface $formatter)
     {

--- a/lib/Report/Renderer/DelimitedRenderer.php
+++ b/lib/Report/Renderer/DelimitedRenderer.php
@@ -42,8 +42,8 @@ class DelimitedRenderer implements RendererInterface, OutputAwareInterface
     /**
      * Render the table.
      *
-     * @param mixed $tableDom
-     * @param mixed $config
+     * @param Document $reportDom
+     * @param Config $config
      */
     public function render(Document $reportDom, Config $config)
     {

--- a/lib/Report/Renderer/XsltRenderer.php
+++ b/lib/Report/Renderer/XsltRenderer.php
@@ -59,8 +59,8 @@ class XsltRenderer implements RendererInterface, OutputAwareInterface
     /**
      * Render the table.
      *
-     * @param mixed $tableDom
-     * @param mixed $config
+     * @param Document $reportDom
+     * @param Config $config
      */
     public function render(Document $reportDom, Config $config)
     {

--- a/lib/Report/ReportManager.php
+++ b/lib/Report/ReportManager.php
@@ -44,9 +44,10 @@ class ReportManager
     /**
      * Generate the named reports.
      *
-     * @param OutputInterface $output
-     * @param Document $suiteDocument
+     * @param SuiteCollection $collection
      * @param array $reportNames
+     *
+     * @return array
      */
     public function generateReports(SuiteCollection $collection, array $reportNames)
     {
@@ -83,7 +84,7 @@ class ReportManager
      * Render reports (as opposed to just generating the report XML documents via. generateReports).
      *
      * @param OutputInterface $output
-     * @param Document $suiteDocument
+     * @param SuiteCollection $collection
      * @param array $reportNames
      * @param array $outputNames
      */

--- a/lib/Storage/Archiver/XmlArchiver.php
+++ b/lib/Storage/Archiver/XmlArchiver.php
@@ -17,6 +17,8 @@ use PhpBench\Registry\Registry;
 use PhpBench\Serializer\XmlDecoder;
 use PhpBench\Serializer\XmlEncoder;
 use PhpBench\Storage\ArchiverInterface;
+use PhpBench\Storage\DriverInterface;
+use PhpBench\Storage\HistoryEntry;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -69,6 +71,7 @@ class XmlArchiver implements ArchiverInterface
      */
     public function archive(OutputInterface $output)
     {
+        /** @var DriverInterface $driver */
         $driver = $this->storageRegistry->getService();
 
         if (!$this->filesystem->exists($this->archivePath)) {
@@ -78,6 +81,7 @@ class XmlArchiver implements ArchiverInterface
         $runIds = [];
 
         foreach ($driver->history() as $entry) {
+            /** @var HistoryEntry $entry */
             $runIds[] = $entry->getRunId();
         }
 
@@ -108,6 +112,7 @@ class XmlArchiver implements ArchiverInterface
      */
     public function restore(OutputInterface $output)
     {
+        /** @var DriverInterface $driver */
         $driver = $this->storageRegistry->getService();
 
         $iterator = new \DirectoryIterator($this->archivePath);

--- a/lib/Storage/ArchiverInterface.php
+++ b/lib/Storage/ArchiverInterface.php
@@ -28,7 +28,7 @@ interface ArchiverInterface
      *
      * Progress should be written to the given console output class.
      *
-     * @param OutputInterface
+     * @param OutputInterface $output
      */
     public function archive(OutputInterface $output);
 

--- a/lib/Storage/DriverInterface.php
+++ b/lib/Storage/DriverInterface.php
@@ -47,7 +47,7 @@ interface DriverInterface
      *
      * @param int $runId
      *
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      *
      * @return SuiteCollection
      */

--- a/lib/Util/TimeUnit.php
+++ b/lib/Util/TimeUnit.php
@@ -97,7 +97,9 @@ class TimeUnit
     /**
      * Convert instance value to given unit.
      *
-     * @param string
+     * @param int $time
+     * @param string $destUnit
+     * @param string $mode
      *
      * @return int
      */
@@ -109,7 +111,7 @@ class TimeUnit
     /**
      * Override the destination unit.
      *
-     * @param string
+     * @param string $destUnit
      */
     public function overrideDestUnit($destUnit)
     {
@@ -210,7 +212,7 @@ class TimeUnit
     /**
      * Return the destination mode.
      *
-     * @param string $unit
+     * @param string $mode
      *
      * @return string
      */
@@ -240,9 +242,13 @@ class TimeUnit
     /**
      * Return a human readable representation of the unit including the suffix.
      *
-     * @param int
-     * @param string
-     * @param string
+     * @param int $time
+     * @param string $unit
+     * @param string $mode
+     * @param int $precision
+     * @param bool $suffix
+     *
+     * @return string
      */
     public function format($time, $unit = null, $mode = null, $precision = null, $suffix = true)
     {
@@ -286,9 +292,9 @@ class TimeUnit
      *
      * @static
      *
-     * @param int
-     * @param string
-     * @param string
+     * @param int $time
+     * @param string $unit
+     * @param string $destUnit
      *
      * @return int
      */
@@ -315,9 +321,9 @@ class TimeUnit
      *
      * @static
      *
-     * @param int
-     * @param string
-     * @param string
+     * @param int $time
+     * @param string $unit
+     * @param string $destUnit
      *
      * @return int
      */
@@ -339,7 +345,8 @@ class TimeUnit
      *
      * @static
      *
-     * @param string
+     * @param string $unit
+     * @param string $mode
      *
      * @return string
      */

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,6 @@ includes:
 
 parameters:
     ignoreErrors:
-        - '#Undefined variable: \$argv#'
         - '#Call to an undefined method DOMNode::#'
     paths:
         - lib

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,3 +2,5 @@ parameters:
     ignoreErrors:
         - '#Undefined variable: \$argv#'
         - '#Call to an undefined method DOMNode::#'
+    paths:
+        - lib

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,6 @@
+includes:
+    - vendor/phpstan/phpstan/conf/config.level4.neon
+
 parameters:
     ignoreErrors:
         - '#Undefined variable: \$argv#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,9 @@ includes:
 
 parameters:
     ignoreErrors:
+        - '#Argument of an invalid type PhpBench\\Benchmark\\RunnerConfig supplied for foreach, only iterables are supported.#'
         - '#Call to an undefined method DOMNode::#'
+        - "#Offset 'name' does not exist on string.#"
+        - '#Variable \$reject might not be defined.#'
     paths:
         - lib

--- a/tests/Unit/Console/Command/LogCommandTest.php
+++ b/tests/Unit/Console/Command/LogCommandTest.php
@@ -71,6 +71,11 @@ class LogCommandTest extends TestCase
         $this->timeUnit->getDestSuffix()->willReturn('s');
     }
 
+    protected function tearDown(): void
+    {
+        $this->resetTerminalDimensions();
+    }
+
     /**
      * It should be configured.
      */
@@ -89,7 +94,8 @@ class LogCommandTest extends TestCase
             '--no-pagination' => true,
         ], $this->command->getDefinition());
 
-        $this->application->setTerminalDimensions(100, 10);
+        $this->setTerminalDimensions(100, 10);
+
         $this->characterReader->read()->shouldNotBeCalled();
 
         $this->driver->history()->willReturn($this->history->reveal());
@@ -146,7 +152,8 @@ EOT;
         $input = new ArrayInput([], $this->command->getDefinition());
         $output = $this->output;
 
-        $this->application->setTerminalDimensions(100, 14);
+        $this->setTerminalDimensions(100, 14);
+
         $this->characterReader->read()->willReturn('')->shouldBeCalledTimes(1);
 
         $this->driver->history()->willReturn($this->history->reveal());
@@ -201,7 +208,8 @@ EOT;
         $input = new ArrayInput([], $this->command->getDefinition());
         $output = $this->output;
 
-        $this->application->setTerminalDimensions(100, 14);
+        $this->setTerminalDimensions(100, 14);
+
         $this->characterReader->read()->willReturn('q')->shouldBeCalledTimes(1);
 
         $this->driver->history()->willReturn($this->history->reveal());
@@ -259,5 +267,17 @@ EOT;
             0.75,
             100
         );
+    }
+
+    private function setTerminalDimensions(int $columns, int $lines): void
+    {
+        putenv('COLUMNS=' . $columns);
+        putenv('LINES=' . $lines);
+    }
+
+    private function resetTerminalDimensions(): void
+    {
+        putenv('COLUMNS');
+        putenv('LINES');
     }
 }


### PR DESCRIPTION
This PR

* [x] updates `phpstan/phpstan`
* [x] configures paths to analyse in `phpstan.neon`
* [x] configures `phpstan` level via `includes` in `phpstan.neon`
* [x] uses 🇬🇧 spelling when asking `phpstan` to analyse code
* [x] removes an ignored error that does not match any reported errors anymore
* [x] fixes issues detected by `phpstan`
* [x] removes ignored error not matched anymore
* [x] ignores errors for now
* [x] sets terminal dimensions via environment variables as `setTerminalDimensions()` has been removed in `symfony/console:^4.0.0`

💁‍♂️ For reference, see https://github.com/phpstan/phpstan/compare/0.8.5...0.10.6