### PR TITLE
Revert "Symfony 5"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
         "phpbench/container": "~1.2",
         "phpbench/dom": "~0.2.0",
         "seld/jsonlint": "^1.1",
-        "symfony/console": "^3.2 || ^4.0 || ^5.0",
-        "symfony/debug": "^2.4 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/filesystem": "^2.4 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/finder": "^2.4 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/options-resolver": "^2.6 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/process": "^2.1 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/console": "^3.2 || ^4.0",
+        "symfony/debug": "^2.4 || ^3.0 || ^4.0",
+        "symfony/filesystem": "^2.4 || ^3.0 || ^4.0",
+        "symfony/finder": "^2.4 || ^3.0 || ^4.0",
+        "symfony/options-resolver": "^2.6 || ^3.0 || ^4.0",
+        "symfony/process": "^2.1 || ^3.0 || ^4.0",
         "webmozart/path-util": "^2.3"
     },
     "require-dev": {

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -31,6 +31,7 @@ use PhpBench\Model\Result\RejectionCountResult;
 use PhpBench\Model\Subject;
 use PhpBench\Model\Suite;
 use PhpBench\Model\Variant;
+use PhpBench\PhpBench;
 use PhpBench\Progress\Logger\NullLogger;
 use PhpBench\Progress\LoggerInterface;
 use PhpBench\Registry\Config;

--- a/lib/Console/Command/RunCommand.php
+++ b/lib/Console/Command/RunCommand.php
@@ -18,6 +18,7 @@ use PhpBench\Console\Command\Handler\ReportHandler;
 use PhpBench\Console\Command\Handler\RunnerHandler;
 use PhpBench\Console\Command\Handler\TimeUnitHandler;
 use PhpBench\Model\SuiteCollection;
+use PhpBench\PhpBench;
 use PhpBench\Registry\Registry;
 use PhpBench\Storage\DriverInterface;
 use RuntimeException;

--- a/tests/Unit/Benchmark/RunnerTest.php
+++ b/tests/Unit/Benchmark/RunnerTest.php
@@ -28,6 +28,7 @@ use PhpBench\Model\Iteration;
 use PhpBench\Model\Result\MemoryResult;
 use PhpBench\Model\Result\TimeResult;
 use PhpBench\Model\Suite;
+use PhpBench\PhpBench;
 use PhpBench\Registry\Config;
 use PhpBench\Registry\ConfigurableRegistry;
 use PhpBench\Tests\Util\TestUtil;


### PR DESCRIPTION
@julien-boudry reverting this for now as there are breaking BC breaks (e.g. process requires array not string). I assumed wrongly that the CI would test v5, but as it's still RC it wasn't picked up (and php-cs-fixer requires 4x)