### PR TITLE
refactor: SC2086 and SC2154 error of shellcheck

### DIFF
--- a/.travis/before-deploy.sh
+++ b/.travis/before-deploy.sh
@@ -7,7 +7,12 @@ export PATH=.:$PATH
 sed -ie '/^\/phpbench.phar*/d'  .gitignore
 
 # Extract the private key (needed to sign the PHAR)
-openssl aes-256-cbc -K $encrypted_d58d55177063_key -iv $encrypted_d58d55177063_iv -in .travis/secrets.tar.enc -out .travis/secrets.tar -d
+openssl aes-256-cbc \
+    -K "${encrypted_d58d55177063_key:?'Encrypted key not assigned'}" \
+    -iv "${encrypted_d58d55177063_iv:?'Encrypted iv not assigned'}" \
+    -in .travis/secrets.tar.enc \
+    -out .travis/secrets.tar \
+    -d
 tar xvf .travis/secrets.tar -C .travis
 
 # Install PHAR dependencies and remove strip other dev deps.

--- a/.travis/xdebug.sh
+++ b/.travis/xdebug.sh
@@ -11,12 +11,12 @@ config="/home/travis/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.i
 
 function xdebug-disable() {
     if [[ -f $config ]]; then
-        mv $config "$config.bak"
+        mv "$config" "$config.bak"
     fi
 }
 
 function xdebug-enable() {
     if [[ -f "$config.bak" ]]; then
-        mv "$config.bak" $config
+        mv "$config.bak" "$config"
     fi
 }


### PR DESCRIPTION
Small fixes for shell script static analysis, [Shell Check](https://github.com/koalaman/shellcheck).
- [SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086): Double quote to prevent globbing and word splitting.
- [SC2154](https://github.com/koalaman/shellcheck/wiki/SC2154): Throw error if the referenced variable is  not assigned.