### PR TITLE
Fix .phar compilation during release

### DIFF
--- a/.github/workflows/release-phar.yml
+++ b/.github/workflows/release-phar.yml
@@ -8,7 +8,7 @@ name: Append phpbench.phar to release
 jobs:
   build:
     name: Compile and upload Phar
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/release-phar.yml
+++ b/.github/workflows/release-phar.yml
@@ -13,10 +13,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Compile phpbench.phar
+      - name: Set PHP 7.3
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.3'
+
+      - name: Compile phpbench.phar
         run: |
           composer install
           wget https://github.com/box-project/box/releases/download/3.9.1/box.phar

--- a/.github/workflows/release-phar.yml
+++ b/.github/workflows/release-phar.yml
@@ -18,6 +18,7 @@ jobs:
           composer install
           wget https://github.com/box-project/box/releases/download/3.9.1/box.phar
           php box.phar compile -c box.json.gh-release
+
       - name: Check existence of compiled .phar
         run: test -e phpbench.phar && exit 0 || exit 10
 

--- a/.github/workflows/release-phar.yml
+++ b/.github/workflows/release-phar.yml
@@ -14,6 +14,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Compile phpbench.phar
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.3'
         run: |
           composer install
           wget https://github.com/box-project/box/releases/download/3.9.1/box.phar


### PR DESCRIPTION
Due Github Actions updated PHP version to the latest (8.0) in their images, latest release failed and didn't uploaded `.phar` into it.

Working example - https://github.com/Jeckerson/phpbench/runs/1622156785?check_suite_focus=true