### PR TITLE
Silencing unserialize notice to benefit from full error message

### DIFF
--- a/lib/Benchmark/Remote/Payload.php
+++ b/lib/Benchmark/Remote/Payload.php
@@ -198,7 +198,7 @@ class Payload
     private function decodeResults(): array
     {
         $output = $this->process->getOutput();
-        $result = unserialize($output);
+        $result = @unserialize($output);
 
         if (is_array($result)) {
             return $result;


### PR DESCRIPTION
While running PHPBench, I ran into this error:

```
PhpBench @git_tag@. Running benchmarks.
Using configuration file: /home/travis/build/thecodingmachine/tdbm/phpbench.json

In Payload.php line 201:
                                                        
  Notice: unserialize(): Error at offset 0 of 776 bytes  
```

The unserialize notice is causing phpbench to halt (because of the error handler that treats notices as fatal errors).

The message is quite unhelpful. What I wanted was this nice exception to be triggered:

https://github.com/moufmouf/phpbench/blob/d58804dcb85759d6babf8e8208a2b71fa017f9af/lib/Benchmark/Remote/Payload.php#L207-L211

So I simply silenced the unserialize warnings. That way, when an error occurs, it is correctly caught by the code and a nice exception is thrown. I can now see the issues in my code more clearly:

```
PhpBench @git_tag@. Running benchmarks.
Using configuration file: /home/travis/build/thecodingmachine/tdbm/phpbench.json

In Payload.php line 207:
                                                                               

  Script "/home/travis/build/thecodingmachine/tdbm/vendor/phpbench/phpbench/l  
  ib/Executor/Method/template/execute_static_methods.template" did not return  
   an array, got:                                                              
  Deprecated: Non-static method TheCodingMachine\TDBM\Performance\ManyToOneBe  
  nch::getConnection() should not be called statically in /home/travis/build/  
  thecodingmachine/tdbm/tests/Performance/ManyToOneBench.php on line 152
```

... which is way way more useful :)

By the way, thanks a lot for PHPBench. It's the first time I'm giving it a shot and it is delightful to use :)