### PR TITLE
Fix: Remove apparently unused configuration for StyleCI

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,7 +1,0 @@
-enabled:
-
-disabled:
-  - align_double_arrow
-  - concat_without_spaces
-  - phpdoc_indent
-  - phpdoc_params


### PR DESCRIPTION
This PR

* [x] removes an apparently unused configuration for StyleCI

Follows #537.