### PR TITLE
Enhancement: Explicitly test against lowest and highest versions of dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,8 @@ jobs:
 
       php: 7.1
 
+      env: WITH_LOWEST=true
+
       before_install:
         - source .travis/xdebug.sh
         - xdebug-disable
@@ -55,8 +57,8 @@ jobs:
 
       install:
         - if [[ "$TRAVIS_PHP_VERSION" == "7.3" ]]; then composer remove --dev friendsofphp/php-cs-fixer; fi
-        - if [ -n "${SYMFONY_VERSION}" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --no-update; fi;
-        - composer update ${COMPOSER_FLAGS} --prefer-dist
+        - if [[ "$WITH_LOWEST" == "true" ]]; then composer update --prefer-lowest; fi
+        - if [[ "$WITH_HIGHEST" == "true" ]]; then composer update; fi
 
       before_script:
         - export TZ=Europe/Paris
@@ -70,21 +72,19 @@ jobs:
 
       php: 7.1
 
-      env: COMPOSER_FLAGS="--prefer-lowest"
-
-    - <<: *TEST
-
-      php: 7.1
-
-      env: SYMFONY_VERSION=^3.2
+      env: WITH_HIGHEST=true
 
     - <<: *TEST
 
       php: 7.2
 
+      env: WITH_HIGHEST=true
+
     - <<: *TEST
 
       php: 7.3
+
+      env: WITH_HIGHEST=true
 
     - stage: Deploy
 


### PR DESCRIPTION
This PR

* [x] checks in `composer.lock` and runs tests against lowest, locked, and highest versions of dependencies

### Before

See https://travis-ci.org/phpbench/phpbench/builds/472739856:

![screen shot 2018-12-28 at 00 45 47](https://user-images.githubusercontent.com/605483/50497641-f157fd80-0a39-11e9-899f-5257e2011568.png)

### After

See https://travis-ci.org/phpbench/phpbench/builds/473001742:

![screen shot 2018-12-29 at 12 53 03](https://user-images.githubusercontent.com/605483/50538013-b4d6ef80-0b68-11e9-81a2-32f7d02613de.png)
