### PR TITLE
Execution context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Backward compatiblity breaks:
 - Extensions use the Symfony `OptionsResolver` instead of provding an array of
   default values (which is in line with how other parts of PHPBench are
   working).
+- Executors accept a single, immutable `ExecutionContext` instead of the
+  mutable `SubjectMetadata` and `Iteration`
 
 Features:
 

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "webmozart/path-util": "^2.3"
     },
     "require-dev": {
+        "dantleech/invoke": "^1.1",
         "doctrine/dbal": "^2.4",
         "friendsofphp/php-cs-fixer": "^2.13.1",
         "jangregor/phpstan-prophecy": "^0.8.1",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "webmozart/path-util": "^2.3"
     },
     "require-dev": {
-        "dantleech/invoke": "^1.1",
+        "dantleech/invoke": "^1.2",
         "doctrine/dbal": "^2.4",
         "friendsofphp/php-cs-fixer": "^2.13.1",
         "jangregor/phpstan-prophecy": "^0.8.1",

--- a/extensions/xdebug/lib/Command/ProfileCommand.php
+++ b/extensions/xdebug/lib/Command/ProfileCommand.php
@@ -76,7 +76,7 @@ EOT
                 'executor' => 'xdebug_profile',
                 'output_dir' => $outputDir,
                 'callback' => function ($iteration) use ($outputDir, $guiBin, &$generatedFiles) {
-                    $generatedFiles[] = $generatedFile = $outputDir . DIRECTORY_SEPARATOR . XDebugUtil::filenameFromIteration($iteration, '.cachegrind');
+                    $generatedFiles[] = $generatedFile = $outputDir . DIRECTORY_SEPARATOR . XDebugUtil::filenameFromContext($iteration, '.cachegrind');
 
                     if ($guiBin) {
                         $process = Process::fromShellCommandline(sprintf(

--- a/extensions/xdebug/lib/Executor/ProfileExecutor.php
+++ b/extensions/xdebug/lib/Executor/ProfileExecutor.php
@@ -12,13 +12,11 @@
 
 namespace PhpBench\Extensions\XDebug\Executor;
 
-use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Executor\Benchmark\TemplateExecutor;
 use PhpBench\Executor\BenchmarkExecutorInterface;
 use PhpBench\Executor\ExecutionContext;
 use PhpBench\Executor\ExecutionResults;
 use PhpBench\Extensions\XDebug\XDebugUtil;
-use PhpBench\Model\Iteration;
 use PhpBench\PhpBench;
 use PhpBench\Registry\Config;
 use Symfony\Component\OptionsResolver\OptionsResolver;

--- a/extensions/xdebug/lib/Executor/ProfileExecutor.php
+++ b/extensions/xdebug/lib/Executor/ProfileExecutor.php
@@ -15,6 +15,7 @@ namespace PhpBench\Extensions\XDebug\Executor;
 use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Executor\Benchmark\TemplateExecutor;
 use PhpBench\Executor\BenchmarkExecutorInterface;
+use PhpBench\Executor\ExecutionContext;
 use PhpBench\Executor\ExecutionResults;
 use PhpBench\Extensions\XDebug\XDebugUtil;
 use PhpBench\Model\Iteration;
@@ -48,11 +49,11 @@ class ProfileExecutor implements BenchmarkExecutorInterface
         ]);
     }
 
-    public function execute(SubjectMetadata $subjectMetadata, Iteration $iteration, Config $config): ExecutionResults
+    public function execute(ExecutionContext $context, Config $config): ExecutionResults
     {
         $outputDir = $config['output_dir'];
         $callback = $config['callback'];
-        $name = XDebugUtil::filenameFromIteration($iteration, '.cachegrind');
+        $name = XDebugUtil::filenameFromContext($context, '.cachegrind');
 
         $config[TemplateExecutor::OPTION_PHP_CONFIG] = [
             'xdebug.profiler_enable' => 1,
@@ -60,11 +61,9 @@ class ProfileExecutor implements BenchmarkExecutorInterface
             'xdebug.profiler_output_name' => $name,
         ];
 
-        $results = $this->innerExecutor->execute(
-            $subjectMetadata, $iteration, $config
-        );
+        $results = $this->innerExecutor->execute($context, $config);
 
-        $callback($iteration);
+        $callback($context);
 
         return $results;
     }

--- a/extensions/xdebug/lib/XDebugUtil.php
+++ b/extensions/xdebug/lib/XDebugUtil.php
@@ -12,17 +12,18 @@
 
 namespace PhpBench\Extensions\XDebug;
 
+use PhpBench\Executor\ExecutionContext;
 use PhpBench\Model\Iteration;
 
 class XDebugUtil
 {
-    public static function filenameFromIteration(Iteration $iteration, $extension = ''): string
+    public static function filenameFromContext(ExecutionContext $context, $extension = ''): string
     {
         $name = sprintf(
             '%s%s%s',
-            $iteration->getVariant()->getSubject()->getBenchmark()->getClass(),
-            $iteration->getVariant()->getSubject()->getName(),
-            $iteration->getVariant()->getParameterSet()->getName()
+            $context->getClassName(),
+            $context->getMethodName(),
+            $context->getParameterSetName()
         );
 
 

--- a/extensions/xdebug/lib/XDebugUtil.php
+++ b/extensions/xdebug/lib/XDebugUtil.php
@@ -13,7 +13,6 @@
 namespace PhpBench\Extensions\XDebug;
 
 use PhpBench\Executor\ExecutionContext;
-use PhpBench\Model\Iteration;
 
 class XDebugUtil
 {

--- a/extensions/xdebug/tests/Unit/XDebugUtilTest.php
+++ b/extensions/xdebug/tests/Unit/XDebugUtilTest.php
@@ -15,11 +15,7 @@ namespace PhpBench\Extensions\XDebug\Tests\Unit;
 use DTL\Invoke\Invoke;
 use PhpBench\Executor\ExecutionContext;
 use PhpBench\Extensions\XDebug\XDebugUtil;
-use PhpBench\Model\Benchmark;
 use PhpBench\Model\Iteration;
-use PhpBench\Model\ParameterSet;
-use PhpBench\Model\Subject;
-use PhpBench\Model\Variant;
 use PhpBench\Tests\TestCase;
 
 class XDebugUtilTest extends TestCase

--- a/extensions/xdebug/tests/Unit/XDebugUtilTest.php
+++ b/extensions/xdebug/tests/Unit/XDebugUtilTest.php
@@ -12,6 +12,8 @@
 
 namespace PhpBench\Extensions\XDebug\Tests\Unit;
 
+use DTL\Invoke\Invoke;
+use PhpBench\Executor\ExecutionContext;
 use PhpBench\Extensions\XDebug\XDebugUtil;
 use PhpBench\Model\Benchmark;
 use PhpBench\Model\Iteration;
@@ -27,31 +29,22 @@ class XDebugUtilTest extends TestCase
     private $benchmark;
     private $parameters;
 
-    protected function setUp(): void
-    {
-        $this->iteration = $this->prophesize(Iteration::class);
-        $this->subject = $this->prophesize(Subject::class);
-        $this->benchmark = $this->prophesize(Benchmark::class);
-        $this->parameters = $this->prophesize(ParameterSet::class);
-        $this->variant = $this->prophesize(Variant::class);
-    }
-
     /**
      * It should generate a filename for an iteration.
      *
      * @dataProvider provideGenerate
      */
-    public function testGenerate($class, $subject, $expected)
+    public function testGenerate($class, $subject, $expected): void
     {
-        $this->benchmark->getClass()->willReturn($class);
-        $this->subject->getName()->willReturn($subject);
+        $params = [
+            'classPath' => '/foobar',
+            'parameterSetName' => '7',
+            'parameters' => ['asd'],
+            'className' => $class,
+            'methodName' => $subject,
+        ];
 
-        $this->parameters->getName()->willReturn(7);
-        $this->variant->getParameterSet()->willReturn($this->parameters->reveal());
-        $this->subject->getBenchmark()->willReturn($this->benchmark->reveal());
-        $this->variant->getSubject()->willReturn($this->subject->reveal());
-        $this->iteration->getVariant()->willReturn($this->variant->reveal());
-        $result = XDebugUtil::filenameFromIteration($this->iteration->reveal());
+        $result = XDebugUtil::filenameFromContext(Invoke::new(ExecutionContext::class, $params));
         $this->assertEquals(
             $expected,
             $result

--- a/lib/Benchmark/Exception/RetryLimitReachedException.php
+++ b/lib/Benchmark/Exception/RetryLimitReachedException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PhpBench\Benchmark\Exception;
+
+use RuntimeException;
+
+class RetryLimitReachedException extends RuntimeException
+{
+}

--- a/lib/Benchmark/Metadata/SubjectMetadata.php
+++ b/lib/Benchmark/Metadata/SubjectMetadata.php
@@ -113,6 +113,11 @@ class SubjectMetadata
     private $timeout = 0;
 
     /**
+     * @var int|null
+     */
+    private $retryLimit = null;
+
+    /**
      */
     public function __construct(BenchmarkMetadata $benchmarkMetadata, string $name)
     {
@@ -336,5 +341,15 @@ class SubjectMetadata
     public function setTimeout(?float $timeout): void
     {
         $this->timeout = $timeout;
+    }
+
+    public function setRetryLimit(int $retryLimit): void
+    {
+        $this->retryLimit = $retryLimit;
+    }
+
+    public function getRetryLimit(): ?int
+    {
+        return $this->retryLimit;
     }
 }

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -33,7 +33,6 @@ use PhpBench\Progress\Logger\NullLogger;
 use PhpBench\Progress\LoggerInterface;
 use PhpBench\Registry\Config;
 use PhpBench\Registry\ConfigurableRegistry;
-use RuntimeException;
 
 /**
  * The benchmark runner.

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -18,6 +18,7 @@ use PhpBench\Benchmark\Metadata\BenchmarkMetadata;
 use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Environment\Supplier;
 use PhpBench\Executor\BenchmarkExecutorInterface;
+use PhpBench\Executor\ExecutionContext;
 use PhpBench\Executor\HealthCheckInterface;
 use PhpBench\Executor\MethodExecutorInterface;
 use PhpBench\Model\Benchmark;
@@ -331,7 +332,7 @@ final class Runner
     {
         $this->logger->iterationStart($iteration);
 
-        foreach ($executor->execute($subjectMetadata, $iteration, $executorConfig) as $result) {
+        foreach ($executor->execute(ExecutionContext::fromSubjectMetadataAndIteration($subjectMetadata, $iteration), $executorConfig) as $result) {
             $iteration->setResult($result);
         }
 

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -308,7 +308,7 @@ final class Runner
                 if ($subjectMetadata->getRetryLimit() && $rejectCount[spl_object_hash($reject)] > $subjectMetadata->getRetryLimit()) {
                     throw new RetryLimitReachedException(sprintf(
                         'Retry limit of %s exceeded',
-                        $subjectMetadata->getRetryLimit(),
+                        $subjectMetadata->getRetryLimit()
                     ));
                 }
 

--- a/lib/Executor/Benchmark/DebugExecutor.php
+++ b/lib/Executor/Benchmark/DebugExecutor.php
@@ -14,6 +14,7 @@ namespace PhpBench\Executor\Benchmark;
 
 use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Executor\BenchmarkExecutorInterface;
+use PhpBench\Executor\ExecutionContext;
 use PhpBench\Executor\ExecutionResults;
 use PhpBench\Model\Iteration;
 use PhpBench\Model\Result\MemoryResult;
@@ -33,7 +34,7 @@ class DebugExecutor implements BenchmarkExecutorInterface
     /**
      * {@inheritdoc}
      */
-    public function execute(SubjectMetadata $subjectMetadata, Iteration $iteration, Config $config): ExecutionResults
+    public function execute(ExecutionContext $context, Config $config): ExecutionResults
     {
         $results = ExecutionResults::new();
 
@@ -47,21 +48,21 @@ class DebugExecutor implements BenchmarkExecutorInterface
             return $results;
         }
 
-        $variantHash = spl_object_hash($iteration->getVariant());
+        $contextHash = spl_object_hash($context);
 
-        if (!isset($this->variantTimes[$variantHash])) {
-            $this->variantTimes[$variantHash] = $config['times'];
+        if (!isset($this->variantTimes[$contextHash])) {
+            $this->variantTimes[$contextHash] = $config['times'];
         }
 
-        if (!isset($this->variantTimes[$variantHash][$this->index])) {
+        if (!isset($this->variantTimes[$contextHash][$this->index])) {
             $this->index = 0;
         }
 
-        $time = $this->variantTimes[$variantHash][$this->index];
+        $time = $this->variantTimes[$contextHash][$this->index];
         $this->index++;
 
         if ($config['spread']) {
-            $index = $iteration->getIndex() % count($config['spread']);
+            $index = $context->getIterationIndex() % count($config['spread']);
             $spreadDiff = $config['spread'][$index];
             $time = $time + $spreadDiff;
         }

--- a/lib/Executor/Benchmark/DebugExecutor.php
+++ b/lib/Executor/Benchmark/DebugExecutor.php
@@ -12,11 +12,9 @@
 
 namespace PhpBench\Executor\Benchmark;
 
-use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Executor\BenchmarkExecutorInterface;
 use PhpBench\Executor\ExecutionContext;
 use PhpBench\Executor\ExecutionResults;
-use PhpBench\Model\Iteration;
 use PhpBench\Model\Result\MemoryResult;
 use PhpBench\Model\Result\TimeResult;
 use PhpBench\Registry\Config;

--- a/lib/Executor/Benchmark/TemplateExecutor.php
+++ b/lib/Executor/Benchmark/TemplateExecutor.php
@@ -12,12 +12,10 @@
 
 namespace PhpBench\Executor\Benchmark;
 
-use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Benchmark\Remote\Launcher;
 use PhpBench\Executor\BenchmarkExecutorInterface;
 use PhpBench\Executor\ExecutionContext;
 use PhpBench\Executor\ExecutionResults;
-use PhpBench\Model\Iteration;
 use PhpBench\Model\Result\MemoryResult;
 use PhpBench\Model\Result\TimeResult;
 use PhpBench\Registry\Config;

--- a/lib/Executor/Benchmark/TestExecutor.php
+++ b/lib/Executor/Benchmark/TestExecutor.php
@@ -5,6 +5,7 @@ namespace PhpBench\Executor\Benchmark;
 use PhpBench\Benchmark\Metadata\BenchmarkMetadata;
 use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Executor\BenchmarkExecutorInterface;
+use PhpBench\Executor\ExecutionContext;
 use PhpBench\Executor\ExecutionResults;
 use PhpBench\Executor\HealthCheckInterface;
 use PhpBench\Executor\MethodExecutorInterface;
@@ -27,19 +28,21 @@ class TestExecutor implements BenchmarkExecutorInterface, MethodExecutorInterfac
     private $healthChecked = false;
 
     /**
-     * @var array<SubjectMetadata>
+     * @var array<ExecutionContext>
      */
-    private $executedSubjects = [];
+    private $executedContexts = [];
 
     /**
-     * @var SubjectMetadata|null
+     * @var ExecutionContext|null
      */
-    private $lastSubject;
+    private $lastContext;
 
     /**
      * @var Variant|null
      */
     private $lastVariant;
+
+    private $index = 0;
 
     /**
      * {@inheritDoc}
@@ -52,16 +55,15 @@ class TestExecutor implements BenchmarkExecutorInterface, MethodExecutorInterfac
         ]);
     }
 
-    public function execute(SubjectMetadata $subjectMetadata, Iteration $iteration, Config $config): ExecutionResults
+    public function execute(ExecutionContext $context, Config $config): ExecutionResults
     {
         if ($config['exception']) {
             throw $config['exception'];
         }
-        $this->executedSubjects[] = $subjectMetadata;
-        $this->lastSubject = $subjectMetadata;
-        $this->lastVariant = $iteration->getVariant();
+        $this->executedContexts[] = $context;
+        $this->lastContext = $context;
 
-        return ExecutionResults::fromResults(...$config['results']);
+        return ExecutionResults::fromResults($config['results'][$this->index++ % count($config['results'])]);
     }
 
     public function executeMethods(BenchmarkMetadata $benchmark, array $methods): void
@@ -77,26 +79,15 @@ class TestExecutor implements BenchmarkExecutorInterface, MethodExecutorInterfac
         $this->healthChecked = true;
     }
 
-    public function lastSubjectOrException(): SubjectMetadata
+    public function lastContextOrException(): ExecutionContext
     {
-        if (null === $this->lastSubject) {
+        if (null === $this->lastContext) {
             throw new RuntimeException(
                 'No subject has been executed'
             );
         }
 
-        return $this->lastSubject;
-    }
-
-    public function lastVariantOrException(): Variant
-    {
-        if (null === $this->lastVariant) {
-            throw new RuntimeException(
-                'No variant has been executed'
-            );
-        }
-
-        return $this->lastVariant;
+        return $this->lastContext;
     }
 
     public function hasMethodBeenExecuted(string $name): bool
@@ -109,8 +100,8 @@ class TestExecutor implements BenchmarkExecutorInterface, MethodExecutorInterfac
         return $this->healthChecked;
     }
 
-    public function getExecutedSubjectCount(): int
+    public function getExecutedContextCount(): int
     {
-        return count($this->executedSubjects);
+        return count($this->executedContexts);
     }
 }

--- a/lib/Executor/Benchmark/TestExecutor.php
+++ b/lib/Executor/Benchmark/TestExecutor.php
@@ -3,13 +3,11 @@
 namespace PhpBench\Executor\Benchmark;
 
 use PhpBench\Benchmark\Metadata\BenchmarkMetadata;
-use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Executor\BenchmarkExecutorInterface;
 use PhpBench\Executor\ExecutionContext;
 use PhpBench\Executor\ExecutionResults;
 use PhpBench\Executor\HealthCheckInterface;
 use PhpBench\Executor\MethodExecutorInterface;
-use PhpBench\Model\Iteration;
 use PhpBench\Model\Variant;
 use PhpBench\Registry\Config;
 use RuntimeException;

--- a/lib/Executor/BenchmarkExecutorInterface.php
+++ b/lib/Executor/BenchmarkExecutorInterface.php
@@ -12,8 +12,6 @@
 
 namespace PhpBench\Executor;
 
-use PhpBench\Benchmark\Metadata\SubjectMetadata;
-use PhpBench\Model\Iteration;
 use PhpBench\Registry\Config;
 use PhpBench\Registry\RegistrableInterface;
 

--- a/lib/Executor/BenchmarkExecutorInterface.php
+++ b/lib/Executor/BenchmarkExecutorInterface.php
@@ -19,5 +19,5 @@ use PhpBench\Registry\RegistrableInterface;
 
 interface BenchmarkExecutorInterface extends RegistrableInterface
 {
-    public function execute(SubjectMetadata $subjectMetadata, Iteration $iteration, Config $config): ExecutionResults;
+    public function execute(ExecutionContext $context, Config $config): ExecutionResults;
 }

--- a/lib/Executor/CompositeExecutor.php
+++ b/lib/Executor/CompositeExecutor.php
@@ -41,9 +41,9 @@ class CompositeExecutor implements BenchmarkExecutorInterface, HealthCheckInterf
         $this->benchmarkExecutor->configure($options);
     }
 
-    public function execute(SubjectMetadata $subjectMetadata, Iteration $iteration, Config $config): ExecutionResults
+    public function execute(ExecutionContext $context, Config $config): ExecutionResults
     {
-        return $this->benchmarkExecutor->execute($subjectMetadata, $iteration, $config);
+        return $this->benchmarkExecutor->execute($context, $config);
     }
 
     /**

--- a/lib/Executor/CompositeExecutor.php
+++ b/lib/Executor/CompositeExecutor.php
@@ -3,9 +3,7 @@
 namespace PhpBench\Executor;
 
 use PhpBench\Benchmark\Metadata\BenchmarkMetadata;
-use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Executor\HealthCheck\AlwaysFineHealthCheck;
-use PhpBench\Model\Iteration;
 use PhpBench\Registry\Config;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 

--- a/lib/Executor/ExecutionContext.php
+++ b/lib/Executor/ExecutionContext.php
@@ -101,7 +101,7 @@ final class ExecutionContext
             $iteration->getVariant()->getWarmup() ?: 0,
             $iteration->getIndex(),
             $subjectMetadata->getTimeout(),
-            $iteration->getVariant()->getParameterSet()->getName(),
+            $iteration->getVariant()->getParameterSet()->getName()
         );
     }
 

--- a/lib/Executor/ExecutionContext.php
+++ b/lib/Executor/ExecutionContext.php
@@ -2,10 +2,8 @@
 
 namespace PhpBench\Executor;
 
-use DTL\Invoke\Invoke;
 use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Model\Iteration;
-use PhpCsFixer\Config;
 
 final class ExecutionContext
 {
@@ -59,19 +57,24 @@ final class ExecutionContext
      */
     private $timeOut;
 
+    /**
+     * @var string
+     */
+    private $parameterSetName;
+
     public function __construct(
         string $className,
         string $classPath,
         string $methodName,
-        int $revolutions,
-        array $beforeMethods,
-        array $afterMethods,
-        array $parameters,
-        int $warmup,
-        int $iterationIndex,
-        ?float $timeOut
-    )
-    {
+        int $revolutions = 1,
+        array $beforeMethods = [],
+        array $afterMethods = [],
+        array $parameters = [],
+        int $warmup = 0,
+        int $iterationIndex = 0,
+        ?float $timeOut = null,
+        string $parameterSetName = ''
+    ) {
         $this->className = $className;
         $this->classPath = $classPath;
         $this->methodName = $methodName;
@@ -82,6 +85,7 @@ final class ExecutionContext
         $this->warmup = $warmup;
         $this->iterationIndex = $iterationIndex;
         $this->timeOut = $timeOut;
+        $this->parameterSetName = $parameterSetName;
     }
 
     public static function fromSubjectMetadataAndIteration(SubjectMetadata $subjectMetadata, Iteration $iteration): self
@@ -97,6 +101,7 @@ final class ExecutionContext
             $iteration->getVariant()->getWarmup() ?: 0,
             $iteration->getIndex(),
             $subjectMetadata->getTimeout(),
+            $iteration->getVariant()->getParameterSet()->getName(),
         );
     }
 
@@ -148,5 +153,10 @@ final class ExecutionContext
     public function getTimeOut(): ?float
     {
         return $this->timeOut;
+    }
+
+    public function getParameterSetName(): string
+    {
+        return $this->parameterSetName;
     }
 }

--- a/lib/Executor/ExecutionContext.php
+++ b/lib/Executor/ExecutionContext.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace PhpBench\Executor;
+
+use DTL\Invoke\Invoke;
+use PhpBench\Benchmark\Metadata\SubjectMetadata;
+use PhpBench\Model\Iteration;
+use PhpCsFixer\Config;
+
+final class ExecutionContext
+{
+    /**
+     * @var string
+     */
+    private $className;
+
+    /**
+     * @var array<string,mixed>
+     */
+    private $parameters;
+
+    /**
+     * @var string
+     */
+    private $classPath;
+
+    /**
+     * @var int
+     */
+    private $iterationIndex;
+
+    /**
+     * @var int
+     */
+    private $warmup;
+
+    /**
+     * @var array<string>
+     */
+    private $afterMethods;
+
+    /**
+     * @var array<string>
+     */
+    private $beforeMethods;
+
+    /**
+     * @var int
+     */
+    private $revolutions;
+
+    /**
+     * @var string
+     */
+    private $methodName;
+
+    /**
+     * @var float|null
+     */
+    private $timeOut;
+
+    public function __construct(
+        string $className,
+        string $classPath,
+        string $methodName,
+        int $revolutions,
+        array $beforeMethods,
+        array $afterMethods,
+        array $parameters,
+        int $warmup,
+        int $iterationIndex,
+        ?float $timeOut
+    )
+    {
+        $this->className = $className;
+        $this->classPath = $classPath;
+        $this->methodName = $methodName;
+        $this->revolutions = $revolutions;
+        $this->beforeMethods = $beforeMethods;
+        $this->afterMethods = $afterMethods;
+        $this->parameters = $parameters;
+        $this->warmup = $warmup;
+        $this->iterationIndex = $iterationIndex;
+        $this->timeOut = $timeOut;
+    }
+
+    /**
+     * @param array<string,mixed> $options
+     */
+    public static function create(string $classPath, string $className, string $methodName, array $options = []): self
+    {
+        return Invoke::new(self::class, array_merge($options, [
+            'className' => $className,
+            'methodName' => $classPath,
+            'classPath' => $methodName
+        ]));
+    }
+
+    public static function fromSubjectMetadataAndIteration(SubjectMetadata $subjectMetadata, Iteration $iteration): self
+    {
+        return new self(
+            $subjectMetadata->getBenchmark()->getClass(),
+            $subjectMetadata->getBenchmark()->getPath(),
+            $subjectMetadata->getName(),
+            $iteration->getVariant()->getRevolutions(),
+            $subjectMetadata->getBeforeMethods(),
+            $subjectMetadata->getAfterMethods(),
+            $iteration->getVariant()->getParameterSet()->getArrayCopy(),
+            $iteration->getVariant()->getWarmup() ?: 0,
+            $iteration->getIndex(),
+            $subjectMetadata->getTimeout()
+        );
+    }
+
+    public function getClassName(): string
+    {
+        return $this->className;
+    }
+
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    public function getClassPath(): string
+    {
+        return $this->classPath;
+    }
+
+    public function getIterationIndex(): int
+    {
+        return $this->iterationIndex;
+    }
+
+    public function getWarmup(): int
+    {
+        return $this->warmup;
+    }
+
+    public function getAfterMethods(): array
+    {
+        return $this->afterMethods;
+    }
+
+    public function getBeforeMethods(): array
+    {
+        return $this->beforeMethods;
+    }
+
+    public function getRevolutions(): int
+    {
+        return $this->revolutions;
+    }
+
+    public function getMethodName(): string
+    {
+        return $this->methodName;
+    }
+
+    public function getTimeOut(): ?float
+    {
+        return $this->timeOut;
+    }
+}

--- a/lib/Executor/ExecutionContext.php
+++ b/lib/Executor/ExecutionContext.php
@@ -84,18 +84,6 @@ final class ExecutionContext
         $this->timeOut = $timeOut;
     }
 
-    /**
-     * @param array<string,mixed> $options
-     */
-    public static function create(string $classPath, string $className, string $methodName, array $options = []): self
-    {
-        return Invoke::new(self::class, array_merge($options, [
-            'className' => $className,
-            'methodName' => $classPath,
-            'classPath' => $methodName
-        ]));
-    }
-
     public static function fromSubjectMetadataAndIteration(SubjectMetadata $subjectMetadata, Iteration $iteration): self
     {
         return new self(
@@ -108,7 +96,7 @@ final class ExecutionContext
             $iteration->getVariant()->getParameterSet()->getArrayCopy(),
             $iteration->getVariant()->getWarmup() ?: 0,
             $iteration->getIndex(),
-            $subjectMetadata->getTimeout()
+            $subjectMetadata->getTimeout(),
         );
     }
 

--- a/tests/Unit/Benchmark/RunnerTest.php
+++ b/tests/Unit/Benchmark/RunnerTest.php
@@ -273,8 +273,6 @@ class RunnerTest extends TestCase
 
         $this->assertNoErrors($suite);
 
-        //self::assertEquals(100, $this->executor->lastContextOrException()->getSleep());
-        //self::assertEquals(12, $this->executor->lastContextOrException()->getRetryThreshold());
         self::assertEquals(88, $this->executor->lastContextOrException()->getRevolutions());
         self::assertEquals(66, $this->executor->lastContextOrException()->getWarmup());
     }

--- a/tests/Unit/Benchmark/RunnerTest.php
+++ b/tests/Unit/Benchmark/RunnerTest.php
@@ -16,6 +16,7 @@ use Exception;
 use Generator;
 use InvalidArgumentException;
 use PhpBench\Assertion\AssertionProcessor;
+use PhpBench\Benchmark\Exception\RetryLimitReachedException;
 use PhpBench\Benchmark\Metadata\BenchmarkMetadata;
 use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Benchmark\Runner;
@@ -132,7 +133,7 @@ class RunnerTest extends TestCase
         $this->assertInstanceOf('PhpBench\Model\Suite', $suite);
         $this->assertNoErrors($suite);
 
-        self::assertEquals((int)(count($revs) * array_sum($iterations)), $this->executor->getExecutedSubjectCount());
+        self::assertEquals((int)(count($revs) * array_sum($iterations)), $this->executor->getExecutedContextCount());
 
         foreach ($assertionCallbacks as $callback) {
             $callback($this, $suite);
@@ -245,15 +246,16 @@ class RunnerTest extends TestCase
     public function testSleep(): void
     {
         $subject = new SubjectMetadata($this->benchmark->reveal(), 'name');
-        $subject->setSleep(50);
+        $subject->setSleep(10000);
         $this->benchmark->getSubjects()->willReturn([
             $subject,
         ]);
         TestUtil::configureBenchmarkMetadata($this->benchmark);
 
+        $start = microtime(true);
         $suite = $this->runner->run([ $this->benchmark->reveal() ], RunnerConfig::create());
-        $this->assertNoErrors($suite);
-        self::assertEquals(50, $this->executor->lastSubjectOrException()->getSleep());
+        $end = microtime(true);
+        self::assertGreaterThanOrEqual(10000, ($end - $start) * 1E6, 'Should take at least 10 milliseconds');
     }
 
     public function testOverrideMetadata(): void
@@ -273,30 +275,69 @@ class RunnerTest extends TestCase
 
         $this->assertNoErrors($suite);
 
-        self::assertEquals(100, $this->executor->lastSubjectOrException()->getSleep());
-        self::assertEquals(12, $this->executor->lastSubjectOrException()->getRetryThreshold());
-        self::assertEquals(66, $this->executor->lastVariantOrException()->getWarmup());
-        self::assertEquals(88, $this->executor->lastVariantOrException()->getRevolutions());
+        //self::assertEquals(100, $this->executor->lastContextOrException()->getSleep());
+        //self::assertEquals(12, $this->executor->lastContextOrException()->getRetryThreshold());
+        self::assertEquals(88, $this->executor->lastContextOrException()->getRevolutions());
+        self::assertEquals(66, $this->executor->lastContextOrException()->getWarmup());
     }
 
     /**
      * It should serialize the retry threshold.
      */
-    public function testRetryThreshold(): void
+    public function testRetryThresholdExceeded(): void
     {
+        $this->expectException(RetryLimitReachedException::class);
+
         $subject = new SubjectMetadata($this->benchmark->reveal(), 'name');
+        $subject->setIterations([3]);
+        $subject->setRetryLimit(10);
+
         $this->benchmark->getSubjects()->willReturn([
             $subject,
         ]);
+
         TestUtil::configureBenchmarkMetadata($this->benchmark);
 
-        $suite = $this->runner->run(
+        $this->setUpExecutorConfig([
+            'results' => [
+                new TimeResult(1),
+                new TimeResult(1),
+                new TimeResult(1000),
+            ],
+        ]);
+
+        $this->runner->run(
+            [ $this->benchmark->reveal() ],
+            RunnerConfig::create()->withRetryThreshold(10)
+        );
+    }
+
+    public function testRetryThresholdMet(): void
+    {
+        $subject = new SubjectMetadata($this->benchmark->reveal(), 'name');
+        $subject->setIterations([3]);
+        $subject->setRetryLimit(10);
+
+        $this->benchmark->getSubjects()->willReturn([
+            $subject,
+        ]);
+
+        TestUtil::configureBenchmarkMetadata($this->benchmark);
+
+        $this->setUpExecutorConfig([
+            'results' => [
+                new TimeResult(10),
+                new TimeResult(10),
+                new TimeResult(10),
+            ],
+        ]);
+
+        $this->runner->run(
             [ $this->benchmark->reveal() ],
             RunnerConfig::create()->withRetryThreshold(10)
         );
 
-        self::assertEquals(10, $this->executor->lastSubjectOrException()->getRetryThreshold());
-        $this->assertInstanceOf('PhpBench\Model\Suite', $suite);
+        $this->addToAssertionCount(1); // no exception = retry limit not exceeded
     }
 
     /**

--- a/tests/Unit/Benchmark/RunnerTest.php
+++ b/tests/Unit/Benchmark/RunnerTest.php
@@ -25,8 +25,6 @@ use PhpBench\Environment\Information;
 use PhpBench\Environment\Supplier;
 use PhpBench\Executor;
 use PhpBench\Executor\Benchmark\TestExecutor;
-use PhpBench\Executor\BenchmarkExecutorInterface;
-use PhpBench\Executor\ExecutionContext;
 use PhpBench\Executor\ExecutionResults;
 use PhpBench\Model\Result\MemoryResult;
 use PhpBench\Model\Result\TimeResult;

--- a/tests/Unit/Benchmark/RunnerTest.php
+++ b/tests/Unit/Benchmark/RunnerTest.php
@@ -24,6 +24,8 @@ use PhpBench\Environment\Information;
 use PhpBench\Environment\Supplier;
 use PhpBench\Executor;
 use PhpBench\Executor\Benchmark\TestExecutor;
+use PhpBench\Executor\BenchmarkExecutorInterface;
+use PhpBench\Executor\ExecutionContext;
 use PhpBench\Executor\ExecutionResults;
 use PhpBench\Model\Result\MemoryResult;
 use PhpBench\Model\Result\TimeResult;

--- a/tests/Unit/Executor/Benchmark/DebugExecutorTest.php
+++ b/tests/Unit/Executor/Benchmark/DebugExecutorTest.php
@@ -12,9 +12,11 @@
 
 namespace PhpBench\Tests\Unit\Executor\Benchmark;
 
+use DTL\Invoke\Invoke;
 use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Benchmark\Remote\Launcher;
 use PhpBench\Executor\Benchmark\DebugExecutor;
+use PhpBench\Executor\ExecutionContext;
 use PhpBench\Model\Iteration;
 use PhpBench\Model\Result\TimeResult;
 use PhpBench\Model\Variant;
@@ -29,7 +31,6 @@ class DebugExecutorTest extends TestCase
     {
         $launcher = $this->prophesize(Launcher::class);
         $this->executor = new DebugExecutor($launcher->reveal());
-        $this->subjectMetadata = $this->prophesize(SubjectMetadata::class);
     }
 
     /**
@@ -42,16 +43,14 @@ class DebugExecutorTest extends TestCase
         $actualTimes = [];
 
         for ($i = 0; $i < $nbCollections; $i++) {
-            $variant = $this->prophesize(Variant::class);
-
             for ($ii = 0; $ii < $nbIterations; $ii++) {
-                $iteration = $this->prophesize(Iteration::class);
-                $iteration->getVariant()->willReturn($variant->reveal());
-                $iteration->getIndex()->willReturn($ii);
-
                 $results = $this->executor->execute(
-                    $this->subjectMetadata->reveal(),
-                    $iteration->reveal(),
+                    Invoke::new(ExecutionContext::class, [
+                        'classPath' => '',
+                        'className' => '',
+                        'methodName' => '',
+                        'iterationIndex' => $ii,
+                    ]),
                     new Config('test', [
                         'times' => $times,
                         'spread' => $spread,

--- a/tests/Unit/Executor/Benchmark/DebugExecutorTest.php
+++ b/tests/Unit/Executor/Benchmark/DebugExecutorTest.php
@@ -13,13 +13,10 @@
 namespace PhpBench\Tests\Unit\Executor\Benchmark;
 
 use DTL\Invoke\Invoke;
-use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Benchmark\Remote\Launcher;
 use PhpBench\Executor\Benchmark\DebugExecutor;
 use PhpBench\Executor\ExecutionContext;
-use PhpBench\Model\Iteration;
 use PhpBench\Model\Result\TimeResult;
-use PhpBench\Model\Variant;
 use PhpBench\Registry\Config;
 use PhpBench\Tests\TestCase;
 

--- a/tests/Unit/Executor/Benchmark/MicrotimeExecutorTest.php
+++ b/tests/Unit/Executor/Benchmark/MicrotimeExecutorTest.php
@@ -165,18 +165,16 @@ class MicrotimeExecutorTest extends PhpBenchTestCase
         $this->assertEquals($expected->getArrayCopy(), $params);
     }
 
+    private function buildContext(array $config): ExecutionContext
+    {
+        return Invoke::new(ExecutionContext::class, $this->buildConfig($config));
+    }
+
     private function buildConfig(array $config): array
     {
         return array_merge([
             'className' => 'PhpBench\Tests\Unit\Executor\benchmarks\MicrotimeExecutorBench',
             'classPath' => __DIR__ . '/../benchmarks/MicrotimeExecutorBench.php',
         ], $config);
-    }
-
-    private function buildContext(array $config)
-    {
-        $context = Invoke::new(ExecutionContext::class, $this->buildConfig($config));
-
-        return $context;
     }
 }

--- a/tests/Unit/Executor/Benchmark/MicrotimeExecutorTest.php
+++ b/tests/Unit/Executor/Benchmark/MicrotimeExecutorTest.php
@@ -13,15 +13,11 @@
 namespace PhpBench\Tests\Unit\Executor\Benchmark;
 
 use DTL\Invoke\Invoke;
-use PhpBench\Benchmark\Metadata\BenchmarkMetadata;
-use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Benchmark\Remote\Launcher;
 use PhpBench\Executor\Benchmark\MicrotimeExecutor;
 use PhpBench\Executor\ExecutionContext;
 use PhpBench\Model\Benchmark;
-use PhpBench\Model\Iteration;
 use PhpBench\Model\ParameterSet;
-use PhpBench\Model\Variant;
 use PhpBench\Registry\Config;
 use PhpBench\Tests\PhpBenchTestCase;
 use RuntimeException;
@@ -180,6 +176,7 @@ class MicrotimeExecutorTest extends PhpBenchTestCase
     private function buildContext(array $config)
     {
         $context = Invoke::new(ExecutionContext::class, $this->buildConfig($config));
+
         return $context;
     }
 }

--- a/tests/Util/TestUtil.php
+++ b/tests/Util/TestUtil.php
@@ -66,7 +66,7 @@ class TestUtil
             'class' => 'Benchmark',
             'beforeClassMethods' => [],
             'afterClassMethods' => [],
-            'path' => null,
+            'path' => 'example',
         ], $options);
 
         $benchmark->getClass()->willReturn($options['class']);


### PR DESCRIPTION
- Executors accept a single, immutable `ExecutionContext` instead of the
  mutable `SubjectMetadata` and `Iteration`
- Refactored the tests around this.