### PR TITLE
Enhancement: Enable phpdoc_separation fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -18,6 +18,7 @@ return PhpCsFixer\Config::create()
         'php_unit_set_up_tear_down_visibility' => true,
         'phpdoc_align' => [],
         'phpdoc_indent' => false,
+        'phpdoc_separation' => true,
     ])
     ->setFinder($finder)
     ;


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_separation` fixer

💁‍♂️ For reference, see https://github.com/friendsofphp/php-cs-fixer/tree/v2.13.1#usage:

>**phpdoc_separation** [`@Symfony`]
>
>Annotations in PHPDoc should be grouped together so that annotations of the same type immediately follow each other, and annotations of a different type are separated by a single blank line.

❗️ This code style is basically in use already, but enabling the fixer ensures that it stays that way.