### PR TITLE
Fix: Extension is called Xdebug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "suggest": {
         "ext-curl": "For (web) reports extension",
-        "ext-xdebug": "For XDebug profiling extension."
+        "ext-xdebug": "For Xdebug profiling extension."
     },
     "config": {
         "sort-packages": true

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -232,8 +232,8 @@ The above will allow you to have benchmark class such as:
 Disable the PHP INI file
 ------------------------
 
-PHP extensions, especially XDebug, can drastically affect the performance of
-your benchmark subjects. You can disable XDebug and other dynamically loaded
+PHP extensions, especially Xdebug, can drastically affect the performance of
+your benchmark subjects. You can disable Xdebug and other dynamically loaded
 extensions by setting ``php_disable_ini`` to ``true``.
 
 .. note:

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -20,7 +20,7 @@ Why PHPBench?
 -------------
 
 Performance can be monitored and measured in a number of ways: profiling (via.
-`XDebug`_ or `Blackfire`_), injecting timing classes (e.g. `Symfony Stopwatch`_, `Hoa
+`Xdebug`_ or `Blackfire`_), injecting timing classes (e.g. `Symfony Stopwatch`_, `Hoa
 Bench`_) or with server tools such as `NewRelic`_.
 
 PHPBench differs from these tools in that it allows you to benchmark explicit
@@ -37,7 +37,7 @@ Are There Other Benchmarking Frameworks?
 You can try `Athletic`_ .
 
 .. _Symfony Stopwatch: http://symfony.com/doc/current/components/stopwatch.html
-.. _XDebug: http://xdebug.org
+.. _Xdebug: http://xdebug.org
 .. _Blackfire: https://blackfire.io/
 .. _NewRelic: http://newrelic.com
 .. _Athletic: https://github.com/polyfractal/athletic

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -75,7 +75,7 @@ Create the file ``phpbench.json`` in the projects root directory:
 
 .. warning::
 
-    Some PHP extensions such as XDebug will affect the performance of your
+    Some PHP extensions such as Xdebug will affect the performance of your
     benchmark subjects and you may want to disable them, see :ref:`Disabling
     the PHP INI file <configuration_disable_php_ini>`.
 
@@ -102,7 +102,7 @@ consumes *time itself*:
 
 In order to benchmark your code you will need to execute that code within
 a method of a benchmarking class. Benchmarking classes MUST have the ``Bench``
-suffix and each benchmarking method must be prefixed with ``bench``. 
+suffix and each benchmarking method must be prefixed with ``bench``.
 
 Create the following class in the ``benchmarks`` directory:
 
@@ -149,7 +149,7 @@ And you should see some output similar to the following:
 
 You may have guessed that the code was only executed once (as indicated by the
 ``revs`` column). To achieve a better measurement we should increase the
-number of times that the code is consecutively executed.  
+number of times that the code is consecutively executed.
 
 .. code-block:: php
 

--- a/extensions/xdebug/lib/Command/ProfileCommand.php
+++ b/extensions/xdebug/lib/Command/ProfileCommand.php
@@ -46,7 +46,7 @@ class ProfileCommand extends Command
     {
         $this->setName('xdebug:profile');
         $this->setDescription(<<<'EOT'
-Generate and optionally visualize profiles with XDebug
+Generate and optionally visualize profiles with Xdebug
 EOT
         );
         RunnerHandler::configure($this);
@@ -100,7 +100,7 @@ EOT
         foreach ($generatedFiles as $generatedFile) {
             if (!file_exists($generatedFile)) {
                 throw new \InvalidArgumentException(sprintf(
-                    'Profile "%s" was not generated. Maybe you do not have XDebug installed?',
+                    'Profile "%s" was not generated. Maybe you do not have Xdebug installed?',
                     $generatedFile
                 ));
             }

--- a/extensions/xdebug/lib/Command/TraceCommand.php
+++ b/extensions/xdebug/lib/Command/TraceCommand.php
@@ -47,7 +47,7 @@ class TraceCommand extends Command
     {
         $this->setName('xdebug:trace');
         $this->setDescription(<<<'EOT'
-Generate and optionally visualize traces with XDebug
+Generate and optionally visualize traces with Xdebug
 EOT
         );
         RunnerHandler::configure($this);

--- a/extensions/xdebug/lib/Executor/TraceExecutor.php
+++ b/extensions/xdebug/lib/Executor/TraceExecutor.php
@@ -75,7 +75,7 @@ class TraceExecutor extends BaseExecutor
 
         $path = $dir . DIRECTORY_SEPARATOR . $name . '.xt';
 
-        // if the file exists, remove it. XDebug might not be installed
+        // if the file exists, remove it. Xdebug might not be installed
         // on the PHP binary and the file may not be generated. We should
         // fail in such a case and not use the file from a previous run.
         if ($this->filesystem->exists($path)) {

--- a/extensions/xdebug/lib/Executor/XDebugTraceExecutor.php
+++ b/extensions/xdebug/lib/Executor/XDebugTraceExecutor.php
@@ -76,7 +76,7 @@ class XDebugTraceExecutor extends BaseExecutor
 
         if (false === $this->filesystem->exists($path)) {
             throw new \RuntimeException(sprintf(
-                'Trace file at "%s" was not generated. Is XDebug enabled in the benchmarking environment',
+                'Trace file at "%s" was not generated. Is Xdebug enabled in the benchmarking environment',
                 $path
             ));
         }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,7 @@
         <testsuite name="PhpBench">
             <directory>./tests</directory>
         </testsuite>
-        <testsuite name="PhpBench XDebug Extension">
+        <testsuite name="PhpBench Xdebug Extension">
             <directory>./extensions/xdebug/tests</directory>
         </testsuite>
         <testsuite name="PhpBench DBAL Extension">


### PR DESCRIPTION
This PR

* [x] fixes occurrences of **XDebug** to **Xdebug** where possible

💁‍♂️ I have naturally used the former myself, but @derickr uses the latter on https://xdebug.org:

![screen shot 2018-12-27 at 19 38 45](https://user-images.githubusercontent.com/605483/50490767-3450ab80-0a0f-11e9-9a5e-4e619710d819.png)
