### PR TITLE
Show xdebug opcache status in header

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,11 @@
     "require-dev": {
         "doctrine/dbal": "^2.4",
         "friendsofphp/php-cs-fixer": "^2.13.1",
+        "jangregor/phpstan-prophecy": "^0.8.0",
         "padraic/phar-updater": "^1.0",
+        "phpspec/prophecy": "^1.8",
         "phpstan/phpstan": "^0.12.7",
-        "phpunit/phpunit": "^8.5",
-        "phpspec/prophecy": "^1.8"
+        "phpunit/phpunit": "^8.5"
     },
     "scripts": {
         "integrate": [

--- a/docs/book.rst
+++ b/docs/book.rst
@@ -1,10 +1,9 @@
-Book
-====
+Reference
+=========
 
 .. toctree::
    :maxdepth: 2
 
-   writing-benchmarks
    benchmark-runner
    reports
    storage
@@ -14,4 +13,3 @@ Book
    assertions-asserters
    configuration
    faq
-

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,24 +1,21 @@
 FAQ
 ===
 
-Why does PHPBench slow on Windows?
-----------------------------------
+PHPBench is slow on Windows
+---------------------------
 
-Process spawning on Windows is more expensive than on Linux, PHPBench spawns
+Process spawning on Windows is more expensive than on Linux/MacOS, PHPBench spawns
 many processes. Actual benchmarking time however is not affected.
 
-Why does PHPBench look terrible on Windows?
--------------------------------------------
+PHPBench's output looks corrupted on Windows
+--------------------------------------------
 
 PHPBench makes use of ansi escape sequences in most of its progress loggers.
 The default Windows console does not support these sequences, so the output
-can look very bad.
+can look corrupted.
 
 You can mitigate this by using the `travis` logger, which does not issue any
 of these escape sequences.
-
-You may also consider using `Cgywin`, `emuCon` or `ansiCon` programs to
-enhance your console. You may also switch to Linux.
 
 Why do `setUp` and `tearDown` methods not automatically get called?
 ----------------------------------------------------------------------

--- a/docs/guides.rst
+++ b/docs/guides.rst
@@ -6,4 +6,5 @@ Guides
 
    installing
    quick-start
+   writing-benchmarks
    regression-testing

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -4,12 +4,27 @@ Installing
 PHPBench can be installed either as dependency for your project or as a global
 package.
 
+Composer Install
+----------------
+
+To install PHPBench as a dependency of your project:
+
+.. code-block:: php
+
+    $ composer require phpbench/phpbench @dev --dev
+
+
+You may then run PHPBench from your project's directory as follows:
+
+.. code-block:: bash
+
+    $ ./vendor/bin/phpbench
+
 Install as a PHAR package
 -------------------------
 
-Installing as a PHAR is convenient, you will need to download the
-phar_ and the `public key`_, this can be
-done with CURL as follows:
+You can download the phar_ and the `public key`_, this can be done with CURL
+as follows:
 
 .. code-block:: bash
 
@@ -33,47 +48,10 @@ You can update the version at any time by using the ``self-update`` command:
 
 .. warning::
 
-    PHPBench is unstable, installing as a PHAR means that you are always
-    updating to the latest version, the latest version may include BC breaks.
-    Therefore it is recommended to include the package as a project dependency
-    for continuous-integration.
+    Installing as a PHAR means that you are always updating to the latest
+    version, the latest version may include BC breaks.  Therefore it is
+    recommended to include the package as a project dependency for
+    continuous-integration.
 
-Composer Install
-----------------
-
-To install PHPBench as a dependency of your project:
-
-.. code-block:: php
-
-    $ composer require phpbench/phpbench @dev --dev
-
-
-You may then run PHPBench from your project's directory as follows:
-
-.. code-block:: bash
-
-    $ ./vendor/bin/phpbench
-
-Composer Global Install
------------------------
-
-You may install `PHPBench globally`_ using composer:
-
-.. code-block:: php
-
-    $ composer global require phpbench/phpbench @dev
-
-.. note::
-
-    You will need to add Composer's global ``bin`` directory to your systems
-    ``PATH`` variable (on linux). See the above link.
-
-You may now run PHPBench simply as:
-
-.. code-block:: bash
-
-    $ phpbench
-
-.. _PHPBench globally: http://akrabat.com/global-installation-of-php-tools-with-composer/
 .. _phar: https://phpbench.github.io/phpbench/phpbench.phar
 .. _public key: https://phpbench.github.io/phpbench/phpbench.phar.pubkey

--- a/lib/Model/Summary.php
+++ b/lib/Model/Summary.php
@@ -38,6 +38,21 @@ class Summary
     private $errorStacks = [];
 
     /**
+     * @var bool
+     */
+    private $opCacheEnabled = false;
+
+    /**
+     * @var bool
+     */
+    private $xdebugEnabled = false;
+
+    /**
+     * @var string
+     */
+    private $phpVersion = null;
+
+    /**
      * @param Suite $suite
      */
     public function __construct(Suite $suite)
@@ -65,39 +80,50 @@ class Summary
                 }
             }
         }
