### PR TITLE
Cast decoded stats to (float) fixes #626

### DIFF
--- a/benchmarks/Macro/ReportBench.php
+++ b/benchmarks/Macro/ReportBench.php
@@ -36,11 +36,10 @@ class ReportBench extends BaseBenchCase
 
     public function benchAggregate()
     {
-        // temporary disabling this to fix the build
-        // $this->runCommand('console.command.report', [
-        //     '--file' => [$this->getWorkspacePath() . '/dump.xml'],
-        //     '--report' => ['aggregate'],
-        // ]);
+        $this->runCommand('console.command.report', [
+            '--file' => [$this->getWorkspacePath() . '/dump.xml'],
+            '--report' => ['aggregate'],
+        ]);
     }
 
     public function benchDefault()

--- a/lib/Report/Generator/TableGenerator.php
+++ b/lib/Report/Generator/TableGenerator.php
@@ -145,7 +145,10 @@ class TableGenerator implements GeneratorInterface, OutputAwareInterface
             $min = min($means);
 
             return F\map($table, function ($row) use ($min, $stat) {
-                if ($row[$stat] === 0 || $min === 0 || $min === 0.0 || $row[$stat] === 0.0) {
+                if (
+                    $row[$stat] === 0 || $row[$stat] === 0.0 ||
+                    $min === 0 || $min === 0.0
+                ) {
                     $row['diff'] = 0;
 
                     return $row;

--- a/lib/Report/Generator/TableGenerator.php
+++ b/lib/Report/Generator/TableGenerator.php
@@ -145,10 +145,7 @@ class TableGenerator implements GeneratorInterface, OutputAwareInterface
             $min = min($means);
 
             return F\map($table, function ($row) use ($min, $stat) {
-                if (
-                    $row[$stat] === 0 || $row[$stat] === 0.0 ||
-                    $min === 0 || $min === 0.0
-                ) {
+                if ($min === 0 || $min === 0.0) {
                     $row['diff'] = 0;
 
                     return $row;

--- a/lib/Serializer/XmlDecoder.php
+++ b/lib/Serializer/XmlDecoder.php
@@ -187,7 +187,7 @@ class XmlDecoder
 
         foreach ($element->query('./stats') as $statsEl) {
             foreach ($statsEl->attributes as $key => $attribute) {
-                $stats[$key] = $attribute->nodeValue;
+                $stats[$key] = (float)$attribute->nodeValue;
             }
         }
 


### PR DESCRIPTION
It seems that computers are getting faster and this is uncovering some of the bad typing in Phpbench.

This should fix the division by zero issue (#626 )