### PR TITLE
Allow Symfony ^5.0 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
         "phpbench/container": "~1.2",
         "phpbench/dom": "~0.2.0",
         "seld/jsonlint": "^1.1",
-        "symfony/console": "^3.2 || ^4.0",
-        "symfony/debug": "^2.4 || ^3.0 || ^4.0",
-        "symfony/filesystem": "^2.4 || ^3.0 || ^4.0",
-        "symfony/finder": "^2.4 || ^3.0 || ^4.0",
-        "symfony/options-resolver": "^2.6 || ^3.0 || ^4.0",
-        "symfony/process": "^2.1 || ^3.0 || ^4.0",
+        "symfony/console": "^3.2 || ^4.0 || ^5.0",
+        "symfony/debug": "^2.4 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/filesystem": "^2.4 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/finder": "^2.4 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/options-resolver": "^2.6 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/process": "^2.1 || ^3.0 || ^4.0 || ^5.0",
         "webmozart/path-util": "^2.3"
     },
     "require-dev": {


### PR DESCRIPTION
Will release in november 2019. Currently in RC1 stage.