### PR TITLE
Enhancement: Enable no_unused_imports fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -40,6 +40,7 @@ return PhpCsFixer\Config::create()
         ],
         'concat_space' => false,
         'method_argument_space' => false,
+        'no_unused_imports' => true,
         'php_unit_set_up_tear_down_visibility' => true,
         'phpdoc_align' => [],
         'phpdoc_indent' => false,

--- a/extensions/dbal/lib/Storage/Driver/Dbal/Persister.php
+++ b/extensions/dbal/lib/Storage/Driver/Dbal/Persister.php
@@ -13,7 +13,6 @@
 namespace PhpBench\Extensions\Dbal\Storage\Driver\Dbal;
 
 use Doctrine\DBAL\Connection;
-use PhpBench\Model\Iteration;
 use PhpBench\Model\Result\MemoryResult;
 use PhpBench\Model\Result\RejectionCountResult;
 use PhpBench\Model\Result\TimeResult;

--- a/extensions/xdebug/lib/Command/ProfileCommand.php
+++ b/extensions/xdebug/lib/Command/ProfileCommand.php
@@ -13,7 +13,6 @@
 namespace PhpBench\Extensions\XDebug\Command;
 
 use PhpBench\Benchmark\RunnerConfig;
-use PhpBench\Console\Command\Configure\Executor;
 use PhpBench\Console\Command\Handler\RunnerHandler;
 use PhpBench\Extensions\XDebug\Command\Handler\OutputDirHandler;
 use PhpBench\Extensions\XDebug\XDebugUtil;

--- a/extensions/xdebug/lib/Command/TraceCommand.php
+++ b/extensions/xdebug/lib/Command/TraceCommand.php
@@ -13,7 +13,6 @@
 namespace PhpBench\Extensions\XDebug\Command;
 
 use PhpBench\Benchmark\RunnerConfig;
-use PhpBench\Console\Command\Configure\Executor;
 use PhpBench\Console\Command\Handler\RunnerHandler;
 use PhpBench\Extensions\XDebug\Command\Handler\OutputDirHandler;
 use PhpBench\Extensions\XDebug\Renderer\TraceRenderer;

--- a/lib/Benchmark/Metadata/BenchmarkMetadata.php
+++ b/lib/Benchmark/Metadata/BenchmarkMetadata.php
@@ -12,8 +12,6 @@
 
 namespace PhpBench\Benchmark\Metadata;
 
-use PhpBench\Benchmark\Metadata\ExecutorMetadata;
-
 /**
  * Benchmark metadata class.
  */

--- a/lib/Benchmark/Metadata/SubjectMetadata.php
+++ b/lib/Benchmark/Metadata/SubjectMetadata.php
@@ -12,8 +12,6 @@
 
 namespace PhpBench\Benchmark\Metadata;
 
-use PhpBench\Benchmark\Metadata\ExecutorMetadata;
-
 /**
  * Metadata for benchmarkMetadata subjects.
  */

--- a/lib/Model/Benchmark.php
+++ b/lib/Model/Benchmark.php
@@ -13,8 +13,6 @@
 namespace PhpBench\Model;
 
 use PhpBench\Benchmark\Metadata\SubjectMetadata;
-use PhpBench\Registry\Config;
-use PhpBench\Model\ResolvedExecutor;
 
 /**
  * Benchmark metadata class.

--- a/lib/Model/Subject.php
+++ b/lib/Model/Subject.php
@@ -13,9 +13,7 @@
 namespace PhpBench\Model;
 
 use PhpBench\Benchmark\Metadata\BenchmarkMetadata;
-use PhpBench\Model\Variant;
 use PhpBench\Util\TimeUnit;
-use PhpBench\Model\ResolvedExecutor;
 
 /**
  * Subject representation.

--- a/lib/Progress/Logger/AnsiLogger.php
+++ b/lib/Progress/Logger/AnsiLogger.php
@@ -12,7 +12,6 @@
 
 namespace PhpBench\Progress\Logger;
 
-use PhpBench\Model\Iteration;
 use PhpBench\Model\Variant;
 
 abstract class AnsiLogger extends PhpBenchLogger

--- a/lib/Serializer/XmlEncoder.php
+++ b/lib/Serializer/XmlEncoder.php
@@ -12,7 +12,6 @@
 
 namespace PhpBench\Serializer;
 
-use DOMElement;
 use PhpBench\Dom\Document;
 use PhpBench\Dom\Element;
 use PhpBench\Model\Benchmark;

--- a/tests/Unit/Storage/Driver/Xml/HistoryIteratorTest.php
+++ b/tests/Unit/Storage/Driver/Xml/HistoryIteratorTest.php
@@ -13,7 +13,6 @@
 namespace PhpBench\Tests\Unit\Storage\Driver\Xml;
 
 use PhpBench\Dom\Document;
-use PhpBench\Environment\Information;
 use PhpBench\Model\Suite;
 use PhpBench\Model\SuiteCollection;
 use PhpBench\Model\Summary;


### PR DESCRIPTION
This PR

* [x] enables the `no_unused_imports` fixer
* [x] runs `php-cs-fixer`

Follows #572.

💁‍♂️ For reference, see https://github.com/friendsofphp/php-cs-fixer/tree/v2.13.1#usage:

>**no_unused_imports** [`@Symfony`]
>
>Unused use statements must be removed.