### PR TITLE
Enhancement: Enable php_unit_set_up_tear_down_visibility fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -9,11 +9,13 @@ $finder = PhpCsFixer\Finder::create()
 ;
 
 return PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
     ->setRules([
         '@PSR2' => true,
         'binary_operator_spaces' => [ 'align_double_arrow' => false ],
         'concat_space' => false,
         'method_argument_space' => false,
+        'php_unit_set_up_tear_down_visibility' => true,
         'phpdoc_align' => [],
         'phpdoc_indent' => false,
     ])

--- a/extensions/dbal/tests/Functional/Command/MigrateCommandTest.php
+++ b/extensions/dbal/tests/Functional/Command/MigrateCommandTest.php
@@ -21,7 +21,7 @@ class MigrateCommandTest extends DbalTestCase
 {
     private $output;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->output = new BufferedOutput();
         $this->command = new MigrateCommand($this->getConnection());

--- a/extensions/dbal/tests/Functional/Storage/Driver/Dbal/HistoryIteratorTest.php
+++ b/extensions/dbal/tests/Functional/Storage/Driver/Dbal/HistoryIteratorTest.php
@@ -25,7 +25,7 @@ class HistoryIteratorTest extends DbalTestCase
     private $persister;
     private $iterator;
 
-    public function setUp()
+    protected function setUp()
     {
         $manager = $this->getManager();
         $tokenVisitor = $this->prophesize(TokenValueVisitor::class);
@@ -35,7 +35,7 @@ class HistoryIteratorTest extends DbalTestCase
         $this->iterator = new HistoryIterator($repository);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->cleanWorkspace();
     }

--- a/extensions/dbal/tests/Functional/Storage/Driver/Dbal/LoaderTest.php
+++ b/extensions/dbal/tests/Functional/Storage/Driver/Dbal/LoaderTest.php
@@ -31,7 +31,7 @@ class LoaderTest extends DbalTestCase
     private $loader;
     private $visitor;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->manager = $this->getManager();
 
@@ -44,7 +44,7 @@ class LoaderTest extends DbalTestCase
         $this->loader = new Loader($repository);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->cleanWorkspace();
     }

--- a/extensions/dbal/tests/Functional/Storage/Driver/Dbal/PeristerTest.php
+++ b/extensions/dbal/tests/Functional/Storage/Driver/Dbal/PeristerTest.php
@@ -24,7 +24,7 @@ class PeristerTest extends DbalTestCase
     private $persister;
     private $manager;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->manager = $this->getManager();
 
@@ -32,7 +32,7 @@ class PeristerTest extends DbalTestCase
         $this->persister = new Persister($this->manager);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->cleanWorkspace();
     }

--- a/extensions/dbal/tests/Functional/Storage/Driver/Dbal/RepositoryTest.php
+++ b/extensions/dbal/tests/Functional/Storage/Driver/Dbal/RepositoryTest.php
@@ -25,7 +25,7 @@ class RepositoryTest extends DbalTestCase
     private $persister;
     private $repository;
 
