### PR TITLE
Execution results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 CHANGELOG
 =========
 
-develop
--------
+1.0.0-alpha-2
+-------------
+
+- PHP 8.0 compatibility
+
+1.0.0-alpha-1
+-------------
 
 Backward compatibility breaks:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+develop
+-------
+
+Backward compatiblity breaks:
+
+- `BenchmarkExecutorInterface#execute()` must now return an `ExecutionResults`
+  object.
+
 1.0.0-alpha-2
 -------------
 

--- a/extensions/xdebug/lib/Executor/ProfileExecutor.php
+++ b/extensions/xdebug/lib/Executor/ProfileExecutor.php
@@ -15,6 +15,7 @@ namespace PhpBench\Extensions\XDebug\Executor;
 use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Executor\Benchmark\TemplateExecutor;
 use PhpBench\Executor\BenchmarkExecutorInterface;
+use PhpBench\Executor\ExecutionResults;
 use PhpBench\Extensions\XDebug\XDebugUtil;
 use PhpBench\Model\Iteration;
 use PhpBench\PhpBench;
@@ -47,7 +48,7 @@ class ProfileExecutor implements BenchmarkExecutorInterface
         ]);
     }
 
-    public function execute(SubjectMetadata $subjectMetadata, Iteration $iteration, Config $config): void
+    public function execute(SubjectMetadata $subjectMetadata, Iteration $iteration, Config $config): ExecutionResults
     {
         $outputDir = $config['output_dir'];
         $callback = $config['callback'];
@@ -59,10 +60,12 @@ class ProfileExecutor implements BenchmarkExecutorInterface
             'xdebug.profiler_output_name' => $name,
         ];
 
