### PR TITLE
Improve error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 CHANGELOG
 =========
 
+master
+------
+
+Bug fixes:
+
+- Numeric tags cause an error #717
+- Benchmark errors cause reports to error
+- Undefined console formatter `subtitle` #729
+- Missing formatters not defined in correct place #727
+
+Improvements:
+
+- Colourful indication of success/failure/warnings when assertions are used.
+
 1.0.0-alpha-3
 -------------
 
@@ -28,7 +42,6 @@ Features:
 
 Improvements:
 
-- Colourful indication of success/failure/warnings when assertions are used.
 - Decorator added to improve error reporting for method executors.
 - Benchmarks executed as they are found (no eager metadata loading)
 - Allow direct reference to services (e.g. `--executor=debug` without need for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Features:
 
 Improvements:
 
+- Colourful indication of success/failure/warnings when assertions are used.
 - Decorator added to improve error reporting for method executors.
 - Benchmarks executed as they are found (no eager metadata loading)
 - Allow direct reference to services (e.g. `--executor=debug` without need for

--- a/examples/Benchmark/Micro/HashingBench.php
+++ b/examples/Benchmark/Micro/HashingBench.php
@@ -26,6 +26,7 @@ function hash_algos()
 class HashingBench
 {
     /**
+     * @Assert("variant.mode < 1ms")
      * @ParamProviders({"\PhpBench\Examples\Benchmark\Micro\hash_algos"})
      */
     public function benchAlgos($params)

--- a/examples/OutputTest/OutputTestBench.php
+++ b/examples/OutputTest/OutputTestBench.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace PhpBench\Examples\Benchmark;
+
+use RuntimeException;
+
+class OutputTestBench
+{
+    public function benchStandard()
+    {
+    }
+
+    /**
+     * @Assert("10ms <= 9ms +/- 1ms")
+     */
+    public function benchWarning()
+    {
+    }
+
+    /**
+     * @Assert("10ms <= 9ms")
+     */
+    public function benchFailure()
+    {
+    }
+
+    public function benchError()
+    {
+        throw new RuntimeException("Example error");
+    }
+}

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -172,7 +172,7 @@ class CoreExtension implements ExtensionInterface
             }
 
             $output = new ConsoleOutput();
-            $output->getFormatter()->setStyle('greenbg', new OutputFormatterStyle('black', 'green', []));
+            $output->getFormatter()->setStyle('success', new OutputFormatterStyle('black', 'green', []));
             $output->getFormatter()->setStyle('warning', new OutputFormatterStyle('black', 'yellow', []));
 
             return $output;

--- a/lib/Model/ErrorStack.php
+++ b/lib/Model/ErrorStack.php
@@ -12,6 +12,7 @@
 
 namespace PhpBench\Model;
 
+use Countable;
 use IteratorAggregate;
 
 /**
@@ -22,7 +23,7 @@ use IteratorAggregate;
  *
  * @implements IteratorAggregate<Error>
  */
-class ErrorStack implements IteratorAggregate
+class ErrorStack implements IteratorAggregate, Countable
 {
     /**
      * @var Error[]
@@ -61,5 +62,13 @@ class ErrorStack implements IteratorAggregate
     public function getIterator(): \ArrayIterator
     {
         return new \ArrayIterator($this->errors);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function count(): int
+    {
+        return count($this->errors);
     }
 }

--- a/lib/Model/Summary.php
+++ b/lib/Model/Summary.php
@@ -25,6 +25,8 @@ class Summary
     private $nbRevolutions = 0;
     private $nbFailures = 0;
     private $nbWarnings = 0;
+    private $nbAssertions = 0;
+    private $nbErrors = 0;
     private $stats = [
         'stdev' => [],
         'mean' => [],
@@ -65,6 +67,8 @@ class Summary
                     $this->nbRevolutions += $variant->getRevolutions();
                     $this->nbFailures += $variant->getAssertionResults()->failures()->count();
                     $this->nbWarnings += $variant->getAssertionResults()->warnings()->count();
+                    $this->nbAssertions += $variant->getAssertionResults()->count();
+                    $this->nbErrors += $variant->getErrorStack()->count();
                     $this->nbRejects += $variant->getRejectCount();
 
                     if ($variant->hasErrorStack()) {
@@ -117,9 +121,19 @@ class Summary
         return $this->nbFailures;
     }
 
+    public function getNbErrors(): int
+    {
+        return $this->nbErrors;
+    }
+
     public function getNbWarnings(): int
     {
         return $this->nbWarnings;
+    }
+
+    public function getNbAssertions(): int
+    {
+        return $this->nbAssertions;
     }
 
     public function getStats(): array

--- a/lib/Progress/Logger/PhpBenchLogger.php
+++ b/lib/Progress/Logger/PhpBenchLogger.php
@@ -15,6 +15,7 @@ namespace PhpBench\Progress\Logger;
 use PhpBench\Model\Iteration;
 use PhpBench\Model\Result\TimeResult;
 use PhpBench\Model\Suite;
+use PhpBench\Model\Summary;
 use PhpBench\Model\Variant;
 use PhpBench\PhpBench;
 use PhpBench\Util\TimeUnit;
@@ -65,18 +66,6 @@ abstract class PhpBenchLogger extends NullLogger
         $this->listFailures($suite);
         $this->listWarnings($suite);
 
-
-        $this->output->writeln(sprintf(
-            '%s subjects, %s iterations, %s revs, %s rejects, %s failures, %s warnings',
-            number_format($summary->getNbSubjects()),
-            number_format($summary->getNbIterations()),
-            number_format($summary->getNbRevolutions()),
-            number_format($summary->getNbRejects()),
-            number_format($summary->getNbFailures()),
-            number_format($summary->getNbWarnings())
-        ));
-
-
         $this->output->writeln(sprintf(
             '(best [mean mode] worst) = %s [%s %s] %s (%s)',
             number_format($this->timeUnit->toDestUnit($summary->getMinTime()), 3),
@@ -92,6 +81,29 @@ abstract class PhpBenchLogger extends NullLogger
             $this->timeUnit->format($summary->getMeanStDev(), null, TimeUnit::MODE_TIME),
             number_format($summary->getMeanRelStDev(), 3)
         ));
+
+        $this->output->writeln((function (Summary $summary, string $message) {
+            if ($summary->getNbFailures() || $summary->getNbErrors()) {
+                return sprintf('<error>%s</>', $message);
+            }
+
+            if ($summary->getNbWarnings()) {
+                return sprintf('<warning>%s</>', $message);
+            }
+           
+            if ($summary->getNbAssertions()) {
+                return sprintf('<greenbg>%s</>', $message);
+            }
+
+            return $message;
+        })($suite->getSummary(), sprintf(
+            'Subjects: %s, Assertions: %s, Warnings: %s warnings, Errors: %s, Failures: %s',
+            number_format($summary->getNbSubjects()),
+            number_format($summary->getNbAssertions()),
+            number_format($summary->getNbWarnings()),
+            number_format($summary->getNbErrors()),
+            number_format($summary->getNbFailures()),
+        )));
     }
 
     private function listErrors(Suite $suite): void

--- a/lib/Progress/Logger/PhpBenchLogger.php
+++ b/lib/Progress/Logger/PhpBenchLogger.php
@@ -102,7 +102,7 @@ abstract class PhpBenchLogger extends NullLogger
             number_format($summary->getNbAssertions()),
             number_format($summary->getNbWarnings()),
             number_format($summary->getNbErrors()),
-            number_format($summary->getNbFailures()),
+            number_format($summary->getNbFailures())
         )));
     }
 

--- a/lib/Progress/Logger/PhpBenchLogger.php
+++ b/lib/Progress/Logger/PhpBenchLogger.php
@@ -92,7 +92,7 @@ abstract class PhpBenchLogger extends NullLogger
             }
            
             if ($summary->getNbAssertions()) {
-                return sprintf('<greenbg>%s</>', $message);
+                return sprintf('<success>%s</>', $message);
             }
 
             return $message;

--- a/tests/Benchmark/ExpresionParserBench.php
+++ b/tests/Benchmark/ExpresionParserBench.php
@@ -27,7 +27,6 @@ class ExpresionParserBench
      * @ParamProviders({"provideExpressions"})
      *
      * @param array<mixed> $params
-     * @Assert("variant.mode < 1 microsecond +/- 10 minutes")
      */
     public function benchEvaluate(array $params): void
     {

--- a/tests/Benchmark/ExpresionParserBench.php
+++ b/tests/Benchmark/ExpresionParserBench.php
@@ -27,6 +27,7 @@ class ExpresionParserBench
      * @ParamProviders({"provideExpressions"})
      *
      * @param array<mixed> $params
+     * @Assert("variant.mode < 1 microsecond +/- 10 minutes")
      */
     public function benchEvaluate(array $params): void
     {

--- a/tests/Unit/Model/SuiteTest.php
+++ b/tests/Unit/Model/SuiteTest.php
@@ -110,6 +110,7 @@ class SuiteTest extends TestCase
         $this->variant1->getRejectCount()->willReturn(0);
         $this->variant1->getAssertionResults()->willReturn(new VariantAssertionResults($this->variant1->reveal(), []));
         $this->variant1->getErrorStack()->willReturn($errorStack->reveal());
+        $errorStack->count()->willReturn(0);
 
         $suite = $this->createSuite([
             $this->bench1->reveal(),

--- a/tests/Unit/Model/SummaryTest.php
+++ b/tests/Unit/Model/SummaryTest.php
@@ -16,6 +16,7 @@ use PhpBench\Assertion\VariantAssertionResults;
 use PhpBench\Environment\Information;
 use PhpBench\Math\Distribution;
 use PhpBench\Model\Benchmark;
+use PhpBench\Model\ErrorStack;
 use PhpBench\Model\Subject;
 use PhpBench\Model\Suite;
 use PhpBench\Model\Summary;
@@ -126,6 +127,7 @@ class SummaryTest extends TestCase
         $this->variant1->getRevolutions()->willReturn(10);
         $this->variant1->getSubject()->willReturn($this->subject1->reveal());
         $this->variant1->getAssertionResults()->willReturn(new VariantAssertionResults($this->variant1->reveal(), []));
+        $this->variant1->getErrorStack()->willReturn(new ErrorStack($this->variant1->reveal(), []));
         $this->stats->getIterator()->willReturn(new \ArrayIterator([
             'min' => '1',
             'max' => '2',

--- a/tests/Unit/Progress/Logger/PhpBenchLoggerTest.php
+++ b/tests/Unit/Progress/Logger/PhpBenchLoggerTest.php
@@ -179,8 +179,12 @@ abstract class PhpBenchLoggerTest extends TestCase
         $meanRelStDev = 231;
         $nbFailures = 0;
         $nbWarnings = 0;
+        $nbAssertions = 0;
 
         $this->summary->getNbSubjects()->willReturn($nbSubjects);
+        $this->summary->getNbAssertions()->willReturn(0);
+        $this->summary->getNbErrors()->willReturn(0);
+
         $this->summary->getNbIterations()->willReturn($nbIterations);
         $this->summary->getNbRevolutions()->willReturn($nbRevolutions);
         $this->summary->getNbRejects()->willReturn($nbRejects);


### PR DESCRIPTION
Show PHPUnit style success indicator when finishing the run:

![image](https://user-images.githubusercontent.com/530801/100785625-d4d45500-3408-11eb-8f86-1c5dae7d8ee3.png)

... and removes some of the less interesting information from this summary line (nb. itreations and revs).

![image](https://user-images.githubusercontent.com/530801/100785817-1e24a480-3409-11eb-81b9-5f84742774dc.png)