+
+        $env = $suite->getEnvInformations();
+
+        if (isset($env['opcache'])) {
+            $this->opCacheEnabled = (bool)($env['opcache']['enabled'] ?? false);
+        }
+
+        if (isset($env['php'])) {
+            $this->xdebugEnabled = (bool)($env['php']['xdebug'] ?? false);
+            $this->phpVersion = $env['php']['version'] ?? null;
+        }
     }
 
-    public function getNbSubjects()
+    public function getNbSubjects(): int
     {
         return $this->nbSubjects;
     }
 
-    public function getNbIterations()
+    public function getNbIterations(): int
     {
         return $this->nbIterations;
     }
 
-    public function getNbRejects()
+    public function getNbRejects(): int
     {
         return $this->nbRejects;
     }
 
-    public function getNbRevolutions()
+    public function getNbRevolutions(): int
     {
         return $this->nbRevolutions;
     }
 
-    public function getNbFailures()
+    public function getNbFailures(): int
     {
         return $this->nbFailures;
     }
 
-    public function getNbWarnings()
+    public function getNbWarnings(): int
     {
         return $this->nbWarnings;
     }
 
-    public function getStats()
+    public function getStats(): array
     {
         return $this->stats;
     }
@@ -135,5 +161,20 @@ class Summary
     public function getMeanRelStDev()
     {
         return Statistics::mean($this->stats['rstdev']);
+    }
+
+    public function getOpcacheEnabled(): ?bool
+    {
+        return $this->opCacheEnabled;
+    }
+
+    public function getXdebugEnabled(): bool
+    {
+        return $this->xdebugEnabled;
+    }
+
+    public function getPhpVersion(): string
+    {
+        return $this->phpVersion;
     }
 }

--- a/lib/Model/Summary.php
+++ b/lib/Model/Summary.php
@@ -173,7 +173,7 @@ class Summary
         return $this->xdebugEnabled;
     }
 
-    public function getPhpVersion(): string
+    public function getPhpVersion(): ?string
     {
         return $this->phpVersion;
     }

--- a/lib/Progress/Logger/PhpBenchLogger.php
+++ b/lib/Progress/Logger/PhpBenchLogger.php
@@ -55,7 +55,7 @@ abstract class PhpBenchLogger extends NullLogger implements OutputAwareInterface
             'with PHP version %s, xdebug %s, opcache %s',
             $summary->getPhpVersion() ?? '<unknown>',
             $summary->getXdebugEnabled() ? '✔' : '❌',
-            $summary->getOpcacheEnabled()  ? '✔' : '❌',
+            $summary->getOpcacheEnabled()  ? '✔' : '❌'
         ));
 
         $this->output->writeln('');

--- a/lib/Progress/Logger/PhpBenchLogger.php
+++ b/lib/Progress/Logger/PhpBenchLogger.php
@@ -44,11 +44,19 @@ abstract class PhpBenchLogger extends NullLogger implements OutputAwareInterface
 
     public function startSuite(Suite $suite)
     {
-        $this->output->writeln('PhpBench ' . PhpBench::VERSION . '. Running benchmarks.');
+        $this->output->writeln('PHPBench ' . PhpBench::VERSION . ' running benchmarks...');
 
         if ($configPath = $suite->getConfigPath()) {
-            $this->output->writeln(sprintf('Using configuration file: %s', $configPath));
+            $this->output->writeln(sprintf('with configuration file: %s', $configPath));
         }
+
+        $summary = $suite->getSummary();
+        $this->output->writeln(sprintf(
+            'with PHP version %s, xdebug %s, opcache %s',
+            $summary->getPhpVersion() ?? '<unknown>',
+            $summary->getXdebugEnabled() ? '✔' : '❌',
+            $summary->getOpcacheEnabled()  ? '✔' : '❌',
+        ));
 
         $this->output->writeln('');
     }
@@ -61,6 +69,7 @@ abstract class PhpBenchLogger extends NullLogger implements OutputAwareInterface
         $this->listFailures($suite);
         $this->listWarnings($suite);
 
+
         $this->output->writeln(sprintf(
             '%s subjects, %s iterations, %s revs, %s rejects, %s failures, %s warnings',
             number_format($summary->getNbSubjects()),
@@ -70,6 +79,7 @@ abstract class PhpBenchLogger extends NullLogger implements OutputAwareInterface
             number_format($summary->getNbFailures()),
             number_format($summary->getNbWarnings())
         ));
+
 
         $this->output->writeln(sprintf(
             '(best [mean mode] worst) = %s [%s %s] %s (%s)',

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,3 +4,5 @@ parameters:
         - '#Call to an undefined method DOMNode#'
     paths:
         - lib
+includes:
+    - vendor/jangregor/phpstan-prophecy/extension.neon


### PR DESCRIPTION
Shows the xdebug / opcache status when running benchmarks:

```
PHPBench @git_tag@ running benchmarks...
with configuration file: /home/daniel/www/phpbench/phpbench/phpbench.json.dist
with PHP version 7.4.3, xdebug ✔, opcache ❌
```