### PR TITLE
Symfony 5 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
         "phpbench/container": "~1.2",
         "phpbench/dom": "~0.2.0",
         "seld/jsonlint": "^1.1",
-        "symfony/console": "^3.2 || ^4.0",
-        "symfony/debug": "^2.4 || ^3.0 || ^4.0",
-        "symfony/filesystem": "^2.4 || ^3.0 || ^4.0",
-        "symfony/finder": "^2.4 || ^3.0 || ^4.0",
-        "symfony/options-resolver": "^2.6 || ^3.0 || ^4.0",
-        "symfony/process": "^2.1 || ^3.0 || ^4.0",
+        "symfony/console": "^3.2 || ^4.0 || ^5.0",
+        "symfony/debug": "^2.4 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/filesystem": "^2.4 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/finder": "^2.4 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/options-resolver": "^2.6 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/process": "^2.1 || ^3.0 || ^4.0 || ^5.0",
         "webmozart/path-util": "^2.3"
     },
     "require-dev": {


### PR DESCRIPTION
There are BC breaks in Symfony 5 which will need to be addressed (e.g. process requires an array argument not a string argument).

cc @julien-boudry 