### PR TITLE
Clean Garbage Collection after each Revolution

### DIFF
--- a/lib/Benchmark/Executor/template/microtime.template
+++ b/lib/Benchmark/Executor/template/microtime.template
@@ -1,8 +1,5 @@
 <?php
 
-// disable garbage collection
-cleanGarbageCollectionAndDisable();
-
 // repress any output from the user scripts
 ob_start();
 
@@ -34,6 +31,9 @@ if ($warmup) {
         $benchmark->{{ subject }}($parameters);
     }
 }
+
+// disable garbage collection
+cleanGarbageCollectionAndDisable();
 
 $time = benchmark($benchmark, $parameters);
 

--- a/lib/Benchmark/Executor/template/microtime.template
+++ b/lib/Benchmark/Executor/template/microtime.template
@@ -1,7 +1,7 @@
 <?php
 
 // disable garbage collection
-gc_disable();
+cleanGarbageCollectionAndDisable();
 
 // repress any output from the user scripts
 ob_start();
@@ -56,30 +56,47 @@ echo serialize([
     'buffer' => $buffer,
 ]);
 
-function benchmark($benchmark, $parameters)
+function benchmark($benchmark, $parameters) : float
 {
+    $time = 0.00;
+
     // run the benchmarks: note that passing arguments to the method slightly increases
     // the calltime, so we explicitly do one thing or the other depending on if parameters
     // are provided.
     if ($parameters) {
-        $startTime = microtime(true);
-
         for ($i = 0; $i < {{ revolutions }}; $i++) {
+            $startTime = microtime(true);
+            
             $benchmark->{{ subject }}($parameters);
-        }
 
-        $endTime = microtime(true);
+            $endTime =  microtime(true);
+
+            $time += ($endTime * 1000000) - ($startTime * 1000000);
+
+            cleanGarbageCollectionAndDisable();
+        }
     } else {
-        $startTime = microtime(true);
-
         for ($i = 0; $i < {{ revolutions }}; $i++) {
-            $benchmark->{{ subject }}();
-        }
+            $startTime = microtime(true);
 
-        $endTime = microtime(true);
+            $benchmark->{{ subject }}();
+
+            $endTime =  microtime(true);
+
+            $time += ($endTime * 1000000) - ($startTime * 1000000);
+
+            cleanGarbageCollectionAndDisable();
+        }
     }
 
-    return ($endTime * 1000000) - ($startTime * 1000000);
+    return $time;
+}
+
+function cleanGarbageCollectionAndDisable () : void
+{
+    gc_enable();
+    gc_collect_cycles();
+    gc_disable();
 }
 
 exit(0);


### PR DESCRIPTION
Memory maintenance is disabled between each Revolution. For obvious reasons of predictability of performance. 
If it is justified for the execution time. But it leads to an uncontrolled memory leak giving a false idea of it in reports, and a risk of exceeding the memory limit.

This correction forces a manual cleaning between each Revolution, in a way that does not impact the time measurement. The time measurement itself is placed a little more precisely in the code.

**Before Fix:**
_Memory increases in proportion to the number of Revolutions to infinity._

* 6 Revolutions :
![image](https://user-images.githubusercontent.com/4020317/53350059-a6b20f00-391e-11e9-8b8a-e59f2a8fc71c.png)

* 12 Revolutions:
![image](https://user-images.githubusercontent.com/4020317/53350166-dd882500-391e-11e9-840f-4d18c64d0b86.png)


**After fix (look memory):**

![image](https://user-images.githubusercontent.com/4020317/53349738-0c51cb80-391e-11e9-99ea-8ef28781ffda.png)