-    public function setUp()
+    protected function setUp()
     {
         $manager = $this->getManager();
 

--- a/extensions/dbal/tests/Unit/Storage/Driver/Dbal/Visitor/SqlVisitorTest.php
+++ b/extensions/dbal/tests/Unit/Storage/Driver/Dbal/Visitor/SqlVisitorTest.php
@@ -23,7 +23,7 @@ class SqlVisitorTest extends TestCase
 {
     private $visitor;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->visitor = new SqlVisitor();
         $this->parser = new Parser();

--- a/extensions/dbal/tests/Unit/Storage/Driver/Dbal/Visitor/TokenValueVisitorTest.php
+++ b/extensions/dbal/tests/Unit/Storage/Driver/Dbal/Visitor/TokenValueVisitorTest.php
@@ -22,7 +22,7 @@ class TokenValueVisitorTest extends TestCase
     private $visitor;
     private $uuidResolver;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->uuidResolver = $this->prophesize(UuidResolverInterface::class);
         $this->visitor = new TokenValueVisitor($this->uuidResolver->reveal());

--- a/extensions/dbal/tests/Unit/Storage/Driver/DbalDriverTest.php
+++ b/extensions/dbal/tests/Unit/Storage/Driver/DbalDriverTest.php
@@ -28,7 +28,7 @@ class DbalDriverTest extends TestCase
     private $constraint;
     private $driver;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->loader = $this->prophesize(Loader::class);
         $this->persister = $this->prophesize(Persister::class);

--- a/extensions/reports/tests/Driver/ReportsDriverTest.php
+++ b/extensions/reports/tests/Driver/ReportsDriverTest.php
@@ -53,7 +53,7 @@ class ReportsDriverTest extends TestCase
      */
     private $history;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->innerDriver = $this->prophesize(DriverInterface::class);
 

--- a/extensions/xdebug/tests/System/XDebugTestCase.php
+++ b/extensions/xdebug/tests/System/XDebugTestCase.php
@@ -16,7 +16,7 @@ use PhpBench\Tests\System\SystemTestCase;
 
 class XDebugTestCase extends SystemTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         if (!extension_loaded('xdebug')) {
             $this->markTestSkipped('XDebug not enabled.');

--- a/extensions/xdebug/tests/Unit/Converter/TraceToXmlConverterTest.php
+++ b/extensions/xdebug/tests/Unit/Converter/TraceToXmlConverterTest.php
@@ -19,7 +19,7 @@ class TraceToXmlConverterTest extends TestCase
 {
     private $converter;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->converter = new TraceToXmlConverter();
     }

--- a/extensions/xdebug/tests/Unit/Executor/TraceExecutorTest.php
+++ b/extensions/xdebug/tests/Unit/Executor/TraceExecutorTest.php
@@ -33,7 +33,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TraceExecutorTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->launcher = $this->prophesize(Launcher::class);
         $this->filesystem = $this->prophesize(Filesystem::class);

--- a/extensions/xdebug/tests/Unit/XDebugUtilTest.php
+++ b/extensions/xdebug/tests/Unit/XDebugUtilTest.php
@@ -27,7 +27,7 @@ class XDebugUtilTest extends TestCase
     private $benchmark;
     private $parameters;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->iteration = $this->prophesize(Iteration::class);
         $this->subject = $this->prophesize(Subject::class);

--- a/tests/System/ReportOutputTest.php
+++ b/tests/System/ReportOutputTest.php
@@ -19,7 +19,7 @@ namespace PhpBench\Tests\System;
  */
 class ReportOutputTest extends SystemTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->getResult();

--- a/tests/System/SystemTestCase.php
+++ b/tests/System/SystemTestCase.php
@@ -23,7 +23,7 @@ class SystemTestCase extends TestCase
     protected $filesystem;
     protected $workspaceDir;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->filesystem = new Filesystem();
         $this->workspaceDir = sys_get_temp_dir() . '/phpbench-tests';

--- a/tests/Unit/Benchmark/BaselineManagerTest.php
+++ b/tests/Unit/Benchmark/BaselineManagerTest.php
@@ -24,7 +24,7 @@ class BaselineManagerTest extends TestCase
 
     public static $callCount = false;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->manager = new BaselineManager();
     }

--- a/tests/Unit/Benchmark/BenchmarkFinderTest.php
+++ b/tests/Unit/Benchmark/BenchmarkFinderTest.php
@@ -25,7 +25,7 @@ class BenchmarkFinderTest extends TestCase
     private $benchmark1;
     private $benchmark2;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->factory = $this->prophesize(MetadataFactory::class);
         $this->benchmark1 = $this->prophesize(BenchmarkMetadata::class);

--- a/tests/Unit/Benchmark/Executor/DebugExecutorTest.php
+++ b/tests/Unit/Benchmark/Executor/DebugExecutorTest.php
@@ -27,7 +27,7 @@ class DebugExecutorTest extends TestCase
 {
     private $executor;
 
-    public function setUp()
+    protected function setUp()
     {
         $launcher = $this->prophesize(Launcher::class);
         $this->executor = new DebugExecutor($launcher->reveal());

--- a/tests/Unit/Benchmark/Executor/MicrotimeExecutorTest.php
+++ b/tests/Unit/Benchmark/Executor/MicrotimeExecutorTest.php
@@ -36,7 +36,7 @@ class MicrotimeExecutorTest extends TestCase
     private $paramBeforeFile;
     private $paramAfterFile;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->beforeMethodFile = __DIR__ . '/benchmarks/before_method.tmp';
         $this->afterMethodFile = __DIR__ . '/benchmarks/after_method.tmp';
@@ -64,7 +64,7 @@ class MicrotimeExecutorTest extends TestCase
         $this->iteration->getVariant()->willReturn($this->variant->reveal());
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->removeTemporaryFiles();
     }

--- a/tests/Unit/Benchmark/Metadata/BenchmarkMetadataTest.php
+++ b/tests/Unit/Benchmark/Metadata/BenchmarkMetadataTest.php
@@ -19,7 +19,7 @@ class BenchmarkMetadataTest extends TestCase
 {
     private $metadata;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->metadata = new BenchmarkMetadata('/path/to', 'Class');
         $this->subject1 = $this->metadata->getOrCreateSubject('subjectOne');

--- a/tests/Unit/Benchmark/Metadata/Driver/AnnotationDriverTest.php
+++ b/tests/Unit/Benchmark/Metadata/Driver/AnnotationDriverTest.php
@@ -28,7 +28,7 @@ class AnnotationDriverTest extends TestCase
     private $driver;
     private $reflector;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->reflector = $this->prophesize(Reflector::class);
     }

--- a/tests/Unit/Benchmark/Metadata/FactoryTest.php
+++ b/tests/Unit/Benchmark/Metadata/FactoryTest.php
@@ -29,7 +29,7 @@ class FactoryTest extends TestCase
 
     private $factory;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->reflector = $this->prophesize(Reflector::class);
         $this->driver = $this->prophesize(DriverInterface::class);

--- a/tests/Unit/Benchmark/Metadata/SubjectMetadataTest.php
+++ b/tests/Unit/Benchmark/Metadata/SubjectMetadataTest.php
@@ -21,7 +21,7 @@ class SubjectMetadataTest extends TestCase
     private $subject;
     private $benchmark;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->benchmark = $this->prophesize(BenchmarkMetadata::class);
         $this->subject = new SubjectMetadata($this->benchmark->reveal(), 'subjectOne', 0);

--- a/tests/Unit/Benchmark/Remote/IniStringBuilderTest.php
+++ b/tests/Unit/Benchmark/Remote/IniStringBuilderTest.php
@@ -22,7 +22,7 @@ class IniStringBuilderTest extends TestCase
      */
     private $builder;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->builder = new IniStringBuilder();
     }

--- a/tests/Unit/Benchmark/Remote/LauncherTest.php
+++ b/tests/Unit/Benchmark/Remote/LauncherTest.php
@@ -24,7 +24,7 @@ class LauncherTest extends TestCase
     private $payload;
     private $finder;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->factory = $this->prophesize(PayloadFactory::class);
         $this->payload = $this->prophesize(Payload::class);

--- a/tests/Unit/Benchmark/Remote/PayloadFactoryTest.php
+++ b/tests/Unit/Benchmark/Remote/PayloadFactoryTest.php
@@ -20,7 +20,7 @@ class PayloadFactoryTest extends TestCase
 {
     private $factory;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->factory = new PayloadFactory();
     }

--- a/tests/Unit/Benchmark/Remote/PayloadTest.php
+++ b/tests/Unit/Benchmark/Remote/PayloadTest.php
@@ -21,7 +21,7 @@ class PayloadTest extends TestCase
 {
     private $process;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->process = $this->prophesize(Process::class);
     }

--- a/tests/Unit/Benchmark/Remote/ReflectionHierarchyTest.php
+++ b/tests/Unit/Benchmark/Remote/ReflectionHierarchyTest.php
@@ -23,7 +23,7 @@ class ReflectionHierarchyTest extends TestCase
     private $reflection1;
     private $reflection2;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->hierarchy = new ReflectionHierarchy();
         $this->reflection1 = new ReflectionClass();

--- a/tests/Unit/Benchmark/Remote/ReflectorTest.php
+++ b/tests/Unit/Benchmark/Remote/ReflectorTest.php
@@ -20,7 +20,7 @@ class ReflectorTest extends TestCase
 {
     private $reflector;
 
-    public function setUp()
+    protected function setUp()
     {
         $executor = new Launcher(null, null, __DIR__ . '/../../../../vendor/autoload.php', null);
         $this->reflector = new Reflector($executor);

--- a/tests/Unit/Benchmark/RunnerTest.php
+++ b/tests/Unit/Benchmark/RunnerTest.php
@@ -86,7 +86,7 @@ class RunnerTest extends TestCase
      */
     private $runner;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->benchmarkFinder = $this->prophesize(BenchmarkFinder::class);
         $this->suite = $this->prophesize(Suite::class);

--- a/tests/Unit/Console/Command/LogCommandTest.php
+++ b/tests/Unit/Console/Command/LogCommandTest.php
@@ -35,7 +35,7 @@ class LogCommandTest extends TestCase
     private $output;
     private $history;
 
-    public function setUp()
+    protected function setUp()
     {
         if (!class_exists(QuestionHelper::class)) {
             $this->markTestSkipped('Not testing if QuestionHelper class does not exist (< Symfony 2.7)');

--- a/tests/Unit/Console/Command/UpdateCommandTest.php
+++ b/tests/Unit/Console/Command/UpdateCommandTest.php
@@ -24,7 +24,7 @@ class UpdateCommandTest extends TestCase
     private $command;
     private $output;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->updater = $this->prophesize(Updater::class);
         $this->command = new SelfUpdateCommand($this->updater->reveal());

--- a/tests/Unit/Environment/Provider/BaselineTest.php
+++ b/tests/Unit/Environment/Provider/BaselineTest.php
@@ -22,7 +22,7 @@ class BaselineTest extends TestCase
     private $manager;
     private $provider;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->manager = $this->prophesize(BaselineManager::class);
         $this->provider = new Baseline(

--- a/tests/Unit/Environment/Provider/GitTest.php
+++ b/tests/Unit/Environment/Provider/GitTest.php
@@ -24,7 +24,7 @@ class GitTest extends TestCase
     private $filesystem;
     private $testRepoDir;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->filesystem = new Filesystem();
 
@@ -41,7 +41,7 @@ class GitTest extends TestCase
         $this->provider = new Provider\Git();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->clean();
     }

--- a/tests/Unit/Environment/Provider/OpcacheTest.php
+++ b/tests/Unit/Environment/Provider/OpcacheTest.php
@@ -22,7 +22,7 @@ class OpcacheTest extends TestCase
     private $launcher;
     private $payload;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->launcher = $this->prophesize(Launcher::class);
         $this->payload = $this->prophesize(Payload::class);

--- a/tests/Unit/Environment/Provider/PhpTest.php
+++ b/tests/Unit/Environment/Provider/PhpTest.php
@@ -21,7 +21,7 @@ class PhpTest extends TestCase
 {
     private $payload;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->payload = $this->prophesize(Payload::class);
     }

--- a/tests/Unit/Environment/Provider/UnameTest.php
+++ b/tests/Unit/Environment/Provider/UnameTest.php
@@ -19,7 +19,7 @@ class UnameTest extends TestCase
 {
     private $provider;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->provider = new Provider\Uname();
     }

--- a/tests/Unit/Environment/Provider/UnixSysloadTest.php
+++ b/tests/Unit/Environment/Provider/UnixSysloadTest.php
@@ -19,7 +19,7 @@ class UnixSysloadTest extends TestCase
 {
     private $provider;
 
-    public function setUp()
+    protected function setUp()
     {
         if (stristr(PHP_OS, 'win')) {
             $this->markTestSkipped('Unix specific test');

--- a/tests/Unit/Environment/SupplierTest.php
+++ b/tests/Unit/Environment/SupplierTest.php
@@ -21,7 +21,7 @@ class SupplierTest extends TestCase
 {
     private $supplier;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->supplier = new Supplier();
         $this->provider1 = $this->prophesize(ProviderInterface::class);

--- a/tests/Unit/Expression/ParserTest.php
+++ b/tests/Unit/Expression/ParserTest.php
@@ -21,7 +21,7 @@ class ParserTest extends TestCase
 {
     private $parser;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->parser = new Parser();
     }

--- a/tests/Unit/Extension/CoreExtensionTest.php
+++ b/tests/Unit/Extension/CoreExtensionTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 
 class CoreExtensionTest extends TestCase
 {
-    public function tearDown()
+    protected function tearDown()
     {
         putenv('CONTINUOUS_INTEGRATION=0');
     }

--- a/tests/Unit/Formatter/ClassLoaderTest.php
+++ b/tests/Unit/Formatter/ClassLoaderTest.php
@@ -19,7 +19,7 @@ class ClassLoaderTest extends TestCase
 {
     private $loader;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->loader = new ClassLoader();
     }

--- a/tests/Unit/Formatter/Format/BalanceFormatTest.php
+++ b/tests/Unit/Formatter/Format/BalanceFormatTest.php
@@ -19,7 +19,7 @@ class BalanceFormatTest extends TestCase
 {
     private $format;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->format = new BalanceFormat();
     }

--- a/tests/Unit/Formatter/Format/NumberFormatTest.php
+++ b/tests/Unit/Formatter/Format/NumberFormatTest.php
@@ -19,7 +19,7 @@ class NumberFormatTest extends TestCase
 {
     private $format;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->format = new NumberFormat();
     }

--- a/tests/Unit/Formatter/Format/PrintfFormatTest.php
+++ b/tests/Unit/Formatter/Format/PrintfFormatTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 
 class PrintfFormatTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->format = new PrintfFormat();
     }

--- a/tests/Unit/Formatter/Format/TruncateFormatTest.php
+++ b/tests/Unit/Formatter/Format/TruncateFormatTest.php
@@ -19,7 +19,7 @@ class TruncateFormatTest extends TestCase
 {
     private $format;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->format = new TruncateFormat();
     }

--- a/tests/Unit/Formatter/FormatRegistryTest.php
+++ b/tests/Unit/Formatter/FormatRegistryTest.php
@@ -21,7 +21,7 @@ class FormatRegistryTest extends TestCase
     private $registry;
     private $format;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->registry = new FormatRegistry();
         $this->format = $this->prophesize(FormatInterface::class);

--- a/tests/Unit/Formatter/FormatterTest.php
+++ b/tests/Unit/Formatter/FormatterTest.php
@@ -23,7 +23,7 @@ class FormatterTest extends TestCase
     private $formatter;
     private $format;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->registry = $this->prophesize(FormatRegistry::class);
         $this->formatter = new Formatter($this->registry->reveal());

--- a/tests/Unit/Json/JsonDecoderTest.php
+++ b/tests/Unit/Json/JsonDecoderTest.php
@@ -19,7 +19,7 @@ class JsonDecoderTest extends TestCase
 {
     private $jsonDecoder;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->jsonDecoder = new JsonDecoder();
     }

--- a/tests/Unit/Model/BenchmarkTest.php
+++ b/tests/Unit/Model/BenchmarkTest.php
@@ -27,7 +27,7 @@ class BenchmarkTest extends TestCase
     private $benchmark;
     private $suite;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->suite = $this->prophesize(Suite::class);
         $this->benchmark = new Benchmark($this->suite->reveal(), '/path/to', 'Class');

--- a/tests/Unit/Model/IterationTest.php
+++ b/tests/Unit/Model/IterationTest.php
@@ -22,7 +22,7 @@ class IterationTest extends TestCase
 {
     private $iteration;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->variant = $this->prophesize(Variant::class);
         $this->iteration = new Iteration(

--- a/tests/Unit/Model/ResultCollectionTest.php
+++ b/tests/Unit/Model/ResultCollectionTest.php
@@ -21,7 +21,7 @@ class ResultCollectionTest extends TestCase
 {
     private $collection;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->timeResult = new TimeResult(1);
         $this->memoryResult = new MemoryResult(1, 0, 0);

--- a/tests/Unit/Model/SubjectTest.php
+++ b/tests/Unit/Model/SubjectTest.php
@@ -22,7 +22,7 @@ class SubjectTest extends TestCase
     private $subject;
     private $benchmark;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->benchmark = $this->prophesize(Benchmark::class);
         $this->benchmark->getSubjects()->willReturn([]);

--- a/tests/Unit/Model/SuiteCollectionTest.php
+++ b/tests/Unit/Model/SuiteCollectionTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 
 class SuiteCollectionTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->suite1 = $this->prophesize(Suite::class);
         $this->suite2 = $this->prophesize(Suite::class);

--- a/tests/Unit/Model/SuiteTest.php
+++ b/tests/Unit/Model/SuiteTest.php
@@ -28,7 +28,7 @@ class SuiteTest extends TestCase
     private $env1;
     private $bench1;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->env1 = $this->prophesize(Information::class);
         $this->bench1 = $this->prophesize(Benchmark::class);

--- a/tests/Unit/Model/SummaryTest.php
+++ b/tests/Unit/Model/SummaryTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\TestCase;
 
 class SummaryTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->suite = $this->prophesize(Suite::class);
         $this->bench1 = $this->prophesize(Benchmark::class);

--- a/tests/Unit/Model/VariantTest.php
+++ b/tests/Unit/Model/VariantTest.php
@@ -28,7 +28,7 @@ class VariantTest extends TestCase
     private $subject;
     private $parameterSet;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->subject = $this->prophesize(Subject::class);
         $this->parameterSet = $this->prophesize(ParameterSet::class);

--- a/tests/Unit/Progress/Logger/BlinkenLoggerTest.php
+++ b/tests/Unit/Progress/Logger/BlinkenLoggerTest.php
@@ -53,7 +53,7 @@ class BlinkenLoggerTest extends TestCase
      */
     private $variant;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->output = new BufferedOutput();
         $this->timeUnit = new TimeUnit(TimeUnit::MICROSECONDS, TimeUnit::MILLISECONDS);

--- a/tests/Unit/Progress/Logger/DotsLoggerTest.php
+++ b/tests/Unit/Progress/Logger/DotsLoggerTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class DotsLoggerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->tearDown();
 
@@ -36,7 +36,7 @@ class DotsLoggerTest extends TestCase
         $this->variant = $this->prophesize(Variant::class);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         putenv('CONTINUOUS_INTEGRATION=0');
     }

--- a/tests/Unit/Progress/Logger/HistogramLoggerTest.php
+++ b/tests/Unit/Progress/Logger/HistogramLoggerTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 class HistogramLoggerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->output = new BufferedOutput();
         $this->timeUnit = new TimeUnit(TimeUnit::MICROSECONDS, TimeUnit::MILLISECONDS);

--- a/tests/Unit/Progress/Logger/PhpBenchLoggerTest.php
+++ b/tests/Unit/Progress/Logger/PhpBenchLoggerTest.php
@@ -41,7 +41,7 @@ abstract class PhpBenchLoggerTest extends TestCase
     protected $parameterSet;
     protected $stats;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->suite = $this->prophesize(Suite::class);
         $this->summary = $this->prophesize(Summary::class);

--- a/tests/Unit/Progress/Logger/TravisLoggerTest.php
+++ b/tests/Unit/Progress/Logger/TravisLoggerTest.php
@@ -18,7 +18,7 @@ use Prophecy\Argument;
 
 class TravisLoggerTest extends PhpBenchLoggerTest
 {
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
     }

--- a/tests/Unit/Progress/LoggerRegistryTest.php
+++ b/tests/Unit/Progress/LoggerRegistryTest.php
@@ -20,7 +20,7 @@ class LoggerRegistryTest extends TestCase
 {
     private $registry;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->registry = new LoggerRegistry();
         $this->progressLogger = $this->prophesize(LoggerInterface::class);

--- a/tests/Unit/Registry/ConfigTest.php
+++ b/tests/Unit/Registry/ConfigTest.php
@@ -19,7 +19,7 @@ class ConfigTest extends TestCase
 {
     private $config;
 
-    public function setUp()
+    protected function setUp()
     {
     }
 

--- a/tests/Unit/Registry/ConfigurableRegistryTest.php
+++ b/tests/Unit/Registry/ConfigurableRegistryTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ConfigurableRegistryTest extends RegistryTest
 {
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests/Unit/Registry/RegistryTest.php
+++ b/tests/Unit/Registry/RegistryTest.php
@@ -24,7 +24,7 @@ class RegistryTest extends TestCase
     protected $service1;
     protected $service2;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->container = $this->prophesize(Container::class);
         $this->service1 = $this->prophesize(RegistrableInterface::class);

--- a/tests/Unit/Report/Generator/CompositeGeneratorTest.php
+++ b/tests/Unit/Report/Generator/CompositeGeneratorTest.php
@@ -25,7 +25,7 @@ class CompositeGeneratorTest extends TestCase
     private $generator;
     private $manager;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->manager = $this->prophesize(ReportManager::class);
         $this->collection = $this->prophesize(SuiteCollection::class);

--- a/tests/Unit/Report/Generator/EnvGeneratorTest.php
+++ b/tests/Unit/Report/Generator/EnvGeneratorTest.php
@@ -24,7 +24,7 @@ class EnvGeneratorTest extends GeneratorTestCase
      */
     private $generator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->generator = new EnvGenerator();
     }

--- a/tests/Unit/Report/Generator/TableGeneratorTest.php
+++ b/tests/Unit/Report/Generator/TableGeneratorTest.php
@@ -25,7 +25,7 @@ class TableGeneratorTest extends GeneratorTestCase
      */
     private $generator;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->generator = new TableGenerator();
     }

--- a/tests/Unit/Report/Renderer/ConsoleRendererTest.php
+++ b/tests/Unit/Report/Renderer/ConsoleRendererTest.php
@@ -22,7 +22,7 @@ class ConsoleRendererTest extends AbstractRendererCase
     private $output;
     private $formatter;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->output = new BufferedOutput();
         $this->formatter = $this->prophesize(Formatter::class);

--- a/tests/Unit/Report/Renderer/XsltRendererTest.php
+++ b/tests/Unit/Report/Renderer/XsltRendererTest.php
@@ -25,7 +25,7 @@ class XsltRendererTest extends AbstractRendererCase
     private $tokenReport;
     private $formatter;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->formatter = $this->prophesize(Formatter::class);
         $this->output = new BufferedOutput();
@@ -37,7 +37,7 @@ class XsltRendererTest extends AbstractRendererCase
         $this->clean();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->clean();
     }

--- a/tests/Unit/Report/ReportManagerTest.php
+++ b/tests/Unit/Report/ReportManagerTest.php
@@ -30,7 +30,7 @@ class ReportManagerTest extends TestCase
     private $suiteCollection;
     private $output;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->rendererRegistry = $this->prophesize(ConfigurableRegistry::class);
         $this->generatorRegistry = $this->prophesize(ConfigurableRegistry::class);

--- a/tests/Unit/Serializer/XmlEncoderTest.php
+++ b/tests/Unit/Serializer/XmlEncoderTest.php
@@ -24,7 +24,7 @@ use PhpBench\Serializer\XmlEncoder;
 
 class XmlEncoderTest extends XmlTestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->suiteCollection = $this->prophesize(SuiteCollection::class);
         $this->suite = $this->prophesize(Suite::class);

--- a/tests/Unit/Serializer/XmlTestCase.php
+++ b/tests/Unit/Serializer/XmlTestCase.php
@@ -36,7 +36,7 @@ use PhpBench\Registry\Config;
 
 class XmlTestCase extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->suiteCollection = $this->prophesize(SuiteCollection::class);
         $this->suite = $this->prophesize(Suite::class);

--- a/tests/Unit/Storage/Archiver/XmlArchiverTest.php
+++ b/tests/Unit/Storage/Archiver/XmlArchiverTest.php
@@ -34,7 +34,7 @@ class XmlArchiverTest extends TestCase
     private $filesystem;
     private $archivePath;
 
-    public function setUp()
+    protected function setUp()
     {
         Workspace::initWorkspace();
 
@@ -70,7 +70,7 @@ class XmlArchiverTest extends TestCase
         $this->registry->getService()->willReturn($this->storage->reveal());
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         Workspace::cleanWorkspace();
     }

--- a/tests/Unit/Storage/Driver/Xml/HistoryIteratorTest.php
+++ b/tests/Unit/Storage/Driver/Xml/HistoryIteratorTest.php
@@ -30,7 +30,7 @@ class HistoryIteratorTest extends TestCase
     private $iterator;
     private $filesystem;
 
-    public function setUp()
+    protected function setUp()
     {
         Workspace::initWorkspace();
 

--- a/tests/Unit/Storage/Driver/Xml/XmlDriverTest.php
+++ b/tests/Unit/Storage/Driver/Xml/XmlDriverTest.php
@@ -36,7 +36,7 @@ class XmlDriverTest extends TestCase
      */
     private $document;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->xmlEncoder = $this->prophesize(XmlEncoder::class);
         $this->xmlDecoder = $this->prophesize(XmlDecoder::class);

--- a/tests/Unit/Storage/UuidResolver/ChainResolverTest.php
+++ b/tests/Unit/Storage/UuidResolver/ChainResolverTest.php
@@ -26,7 +26,7 @@ class ChainResolverTest extends TestCase
      */
     private $resolver;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->resolver = $this->prophesize(UuidResolverInterface::class);
     }

--- a/tests/Unit/Storage/UuidResolver/LatestResolverTest.php
+++ b/tests/Unit/Storage/UuidResolver/LatestResolverTest.php
@@ -28,7 +28,7 @@ class LatestResolverTest extends TestCase
     private $historyEntry;
     private $historyEntry1;
 
-    public function setUp()
+    protected function setUp()
     {
         $registry = $this->prophesize(Registry::class);
         $this->storage = $this->prophesize(DriverInterface::class);

--- a/tests/Unit/Storage/UuidResolver/TagResolverTest.php
+++ b/tests/Unit/Storage/UuidResolver/TagResolverTest.php
@@ -47,7 +47,7 @@ class TagResolverTest extends TestCase
      */
     private $resolver;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->storage = $this->prophesize(DriverInterface::class);
         $this->history = $this->prophesize(HistoryIteratorInterface::class);


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_set_up_tear_down_visibility` fixer
* [x] runs `php-cs-fixer`

❗️ Possibly blocked by #571.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.13.1#usage:

>**php_unit_set_up_tear_down_visibility**
>
>Changes the visibility of the `setUp()` and `tearDown()` functions of PHPUnit to `protected`, to match the PHPUnit TestCase.
>
>*Risky rule: this fixer may change functions named ``setUp()`` or ``tearDown()`` outside of PHPUnit tests, when a class is wrongly seen as a PHPUnit test.*