-        $this->innerExecutor->execute(
+        $results = $this->innerExecutor->execute(
             $subjectMetadata, $iteration, $config
         );
 
         $callback($iteration);
+
+        return $results;
     }
 }

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -335,7 +335,10 @@ final class Runner
     public function runIteration(BenchmarkExecutorInterface $executor, Config $executorConfig, Iteration $iteration, SubjectMetadata $subjectMetadata): void
     {
         $this->logger->iterationStart($iteration);
-        $executor->execute($subjectMetadata, $iteration, $executorConfig);
+
+        foreach ($executor->execute($subjectMetadata, $iteration, $executorConfig) as $result) {
+            $iteration->setResult($result);
+        }
 
         $sleep = $subjectMetadata->getSleep();
 

--- a/lib/Executor/Benchmark/DebugExecutor.php
+++ b/lib/Executor/Benchmark/DebugExecutor.php
@@ -14,6 +14,7 @@ namespace PhpBench\Executor\Benchmark;
 
 use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Executor\BenchmarkExecutorInterface;
+use PhpBench\Executor\ExecutionResults;
 use PhpBench\Model\Iteration;
 use PhpBench\Model\Result\MemoryResult;
 use PhpBench\Model\Result\TimeResult;
@@ -32,16 +33,18 @@ class DebugExecutor implements BenchmarkExecutorInterface
     /**
      * {@inheritdoc}
      */
-    public function execute(SubjectMetadata $subjectMetadata, Iteration $iteration, Config $config): void
+    public function execute(SubjectMetadata $subjectMetadata, Iteration $iteration, Config $config): ExecutionResults
     {
+        $results = ExecutionResults::new();
+
         // add 100 bytes of memory.
         $memory = 100;
-        $iteration->setResult(new MemoryResult($memory, $memory, $memory));
+        $results->add(new MemoryResult($memory, $memory, $memory));
 
         if (!$config['times']) {
-            $iteration->setResult(new TimeResult(0));
+            $results->add(new TimeResult(0));
 
-            return;
+            return $results;
         }
 
         $variantHash = spl_object_hash($iteration->getVariant());
@@ -63,7 +66,9 @@ class DebugExecutor implements BenchmarkExecutorInterface
             $time = $time + $spreadDiff;
         }
 
-        $iteration->setResult(new TimeResult($time));
+        $results->add(new TimeResult($time));
+
+        return $results;
     }
 
     /**

--- a/lib/Executor/BenchmarkExecutorInterface.php
+++ b/lib/Executor/BenchmarkExecutorInterface.php
@@ -19,5 +19,5 @@ use PhpBench\Registry\RegistrableInterface;
 
 interface BenchmarkExecutorInterface extends RegistrableInterface
 {
-    public function execute(SubjectMetadata $subjectMetadata, Iteration $iteration, Config $config): void;
+    public function execute(SubjectMetadata $subjectMetadata, Iteration $iteration, Config $config): ExecutionResults;
 }

--- a/lib/Executor/CompositeExecutor.php
+++ b/lib/Executor/CompositeExecutor.php
@@ -41,9 +41,9 @@ class CompositeExecutor implements BenchmarkExecutorInterface, HealthCheckInterf
         $this->benchmarkExecutor->configure($options);
     }
 
-    public function execute(SubjectMetadata $subjectMetadata, Iteration $iteration, Config $config): void
+    public function execute(SubjectMetadata $subjectMetadata, Iteration $iteration, Config $config): ExecutionResults
     {
-        $this->benchmarkExecutor->execute($subjectMetadata, $iteration, $config);
+        return $this->benchmarkExecutor->execute($subjectMetadata, $iteration, $config);
     }
 
     /**
@@ -54,6 +54,9 @@ class CompositeExecutor implements BenchmarkExecutorInterface, HealthCheckInterf
         $this->healthCheck->healthCheck();
     }
 
+    /**
+     * @param array<string> $methods
+     */
     public function executeMethods(BenchmarkMetadata $benchmark, array $methods): void
     {
         $this->methodExecutor->executeMethods($benchmark, $methods);

--- a/lib/Executor/ExecutionResults.php
+++ b/lib/Executor/ExecutionResults.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace PhpBench\Executor;
+
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+use PhpBench\Model\ResultInterface;
+
+/**
+ * @implements IteratorAggregate<int, ResultInterface>
+ */
+final class ExecutionResults implements IteratorAggregate, Countable
+{
+    /**
+     * @var array<int,ResultInterface>
+     */
+    private $results;
+
+    private function __construct(ResultInterface ...$results)
+    {
+        $this->results = $results;
+    }
+
+    public static function fromResults(ResultInterface ...$results): self
+    {
+        return new self(...$results);
+    }
+
+    public function add(ResultInterface $result): void
+    {
+        $this->results[] = $result;
+    }
+
+    public static function new(): self
+    {
+        return new self();
+    }
+
+    /**
+     * @return ArrayIterator<int,ResultInterface>
+     */
+    public function getIterator(): ArrayIterator
+    {
+        return new ArrayIterator($this->results);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function count(): int
+    {
+        return count($this->results);
+    }
+}

--- a/lib/Model/Result/TimeResult.php
+++ b/lib/Model/Result/TimeResult.php
@@ -26,14 +26,6 @@ class TimeResult implements ResultInterface
     private $netTime;
 
     /**
-     * {@inheritdoc}
-     */
-    public static function fromArray(array $values): ResultInterface
-    {
-        return new self((int) $values['net']);
-    }
-
-    /**
      * @param int $time Time taken to execute the iteration in microseconds.
      */
     public function __construct(int $time)
@@ -41,6 +33,14 @@ class TimeResult implements ResultInterface
         Assertion::greaterOrEqualThan($time, 0, 'Time cannot be less than 0, got %s');
 
         $this->netTime = $time;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function fromArray(array $values): ResultInterface
+    {
+        return new self((int) $values['net']);
     }
 
     /**

--- a/tests/Unit/Executor/Benchmark/DebugExecutorTest.php
+++ b/tests/Unit/Executor/Benchmark/DebugExecutorTest.php
@@ -16,12 +16,10 @@ use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Benchmark\Remote\Launcher;
 use PhpBench\Executor\Benchmark\DebugExecutor;
 use PhpBench\Model\Iteration;
-use PhpBench\Model\Result\MemoryResult;
 use PhpBench\Model\Result\TimeResult;
 use PhpBench\Model\Variant;
 use PhpBench\Registry\Config;
 use PhpBench\Tests\TestCase;
-use Prophecy\Argument;
 
 class DebugExecutorTest extends TestCase
 {
@@ -50,12 +48,8 @@ class DebugExecutorTest extends TestCase
                 $iteration = $this->prophesize(Iteration::class);
                 $iteration->getVariant()->willReturn($variant->reveal());
                 $iteration->getIndex()->willReturn($ii);
-                $iteration->setResult(Argument::type(TimeResult::class))->will(function ($args) use (&$actualTimes) {
-                    $actualTimes[] = $args[0]->getNet();
-                });
-                $iteration->setResult(Argument::type(MemoryResult::class))->shouldBeCalled();
 
-                $this->executor->execute(
+                $results = $this->executor->execute(
                     $this->subjectMetadata->reveal(),
                     $iteration->reveal(),
                     new Config('test', [
@@ -63,6 +57,12 @@ class DebugExecutorTest extends TestCase
                         'spread' => $spread,
                     ])
                 );
+
+                foreach ($results as $result) {
+                    if ($result instanceof TimeResult) {
+                        $actualTimes[] = $result->getNet();
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Changes the Executor API to ensure that something is returned than executors having to set the result on the iteration itself.