### PR TITLE
Enhancement: Reference phpunit.xsd as installed with composer

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,6 +2,8 @@
 
 <!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     colors="true"
     bootstrap="vendor/autoload.php"
     >


### PR DESCRIPTION
This PR

* [x] references `phpunit.xsd` in `phpunit.xml.dist` as installed with `composer`

💁‍♂️ Helpful with auto-completion!