### PR TITLE
reduced time/mem centric executor overhead

### DIFF
--- a/lib/Executor/Benchmark/TemplateExecutor.php
+++ b/lib/Executor/Benchmark/TemplateExecutor.php
@@ -45,6 +45,8 @@ class TemplateExecutor implements BenchmarkExecutorInterface
 
     public function execute(SubjectMetadata $subjectMetadata, Iteration $iteration, Config $config): void
     {
+        $parameterSet = $iteration->getVariant()->getParameterSet();
+
         $tokens = [
             'class' => $subjectMetadata->getBenchmark()->getClass(),
             'file' => $subjectMetadata->getBenchmark()->getPath(),
@@ -52,7 +54,7 @@ class TemplateExecutor implements BenchmarkExecutorInterface
             'revolutions' => $iteration->getVariant()->getRevolutions(),
             'beforeMethods' => var_export($subjectMetadata->getBeforeMethods(), true),
             'afterMethods' => var_export($subjectMetadata->getAfterMethods(), true),
-            'parameters' => var_export($iteration->getVariant()->getParameterSet()->getArrayCopy(), true),
+            'parameters' => $parameterSet->count() ? var_export($parameterSet->getArrayCopy(), true) : '',
             'warmup' => $iteration->getVariant()->getWarmup() ?: 0,
         ];
 

--- a/lib/Executor/Benchmark/template/memory.template
+++ b/lib/Executor/Benchmark/template/memory.template
@@ -8,7 +8,6 @@ $file = '{{ file }}';
 $beforeMethods = {{ beforeMethods }};
 $afterMethods = {{ afterMethods }};
 $bootstrap = '{{ bootstrap }}';
-$parameters = {{ parameters }};
 $warmup = {{ warmup }};
 
 if ($bootstrap) {
@@ -21,24 +20,38 @@ require_once($file);
 
 $benchmark = new $class();
 
+// run before methods
 foreach ($beforeMethods as $beforeMethod) {
-    $benchmark->$beforeMethod($parameters);
+    $benchmark->$beforeMethod({{ parameters }});
 }
 
-// warmup if required
+// run warmup if required
 if ($warmup) {
     for ($i = 0; $i < $warmup; $i++) {
-        $benchmark->{{ subject }}($parameters);
+        $benchmark->{{ subject }}({{ parameters }});
     }
 }
 
 // disable garbage collection
 cleanGarbageCollectionAndDisable();
 
-$time = benchmark($benchmark, $parameters);
+// run benchmark
+$time = 0.00;
+for ($i = 0; $i < {{ revolutions }}; $i++) {
+    $startTime = microtime(true);
 
+    $benchmark->{{ subject }}({{ parameters }});
+
+    $endTime = microtime(true);
+
+    $time += ($endTime - $startTime) * 1000000;
+
+    cleanGarbageCollectionAndDisable();
+}
+
+// run after methods
 foreach ($afterMethods as $afterMethod) {
-    $benchmark->$afterMethod($parameters);
+    $benchmark->$afterMethod({{ parameters }});
 }
 
 $buffer = ob_get_contents();
@@ -55,42 +68,6 @@ echo serialize([
     'time' => (int) $time,
     'buffer' => $buffer,
 ]);
-
-function benchmark($benchmark, $parameters) : float
-{
-    $time = 0.00;
-
-    // run the benchmarks: note that passing arguments to the method slightly increases
-    // the calltime, so we explicitly do one thing or the other depending on if parameters
-    // are provided.
-    if ($parameters) {
-        for ($i = 0; $i < {{ revolutions }}; $i++) {
-            $startTime = microtime(true);
-            
-            $benchmark->{{ subject }}($parameters);
-
-            $endTime =  microtime(true);
-
-            $time += ($endTime * 1000000) - ($startTime * 1000000);
-
-            cleanGarbageCollectionAndDisable();
-        }
-    } else {
-        for ($i = 0; $i < {{ revolutions }}; $i++) {
-            $startTime = microtime(true);
-
-            $benchmark->{{ subject }}();
-
-            $endTime =  microtime(true);
-
-            $time += ($endTime * 1000000) - ($startTime * 1000000);
-
-            cleanGarbageCollectionAndDisable();
-        }
-    }
-
-    return $time;
-}
 
 function cleanGarbageCollectionAndDisable () : void
 {

--- a/lib/Executor/Benchmark/template/microtime.template
+++ b/lib/Executor/Benchmark/template/microtime.template
@@ -11,7 +11,6 @@ $file = '{{ file }}';
 $beforeMethods = {{ beforeMethods }};
 $afterMethods = {{ afterMethods }};
 $bootstrap = '{{ bootstrap }}';
-$parameters = {{ parameters }};
 $warmup = {{ warmup }};
 
 if ($bootstrap) {
@@ -24,21 +23,32 @@ require_once($file);
 
 $benchmark = new $class();
 
+// run before methods
 foreach ($beforeMethods as $beforeMethod) {
-    $benchmark->$beforeMethod($parameters);
+    $benchmark->$beforeMethod({{ parameters }});
 }
 
-// warmup if required
+// run warmup if required
 if ($warmup) {
     for ($i = 0; $i < $warmup; $i++) {
-        $benchmark->{{ subject }}($parameters);
+        $benchmark->{{ subject }}({{ parameters }});
     }
 }
 
-$time = benchmark($benchmark, $parameters);
+// run benchmark
+$startTime = microtime(true);
 
+for ($i = 0; $i < {{ revolutions }}; $i++) {
+    $benchmark->{{ subject }}({{ parameters }});
+}
+
+$endTime = microtime(true);
+
+$time = ($endTime - $startTime) * 1000000;
+
+// run after methods
 foreach ($afterMethods as $afterMethod) {
-    $benchmark->$afterMethod($parameters);
+    $benchmark->$afterMethod({{ parameters }});
 }
 
 $buffer = ob_get_contents();
@@ -55,31 +65,5 @@ echo serialize([
     'time' => (int) $time,
     'buffer' => $buffer,
 ]);
-
-function benchmark($benchmark, $parameters)
-{
-    // run the benchmarks: note that passing arguments to the method slightly increases
-    // the calltime, so we explicitly do one thing or the other depending on if parameters
-    // are provided.
-    if ($parameters) {
-        $startTime = microtime(true);
-
-        for ($i = 0; $i < {{ revolutions }}; $i++) {
-            $benchmark->{{ subject }}($parameters);
-        }
-
-        $endTime = microtime(true);
-    } else {
-        $startTime = microtime(true);
-
-        for ($i = 0; $i < {{ revolutions }}; $i++) {
-            $benchmark->{{ subject }}();
-        }
-
-        $endTime = microtime(true);
-    }
-
-    return ($endTime * 1000000) - ($startTime * 1000000);
-}
 
 exit(0);


### PR DESCRIPTION
* parse `parameters` directly into parameter positions -> no variable and parameter condition needed
* removed function `backmark` and instead execute the banchmark in place -> this reduces the function call stack by one


PS: I would like to introduce a condition for hrtime (see #591) to not need to call time function dynamically which would increase time function call overhead.