### PR TITLE
Enhancement: Enable ordered_imports fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -41,6 +41,7 @@ return PhpCsFixer\Config::create()
         'concat_space' => false,
         'method_argument_space' => false,
         'no_unused_imports' => true,
+        'ordered_imports' => true,
         'php_unit_set_up_tear_down_visibility' => true,
         'phpdoc_align' => [],
         'phpdoc_indent' => false,

--- a/tests/Unit/Benchmark/Metadata/Driver/AnnotationDriverTest.php
+++ b/tests/Unit/Benchmark/Metadata/Driver/AnnotationDriverTest.php
@@ -13,8 +13,8 @@
 namespace PhpBench\Tests\Unit\Benchmark\Metadata\Driver;
 
 use PhpBench\Benchmark\Metadata\Annotations;
-use PhpBench\Benchmark\Metadata\DriverInterface;
 use PhpBench\Benchmark\Metadata\Driver\AnnotationDriver;
+use PhpBench\Benchmark\Metadata\DriverInterface;
 use PhpBench\Benchmark\Metadata\ExecutorMetadata;
 use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Benchmark\Remote\ReflectionClass;

--- a/tests/Unit/Model/BenchmarkTest.php
+++ b/tests/Unit/Model/BenchmarkTest.php
@@ -16,8 +16,8 @@ use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Model\Benchmark;
 use PhpBench\Model\ResolvedExecutor;
 use PhpBench\Model\Suite;
-use PHPUnit\Framework\TestCase;
 use PhpBench\Registry\Config;
+use PHPUnit\Framework\TestCase;
 
 class BenchmarkTest extends TestCase
 {

--- a/tests/Unit/Serializer/XmlTestCase.php
+++ b/tests/Unit/Serializer/XmlTestCase.php
@@ -31,8 +31,8 @@ use PhpBench\Model\Subject;
 use PhpBench\Model\Suite;
 use PhpBench\Model\SuiteCollection;
 use PhpBench\Model\Variant;
-use PHPUnit\Framework\TestCase;
 use PhpBench\Registry\Config;
+use PHPUnit\Framework\TestCase;
 
 class XmlTestCase extends TestCase
 {


### PR DESCRIPTION
This PR

* [x] enables the `ordered_imports` fixer
* [x] runs `php-cs-fixer`

Follows #572.

💁‍♂️ For reference, see https://github.com/friendsofphp/php-cs-fixer/tree/v2.13.1#usage:

>**ordered_imports**
>
>Ordering use statements.
>
>Configuration options:
>
>* `imports_order` (`array`, `null`): defines the order of import types; defaults to `null`; DEPRECATED alias: `importsOrder`
>* `sort_algorithm` (`'alpha'`, `'length'`, `'none'`): whether the statements should be sorted alphabetically or by length, or not sorted; defaults to `'alpha'`; DEPRECATED alias: `sortAlgorithm`