### PR TITLE
Baseline.php : Fix PHP 7.4 notice on fgets()

### DIFF
--- a/lib/Benchmark/Baseline/Baselines.php
+++ b/lib/Benchmark/Baseline/Baselines.php
@@ -54,7 +54,7 @@ class Baselines
 
         fclose($handle);
 
-        $handle = fopen($tempName, 'w');
+        $handle = fopen($tempName, 'r');
 
         $line = true;
 


### PR DESCRIPTION
Fix new PHP 7.4 notice on Baseline.php leading to the crash.

![image](https://user-images.githubusercontent.com/4020317/64064004-a14ebd80-cbfc-11e9-938b-f80456ce8d24.png)

https://bugs.php.net/bug.php?id=78482


