### PR TITLE
Correct testing of whether instance method is callable.

### DIFF
--- a/lib/Benchmark/Remote/template/parameter_set_extractor.template
+++ b/lib/Benchmark/Remote/template/parameter_set_extractor.template
@@ -33,7 +33,7 @@ $parameterSets = array();
 ob_start();
 
 foreach ($paramProviders as $paramProvider) {
-    if (is_callable([$class, $paramProvider])) {
+    if (is_callable([$benchmark, $paramProvider])) {
         $parameterSets[] = normalize_parameter_set($benchmark->$paramProvider());
         continue;
     }


### PR DESCRIPTION
The method is an instance method so needs to be tested against the instance.

Pretty sure this is a tidy up for PHP 8.