### PR TITLE
Improve progress output when baseline (reference) is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Backward compatiblity breaks:
 - `--uuid` renamed to `--ref` and `tag:` prefix removed #740
 - No warnings - if assertion fails within tolerance zone then it is OK
 
+Improvements:
+
+- Show difference to baseline in progress loggers.
+- Highlight assertion failures.
+
 1.0.0-alpha-4
 -------------
 

--- a/lib/Console/Command/RunCommand.php
+++ b/lib/Console/Command/RunCommand.php
@@ -153,7 +153,6 @@ EOT
             }
         }
 
-
         $this->reportHandler->reportsFromInput($input, $output, $collection);
 
         if ($suite->getErrorStacks()) {

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -197,6 +197,7 @@ class CoreExtension implements ExtensionInterface
             $output = new ConsoleOutput();
             $output->getFormatter()->setStyle('success', new OutputFormatterStyle('black', 'green', []));
             $output->getFormatter()->setStyle('baseline', new OutputFormatterStyle('cyan', null, []));
+            $output->getFormatter()->setStyle('failure', new OutputFormatterStyle('white', 'red', []));
 
             return $output;
         });

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -119,6 +119,8 @@ class CoreExtension implements ExtensionInterface
     public const PARAM_REMOTE_SCRIPT_PATH = 'remote_script_path';
     public const PARAM_REMOTE_SCRIPT_REMOVE = 'remote_script_remove';
     public const PARAM_DISABLE_OUTPUT = 'console.disable_output';
+    public const PARAM_PROGRESS_SUMMARY_FORMAT = 'progress_summary_variant_format';
+    public const PARAM_PROGRESS_SUMMARY_BASELINE_FORMAT = 'progress_summary_baseline_format';
 
     public const TAG_EXECUTOR = 'benchmark_executor';
     public const TAG_CONSOLE_COMMAND = 'console.command';
@@ -135,8 +137,6 @@ class CoreExtension implements ExtensionInterface
     private const SERVICE_REGISTRY_LOGGER = 'progress_logger.registry';
     private const SERVICE_REGISTRY_RENDERER = 'report.registry.renderer';
     private const SERVICE_VARIANT_SUMMARY_FORMATTER = 'progress_logger.variant_summary_formatter';
-    private const PARAM_PROGRESS_SUMMARY_FORMAT = 'progress_summary_variant_format';
-    private const PARAM_PROGRESS_SUMMARY_BASELINE_FORMAT = 'progress_summary_baseline_format';
 
     public function configure(OptionsResolver $resolver): void
     {
@@ -189,6 +189,8 @@ class CoreExtension implements ExtensionInterface
         $resolver->setAllowedTypes(self::PARAM_REMOTE_SCRIPT_REMOVE, ['bool']);
         $resolver->setAllowedTypes(self::PARAM_REMOTE_SCRIPT_PATH, ['string', 'null']);
         $resolver->setAllowedTypes(self::PARAM_DISABLE_OUTPUT, ['bool']);
+        $resolver->setAllowedTypes(self::PARAM_PROGRESS_SUMMARY_FORMAT, ['string']);
+        $resolver->setAllowedTypes(self::PARAM_PROGRESS_SUMMARY_BASELINE_FORMAT, ['string']);
     }
 
     public function load(Container $container): void

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -195,9 +195,13 @@ class CoreExtension implements ExtensionInterface
             }
 
             $output = new ConsoleOutput();
+
             $output->getFormatter()->setStyle('success', new OutputFormatterStyle('black', 'green', []));
             $output->getFormatter()->setStyle('baseline', new OutputFormatterStyle('cyan', null, []));
-            $output->getFormatter()->setStyle('failure', new OutputFormatterStyle('white', 'red', []));
+            $output->getFormatter()->setStyle('result-neutral', new OutputFormatterStyle('cyan', null, []));
+            $output->getFormatter()->setStyle('result-good', new OutputFormatterStyle('green', null, []));
+            $output->getFormatter()->setStyle('result-none', new OutputFormatterStyle(null, null, []));
+            $output->getFormatter()->setStyle('result-failure', new OutputFormatterStyle('white', 'red', []));
 
             return $output;
         });

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -196,6 +196,7 @@ class CoreExtension implements ExtensionInterface
 
             $output = new ConsoleOutput();
             $output->getFormatter()->setStyle('success', new OutputFormatterStyle('black', 'green', []));
+            $output->getFormatter()->setStyle('baseline', new OutputFormatterStyle('cyan', null, []));
 
             return $output;
         });

--- a/lib/Math/Ratio.php
+++ b/lib/Math/Ratio.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace PhpBench\Math;
-
-class Ratio
-{
-}

--- a/lib/Progress/Logger/BlinkenLogger.php
+++ b/lib/Progress/Logger/BlinkenLogger.php
@@ -22,7 +22,7 @@ class BlinkenLogger extends AnsiLogger
     /**
      * Number of measurements to show per row.
      */
-    const NUMBER_COLS = 15;
+    const NUMBER_COLS = 10;
 
     const INDENT = 4;
 
@@ -105,10 +105,6 @@ class BlinkenLogger extends AnsiLogger
             return;
         }
 
-        if ($variant->getAssertionResults()->hasFailures()) {
-            $this->output->write(' <error>FAIL</error>');
-        }
-
         $this->rejects = [];
 
         foreach ($variant->getRejects() as $reject) {
@@ -121,9 +117,7 @@ class BlinkenLogger extends AnsiLogger
             return;
         }
 
-        $this->output->write(
-            ' = ' . $this->formatIterationsShortSummary($variant)
-        );
+        $this->output->write(' ' . $this->formatIterationsShortSummary($variant));
         $this->output->write(PHP_EOL);
     }
 

--- a/lib/Progress/Logger/BlinkenLogger.php
+++ b/lib/Progress/Logger/BlinkenLogger.php
@@ -121,10 +121,9 @@ class BlinkenLogger extends AnsiLogger
             return;
         }
 
-        $this->output->write(sprintf(
-            ' <comment>%s</comment>',
-            $this->formatIterationsShortSummary($variant)
-        ));
+        $this->output->write(
+            ' = ' . $this->formatIterationsShortSummary($variant)
+        );
         $this->output->write(PHP_EOL);
     }
 

--- a/lib/Progress/Logger/DotsLogger.php
+++ b/lib/Progress/Logger/DotsLogger.php
@@ -16,19 +16,39 @@ use PhpBench\Model\Benchmark;
 use PhpBench\Model\Iteration;
 use PhpBench\Model\Suite;
 use PhpBench\Model\Variant;
+use PhpBench\Progress\VariantSummaryFormatter;
 use PhpBench\Util\TimeUnit;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class DotsLogger extends PhpBenchLogger
 {
+    /**
+     * @var bool
+     */
     private $showBench;
+
+    /**
+     * @var string
+     */
     private $buffer;
+
+    /**
+     * @var bool
+     */
     private $isCi = false;
+
+    /**
+     * @var bool
+     */
     private $firstTime = true;
 
-    public function __construct(OutputInterface $output, TimeUnit $timeUnit, $showBench = false)
-    {
-        parent::__construct($output, $timeUnit);
+    public function __construct(
+        OutputInterface $output,
+        VariantSummaryFormatter $formatter,
+        TimeUnit $timeUnit,
+        bool $showBench = false
+    ) {
+        parent::__construct($output, $formatter, $timeUnit);
         $this->showBench = $showBench;
 
         // if we are in travis, don't do any fancy stuff.

--- a/lib/Progress/Logger/HistogramLogger.php
+++ b/lib/Progress/Logger/HistogramLogger.php
@@ -183,7 +183,7 @@ class HistogramLogger extends AnsiLogger
         $this->drawBlocks($freqs);
 
         $this->output->write(sprintf(
-            '] +%sσ <comment>%s</comment>',
+            '] +%sσ %s</comment>',
             $sigma,
             $variant->isComputed() ? $this->formatIterationsShortSummary($variant) : ''
         ));

--- a/lib/Progress/Logger/PhpBenchLogger.php
+++ b/lib/Progress/Logger/PhpBenchLogger.php
@@ -12,12 +12,14 @@
 
 namespace PhpBench\Progress\Logger;
 
+use PhpBench\Math\Statistics;
 use PhpBench\Model\Iteration;
 use PhpBench\Model\Result\TimeResult;
 use PhpBench\Model\Suite;
 use PhpBench\Model\Summary;
 use PhpBench\Model\Variant;
 use PhpBench\PhpBench;
+use PhpBench\Progress\VariantSummaryFormatter;
 use PhpBench\Util\TimeUnit;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -161,40 +163,12 @@ abstract class PhpBenchLogger extends NullLogger
 
     public function formatIterationsFullSummary(Variant $variant): string
     {
-        $subject = $variant->getSubject();
-        $stats = $variant->getStats();
-        $timeUnit = $this->timeUnit->resolveDestUnit($variant->getSubject()->getOutputTimeUnit());
-        $mode = $this->timeUnit->resolveMode($subject->getOutputMode());
-        $precision = $this->timeUnit->resolvePrecision($subject->getOutputTimePrecision());
-
-        return sprintf(
-            "%s[μ Mo]/r: %s %s (%s) [μSD μRSD]/r: %s %s%%%s",
-
-            $variant->getAssertionResults()->hasFailures() ? '<error>' : '',
-            $this->timeUnit->format($stats->getMean(), $timeUnit, $mode, $precision, false),
-            $this->timeUnit->format($stats->getMode(), $timeUnit, $mode, $precision, false),
-            $this->timeUnit->getDestSuffix($timeUnit, $mode),
-            $this->timeUnit->format($stats->getStdev(), $timeUnit, TimeUnit::MODE_TIME),
-            number_format($stats->getRstdev(), 2),
-            $variant->getAssertionResults()->hasFailures() ? '</error>' : ''
-        );
+        return (new VariantSummaryFormatter($this->timeUnit))->formatVariant($variant);
     }
 
     public function formatIterationsShortSummary(Variant $variant): string
     {
-        $subject = $variant->getSubject();
-        $stats = $variant->getStats();
-        $timeUnit = $this->timeUnit->resolveDestUnit($variant->getSubject()->getOutputTimeUnit());
-        $mode = $this->timeUnit->resolveMode($subject->getOutputMode());
-        $precision = $this->timeUnit->resolvePrecision($subject->getOutputTimePrecision());
-
-        return sprintf(
-            '[μ Mo]/r: %s %s μRSD/r: %s%%',
-
-            $this->timeUnit->format($stats->getMean(), $timeUnit, $mode, $precision, false),
-            $this->timeUnit->format($stats->getMode(), $timeUnit, $mode, $precision, false),
-            number_format($stats->getRstdev(), 2)
-        );
+        return (new VariantSummaryFormatter($this->timeUnit))->formatVariant($variant);
     }
 
     protected function formatIterationTime(Iteration $iteration): string

--- a/lib/Progress/Logger/PhpBenchLogger.php
+++ b/lib/Progress/Logger/PhpBenchLogger.php
@@ -67,20 +67,13 @@ abstract class PhpBenchLogger extends NullLogger
         $this->listFailures($suite);
 
         $this->output->writeln(sprintf(
-            '(best [mean mode] worst) = %s [%s %s] %s (%s)',
-            number_format($this->timeUnit->toDestUnit($summary->getMinTime()), 3),
-            number_format($this->timeUnit->toDestUnit($summary->getMeanTime()), 3),
-            number_format($this->timeUnit->toDestUnit($summary->getModeTime()), 3),
-            number_format($this->timeUnit->toDestUnit($summary->getMaxTime()), 3),
-            $this->timeUnit->getDestSuffix()
-        ));
-
-        $this->output->writeln(sprintf(
             '⅀T: %s μSD/r %s μRSD/r: %s%%',
             $this->timeUnit->format($summary->getTotalTime(), null, TimeUnit::MODE_TIME),
             $this->timeUnit->format($summary->getMeanStDev(), null, TimeUnit::MODE_TIME),
             number_format($summary->getMeanRelStDev(), 3)
         ));
+
+        $this->output->write("\n");
 
         $this->output->writeln((function (Summary $summary, string $message) {
             if ($summary->getNbFailures() || $summary->getNbErrors()) {

--- a/lib/Progress/Logger/PhpBenchLogger.php
+++ b/lib/Progress/Logger/PhpBenchLogger.php
@@ -34,10 +34,19 @@ abstract class PhpBenchLogger extends NullLogger
      */
     public $output;
 
-    public function __construct(OutputInterface $output, TimeUnit $timeUnit = null)
-    {
+    /**
+     * @var VariantSummaryFormatter
+     */
+    private $formatter;
+
+    public function __construct(
+        OutputInterface $output,
+        VariantSummaryFormatter $formatter,
+        TimeUnit $timeUnit = null
+    ) {
         $this->timeUnit = $timeUnit;
         $this->output = $output;
+        $this->formatter = $formatter;
     }
 
     public function startSuite(Suite $suite): void
@@ -155,12 +164,12 @@ abstract class PhpBenchLogger extends NullLogger
 
     public function formatIterationsFullSummary(Variant $variant): string
     {
-        return (new VariantSummaryFormatter($this->timeUnit))->formatVariant($variant);
+        return $this->formatter->formatVariant($variant);
     }
 
     public function formatIterationsShortSummary(Variant $variant): string
     {
-        return (new VariantSummaryFormatter($this->timeUnit))->formatVariant($variant);
+        return $this->formatter->formatVariant($variant);
     }
 
     protected function formatIterationTime(Iteration $iteration): string

--- a/lib/Progress/Logger/PhpBenchLogger.php
+++ b/lib/Progress/Logger/PhpBenchLogger.php
@@ -12,7 +12,6 @@
 
 namespace PhpBench\Progress\Logger;
 
-use PhpBench\Math\Statistics;
 use PhpBench\Model\Iteration;
 use PhpBench\Model\Result\TimeResult;
 use PhpBench\Model\Suite;

--- a/lib/Progress/VariantSummaryFormatter.php
+++ b/lib/Progress/VariantSummaryFormatter.php
@@ -58,8 +58,7 @@ final class VariantSummaryFormatter
         TimeUnit $timeUnit,
         string $format = self::DEFAULT_FORMAT,
         string $baselineFormat = self::BASELINE_FORMAT
-    )
-    {
+    ) {
         $this->format = $format;
         $this->timeUnit = $timeUnit;
         $this->baselineFormat = $baselineFormat;
@@ -134,6 +133,7 @@ final class VariantSummaryFormatter
             if (!$results->count()) {
                 return self::FORMAT_NONE;
             }
+
             if ($results->failures()->count()) {
                 return self::FORMAT_FAILURE;
             }

--- a/lib/Progress/VariantSummaryFormatter.php
+++ b/lib/Progress/VariantSummaryFormatter.php
@@ -15,7 +15,7 @@ final class VariantSummaryFormatter
 
     const NOT_APPLICABLE = 'n/a';
     const FORMAT_NO_CHANGE = 'fg=cyan';
-    const FORMAT_BAD_CHANGE = 'bg=red;fg=white';
+    const FORMAT_FAILURE = 'failure';
     const FORMAT_GOOD_CHANGE = 'fg=green';
 
     /**
@@ -53,7 +53,7 @@ final class VariantSummaryFormatter
         };
 
         $tokens = [
-            'time_unit' => $this->timeUnit->getDestSuffix($timeUnit),
+            'time_unit' => $this->timeUnit->getDestSuffix($timeUnit, $mode),
             'variant.min' => self::NOT_APPLICABLE,
             'variant.max' => self::NOT_APPLICABLE,
             'variant.mean' => self::NOT_APPLICABLE,
@@ -92,6 +92,7 @@ final class VariantSummaryFormatter
     private function populateFromVariant(Closure $f, string $prefix, Variant $variant): array
     {
         $stats = $variant->getStats();
+
         return [
             $prefix.'.min' => $f($stats->getMin()),
             $prefix.'.max' => $f($stats->getMax()),
@@ -114,12 +115,13 @@ final class VariantSummaryFormatter
 
         $tokens['percent_difference'] = (function (float $diff) {
             $prefix = $diff > 0 ? '+' : '';
+
             return $prefix .number_format($diff, 2);
         })($diff);
 
         $tokens['diff_format'] = (function (VariantAssertionResults $results, float $diff) {
             if ($results->failures()->count()) {
-                return self::FORMAT_BAD_CHANGE;
+                return self::FORMAT_FAILURE;
             }
 
             if ($results->tolerations()->count()) {
@@ -127,7 +129,6 @@ final class VariantSummaryFormatter
             }
 
             return self::FORMAT_GOOD_CHANGE;
-
         })($variant->getAssertionResults(), $diff);
 
         return $tokens;

--- a/lib/Progress/VariantSummaryFormatter.php
+++ b/lib/Progress/VariantSummaryFormatter.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace PhpBench\Progress;
+
+use Closure;
+use PhpBench\Math\Statistics;
+use PhpBench\Model\Variant;
+use PhpBench\Util\TimeUnit;
+
+final class VariantSummaryFormatter
+{
+    const DEFAULT_FORMAT = '%variant.mode% %time_unit% (±%variant.rstdev%%)';
+    const BASELINE_FORMAT = '%variant.mode% vs. <baseline>%baseline.mode%</> (%time_unit%) (±%variant.rstdev%%) <%diff_format%>%percent_difference%%</>';
+
+    const NOT_APPLICABLE = 'n/a';
+    const FORMAT_NO_CHANGE = 'fg=cyan';
+    const FORMAT_BAD_CHANGE = 'fg=red';
+    const FORMAT_GOOD_CHANGE = 'fg=green';
+
+    /**
+     * @var string
+     */
+    private $format;
+
+    /**
+     * @var TimeUnit
+     */
+    private $timeUnit;
+
+    /**
+     * @var string
+     */
+    private $baselineFormat;
+
+    public function __construct(TimeUnit $timeUnit, string $format = self::DEFAULT_FORMAT, string $baselineFormat = self::BASELINE_FORMAT)
+    {
+        $this->format = $format;
+        $this->timeUnit = $timeUnit;
+        $this->baselineFormat = $baselineFormat;
+    }
+
+    public function formatVariant(Variant $variant): string
+    {
+        $subject = $variant->getSubject();
+
+        $timeUnit = $this->timeUnit->resolveDestUnit($variant->getSubject()->getOutputTimeUnit());
+        $mode = $this->timeUnit->resolveMode($subject->getOutputMode());
+        $precision = $this->timeUnit->resolvePrecision($subject->getOutputTimePrecision());
+
+        $timeFormatter = function (float $time) use ($timeUnit, $mode, $precision): string {
+            return $this->timeUnit->format($time, $timeUnit, $mode, $precision, false);
+        };
+
+        $tokens = [
+            'time_unit' => $this->timeUnit->getDestSuffix($timeUnit),
+            'variant.min' => self::NOT_APPLICABLE,
+            'variant.max' => self::NOT_APPLICABLE,
+            'variant.mean' => self::NOT_APPLICABLE,
+            'variant.mode' => self::NOT_APPLICABLE,
+            'variant.stdev' => self::NOT_APPLICABLE,
+            'variant.rstdev' => self::NOT_APPLICABLE,
+            'variant.variance' => self::NOT_APPLICABLE,
+            'baseline.min' => self::NOT_APPLICABLE,
+            'baseline.max' => self::NOT_APPLICABLE,
+            'baseline.mean' => self::NOT_APPLICABLE,
+            'baseline.mode' => self::NOT_APPLICABLE,
+            'baseline.stdev' => self::NOT_APPLICABLE,
+            'baseline.rstdev' => self::NOT_APPLICABLE,
+            'baseline.variance' => self::NOT_APPLICABLE,
+            'percent_difference' => self::NOT_APPLICABLE,
+            'diff_format' => self::FORMAT_NO_CHANGE,
+        ];
+
+        $tokens = array_merge($tokens, $this->populateFromVariant($timeFormatter, 'variant', $variant));
+
+        if ($variant->getBaseline()) {
+            $tokens = array_merge($tokens, $this->getBaselineTokens($timeFormatter, $variant, $variant->getBaseline()));
+        }
+
+        return strtr($this->resolveFormat($variant), (array)array_combine(
+            array_map(function (string $token) {
+                return '%' . $token . '%';
+            }, array_keys($tokens)),
+            array_values($tokens)
+        ));
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function populateFromVariant(Closure $f, string $prefix, Variant $variant): array
+    {
+        $stats = $variant->getStats();
+        return [
+            $prefix.'.min' => $f($stats->getMin()),
+            $prefix.'.max' => $f($stats->getMax()),
+            $prefix.'.mean' => $f($stats->getMean()),
+            $prefix.'.mode' => $f($stats->getMode()),
+            $prefix.'.stdev' => $f($stats->getStdev()),
+            $prefix.'.rstdev' => number_format($stats->getRstdev(), 2),
+            $prefix.'.variance' => $f($stats->getVariance()),
+        ];
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function getBaselineTokens(Closure $timeFormatter, Variant $variant, Variant $baseline): array
+    {
+        $stats = $baseline->getStats();
+        $tokens = $this->populateFromVariant($timeFormatter, 'baseline', $baseline);
+        $diff = Statistics::percentageDifference($baseline->getStats()->getMode(), $variant->getStats()->getMode());
+
+        $tokens['percent_difference'] = (function (float $diff) {
+            $prefix = $diff > 0 ? '+' : '';
+            return $prefix .number_format($diff, 2);
+        })($diff);
+
+        $tokens['diff_format'] = (function (float $diff, float $rstdev) {
+            // difference falls within margin of error
+            if (abs($diff) <= abs($rstdev)) {
+                return self::FORMAT_NO_CHANGE;
+            }
+
+            if ($diff > 0) {
+                return self::FORMAT_BAD_CHANGE;
+            }
+            return self::FORMAT_GOOD_CHANGE;
+        })($diff, $stats->getRstdev());
+
+        return $tokens;
+    }
+
+    private function resolveFormat(Variant $variant): string
+    {
+        if ($variant->getBaseline()) {
+            return $this->baselineFormat;
+        }
+
+        return $this->format;
+    }
+}

--- a/lib/Util/TimeUnit.php
+++ b/lib/Util/TimeUnit.php
@@ -111,8 +111,7 @@ class TimeUnit
         string $destUnit = self::MICROSECONDS,
         string $mode = self::MODE_TIME,
         int $precision = 3
-    )
-    {
+    ) {
         $this->sourceUnit = $sourceUnit;
         $this->destUnit = $destUnit;
         $this->mode = $mode;

--- a/lib/Util/TimeUnit.php
+++ b/lib/Util/TimeUnit.php
@@ -106,7 +106,12 @@ class TimeUnit
      */
     private $precision;
 
-    public function __construct(string $sourceUnit = self::MICROSECONDS, string $destUnit = self::MICROSECONDS, string $mode = self::MODE_TIME, int $precision = 3)
+    public function __construct(
+        string $sourceUnit = self::MICROSECONDS,
+        string $destUnit = self::MICROSECONDS,
+        string $mode = self::MODE_TIME,
+        int $precision = 3
+    )
     {
         $this->sourceUnit = $sourceUnit;
         $this->destUnit = $destUnit;

--- a/tests/Benchmark/ExpressionParserBench.php
+++ b/tests/Benchmark/ExpressionParserBench.php
@@ -10,7 +10,7 @@ use PhpBench\Assertion\ExpressionParser;
  * @Iterations(3)
  * @BeforeMethods({"setUp"})
  * @OutputTimeUnit("milliseconds")
- * @Assert("variant.mode = baseline.mode +/- 10%")
+ * @Assert("variant.mode = baseline.mode +/- 5%")
  */
 class ExpressionParserBench
 {

--- a/tests/System/RunTest.php
+++ b/tests/System/RunTest.php
@@ -21,7 +21,7 @@ class RunTest extends SystemTestCase
     {
         $process = $this->phpbench('run --verbose --config=env/config_valid/phpbench.json');
         $this->assertExitCode(0, $process);
-        $this->assertStringContainsString('best [mean mode] worst', $process->getOutput());
+        $this->assertStringContainsString('Subjects', $process->getOutput());
     }
 
     /**
@@ -32,7 +32,7 @@ class RunTest extends SystemTestCase
     {
         $process = $this->phpbench('run', 'env/config_valid');
         $this->assertExitCode(0, $process);
-        $this->assertStringContainsString('best [mean mode] worst', $process->getOutput());
+        $this->assertStringContainsString('Subjects', $process->getOutput());
     }
 
     /**
@@ -42,7 +42,7 @@ class RunTest extends SystemTestCase
     {
         $process = $this->phpbench('run', 'env/config_dist');
         $this->assertExitCode(0, $process);
-        $this->assertStringContainsString('best [mean mode] worst', $process->getOutput());
+        $this->assertStringContainsString('Subjects', $process->getOutput());
     }
 
     /**
@@ -249,7 +249,7 @@ class RunTest extends SystemTestCase
         );
 
         $this->assertExitCode(0, $process);
-        $this->assertStringContainsString('(ms)', $process->getOutput());
+        $this->assertStringContainsString('ms', $process->getOutput());
     }
 
     /**
@@ -262,7 +262,7 @@ class RunTest extends SystemTestCase
         );
 
         $this->assertExitCode(0, $process);
-        $this->assertStringContainsString('(ops/μs)', $process->getOutput());
+        $this->assertStringContainsString('ops/μs', $process->getOutput());
     }
 
     /**
@@ -317,7 +317,7 @@ class RunTest extends SystemTestCase
 
         $this->assertExitCode(0, $process);
         $output = $process->getOutput();
-        $this->assertStringContainsString('best [mean mode] worst', $output);
+        $this->assertStringContainsString('Subjects', $output);
     }
 
     /**

--- a/tests/Unit/Progress/Logger/BlinkenLoggerTest.php
+++ b/tests/Unit/Progress/Logger/BlinkenLoggerTest.php
@@ -161,6 +161,6 @@ class BlinkenLoggerTest extends TestCase
         $this->variant->computeStats();
 
         $this->logger->variantEnd($this->variant);
-        $this->assertStringContainsString('RSD/r: 0.00%', $this->output->fetch());
+        $this->assertStringContainsString('±0.00%', $this->output->fetch());
     }
 }

--- a/tests/Unit/Progress/Logger/BlinkenLoggerTest.php
+++ b/tests/Unit/Progress/Logger/BlinkenLoggerTest.php
@@ -12,30 +12,16 @@
 
 namespace PhpBench\Tests\Unit\Progress\Logger;
 
-use PhpBench\Assertion\AssertionResult;
 use PhpBench\Model\Benchmark;
 use PhpBench\Model\ParameterSet;
-use PhpBench\Model\Result\TimeResult;
 use PhpBench\Model\Subject;
 use PhpBench\Model\Variant;
 use PhpBench\Progress\Logger\BlinkenLogger;
-use PhpBench\Tests\TestCase;
-use PhpBench\Tests\Util\TestUtil;
 use PhpBench\Util\TimeUnit;
-use Symfony\Component\Console\Output\BufferedOutput;
 
-class BlinkenLoggerTest extends TestCase
+class BlinkenLoggerTest extends LoggerTestCase
 {
     const ASSERTION_FAILURE_MESSAGE = 'Failure message';
-
-    /**
-     * @var BufferedOutput
-     */
-    private $output;
-    /**
-     * @var TimeUnit
-     */
-    private $timeUnit;
     /**
      * @var BlinkenLogger
      */
@@ -55,10 +41,10 @@ class BlinkenLoggerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->output = new BufferedOutput();
+        parent::setUp();
         $this->timeUnit = new TimeUnit(TimeUnit::MICROSECONDS, TimeUnit::MILLISECONDS);
 
-        $this->logger = new BlinkenLogger($this->output, $this->timeUnit);
+        $this->logger = new BlinkenLogger($this->output, $this->variantFormatter, $this->timeUnit);
         $this->benchmark = $this->prophesize(Benchmark::class);
         $this->subject = $this->prophesize(Subject::class);
         $this->variant = new Variant(
@@ -130,37 +116,5 @@ class BlinkenLoggerTest extends TestCase
         $this->variant->setException(new \Exception('foo'));
         $this->logger->variantEnd($this->variant);
         $this->assertStringContainsString('ERROR', $this->output->fetch());
-    }
-
-    /**
-     * It should show an error if the iteration has an exception.
-     */
-    public function testIterationFailure()
-    {
-        foreach ($this->variant as $iteration) {
-            $iteration->setResult(new TimeResult(10));
-        }
-        $this->variant->getAssertionResults()->add(AssertionResult::fail(self::ASSERTION_FAILURE_MESSAGE));
-        $this->variant->addIteration($iteration);
-        $this->variant->computeStats();
-        $this->logger->variantEnd($this->variant);
-        $this->assertStringContainsString('FAIL', $this->output->fetch());
-    }
-
-    /**
-     * It should show statistics when an iteration is completed (and there
-     * were no rejections).
-     */
-    public function testIterationEndStats()
-    {
-        foreach ($this->variant as $iteration) {
-            foreach (TestUtil::createResults(10, 10) as $result) {
-                $iteration->setResult($result);
-            }
-        }
-        $this->variant->computeStats();
-
-        $this->logger->variantEnd($this->variant);
-        $this->assertStringContainsString('±0.00%', $this->output->fetch());
     }
 }

--- a/tests/Unit/Progress/Logger/HistogramLoggerTest.php
+++ b/tests/Unit/Progress/Logger/HistogramLoggerTest.php
@@ -18,19 +18,14 @@ use PhpBench\Model\ParameterSet;
 use PhpBench\Model\Subject;
 use PhpBench\Model\Variant;
 use PhpBench\Progress\Logger\HistogramLogger;
-use PhpBench\Tests\TestCase;
 use PhpBench\Tests\Util\TestUtil;
-use PhpBench\Util\TimeUnit;
-use Symfony\Component\Console\Output\BufferedOutput;
 
-class HistogramLoggerTest extends TestCase
+class HistogramLoggerTest extends LoggerTestCase
 {
     protected function setUp(): void
     {
-        $this->output = new BufferedOutput();
-        $this->timeUnit = new TimeUnit(TimeUnit::MICROSECONDS, TimeUnit::MILLISECONDS);
-
-        $this->logger = new HistogramLogger($this->output, $this->timeUnit);
+        parent::setUp();
+        $this->logger = new HistogramLogger($this->output, $this->variantFormatter, $this->timeUnit);
         $this->benchmark = $this->prophesize(Benchmark::class);
         $this->subject = $this->prophesize(Subject::class);
         $this->iteration = $this->prophesize(Iteration::class);
@@ -124,7 +119,7 @@ class HistogramLoggerTest extends TestCase
         $this->logger->variantEnd($this->variant);
         $display = $this->output->fetch();
         $this->assertStringContainsString(
-            '1  (σ = 0.000ms ) -2σ [        █        ] +2σ 0.010 ms (±0.00%)',
+            '1  (σ = 0.000ms ) -2σ [        █        ] +2σ summray',
             $display
         );
     }

--- a/tests/Unit/Progress/Logger/HistogramLoggerTest.php
+++ b/tests/Unit/Progress/Logger/HistogramLoggerTest.php
@@ -124,7 +124,7 @@ class HistogramLoggerTest extends TestCase
         $this->logger->variantEnd($this->variant);
         $display = $this->output->fetch();
         $this->assertStringContainsString(
-            '1  (σ = 0.000ms ) -2σ [        █        ] +2σ [μ Mo]/r: 0.010 0.010 μRSD/r: 0.00%',
+            '1  (σ = 0.000ms ) -2σ [        █        ] +2σ 0.010 ms (±0.00%)',
             $display
         );
     }

--- a/tests/Unit/Progress/Logger/LoggerTestCase.php
+++ b/tests/Unit/Progress/Logger/LoggerTestCase.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace PhpBench\Tests\Unit\Progress\Logger;
+
+use PhpBench\Progress\VariantSummaryFormatter;
+use PhpBench\Tests\TestCase;
+use PhpBench\Util\TimeUnit;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class LoggerTestCase extends TestCase
+{
+    /**
+     * @var TimeUnit
+     */
+    protected $timeUnit;
+
+    /**
+     * @var VariantSummaryFormatter
+     */
+    protected $variantFormatter;
+
+    /**
+     * @var BufferedOutput
+     */
+    protected $output;
+
+    protected function setUp(): void
+    {
+        $this->output = new BufferedOutput();
+
+        $this->timeUnit = new TimeUnit(TimeUnit::MICROSECONDS, TimeUnit::MILLISECONDS);
+        $this->variantFormatter = new VariantSummaryFormatter($this->timeUnit, 'summray', 'baseline summary');
+    }
+}

--- a/tests/Unit/Progress/Logger/PhpBenchLoggerTest.php
+++ b/tests/Unit/Progress/Logger/PhpBenchLoggerTest.php
@@ -23,11 +23,8 @@ use PhpBench\Model\Subject;
 use PhpBench\Model\Suite;
 use PhpBench\Model\Summary;
 use PhpBench\Model\Variant;
-use PhpBench\Tests\TestCase;
-use Prophecy\Argument;
-use Symfony\Component\Console\Output\OutputInterface;
 
-abstract class PhpBenchLoggerTest extends TestCase
+abstract class PhpBenchLoggerTest extends LoggerTestCase
 {
     protected $logger;
     protected $output;
@@ -40,13 +37,13 @@ abstract class PhpBenchLoggerTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
         $this->suite = $this->prophesize(Suite::class);
         $this->summary = $this->prophesize(Summary::class);
         $this->benchmark = $this->prophesize(Benchmark::class);
         $this->variant = $this->prophesize(Variant::class);
         $this->subject = $this->prophesize(Subject::class);
         $this->parameterSet = $this->prophesize(ParameterSet::class);
-        $this->output = $this->prophesize(OutputInterface::class);
         $this->stats = $this->prophesize(Distribution::class);
 
         $this->logger = $this->getLogger();
@@ -81,8 +78,8 @@ abstract class PhpBenchLoggerTest extends TestCase
         $this->setUpSummary();
         $this->suite->getFailures()->willReturn([]);
         $this->suite->getErrorStacks()->willReturn([]);
-        $this->output->writeln(Argument::any())->shouldBeCalled();
         $this->logger->endSuite($this->suite->reveal());
+        self::assertNotEmpty($this->output->fetch());
     }
 
     public function testEndSuiteErrors()
@@ -108,16 +105,16 @@ abstract class PhpBenchLoggerTest extends TestCase
         $this->subject->getBenchmark()->willReturn($this->benchmark->reveal());
         $this->subject->getName()->willReturn('bar');
         $this->benchmark->getClass()->willReturn('Namespace\Foo');
-
-        $this->output->writeln(Argument::containingString('1 subjects encountered errors'))->shouldBeCalled();
-        $this->output->writeln(Argument::containingString('Namespace\Foo::bar'))->shouldBeCalled();
-        $this->output->writeln(Argument::containingString('ExceptionOne'))->shouldBeCalled();
-        $this->output->writeln(Argument::containingString('ExceptionTwo'))->shouldBeCalled();
-        $this->output->writeln(Argument::containingString('MessageOne'))->shouldBeCalled();
-        $this->output->writeln(Argument::containingString('Two'))->shouldBeCalled();
-        $this->output->writeln(Argument::any())->shouldBeCalled();
-
         $this->logger->endSuite($this->suite->reveal());
+
+        $buffer = $this->output->fetch();
+
+        self::assertStringContainsString('1 subjects encountered errors', $buffer);
+        self::assertStringContainsString('Namespace\Foo::bar', $buffer);
+        self::assertStringContainsString('ExceptionOne', $buffer);
+        self::assertStringContainsString('ExceptionTwo', $buffer);
+        self::assertStringContainsString('MessageOne', $buffer);
+        self::assertStringContainsString('Two', $buffer);
     }
 
     public function testEndSuiteFailures()
@@ -135,11 +132,11 @@ abstract class PhpBenchLoggerTest extends TestCase
         $this->subject->getName()->willReturn('bar');
         $this->benchmark->getClass()->willReturn('Namespace\Foo');
 
-        $this->output->writeln(Argument::containingString('1 variants failed'))->shouldBeCalled();
-        $this->output->writeln(Argument::any())->shouldBeCalled();
-        $this->output->write(Argument::any())->shouldBeCalled();
+
 
         $this->logger->endSuite($this->suite->reveal());
+        $buffer = $this->output->fetch();
+        self::assertStringContainsString('1 variants failed', $buffer);
     }
 
     private function setUpSummary()

--- a/tests/Unit/Progress/Logger/PhpBenchLoggerTest.php
+++ b/tests/Unit/Progress/Logger/PhpBenchLoggerTest.php
@@ -52,7 +52,11 @@ abstract class PhpBenchLoggerTest extends TestCase
         $this->logger = $this->getLogger();
 
         $this->suite->getSummary()->willReturn($this->summary->reveal());
+        $this->variant->getBaseline()->willReturn($this->variant->reveal());
 
+        $this->stats->getMin()->willReturn(1.0);
+        $this->stats->getMax()->willReturn(1.0);
+        $this->stats->getVariance()->willReturn(1.0);
         $this->stats->getMean()->willReturn(1.0);
         $this->stats->getMode()->willReturn(1.0);
         $this->stats->getStdev()->willReturn(2.0);

--- a/tests/Unit/Progress/Logger/TravisLoggerTest.php
+++ b/tests/Unit/Progress/Logger/TravisLoggerTest.php
@@ -61,7 +61,7 @@ class TravisLoggerTest extends PhpBenchLoggerTest
         $this->subject->getOutputTimePrecision()->willReturn(null);
         $this->parameterSet->getIndex()->willReturn(0);
 
-        $this->output->writeln(Argument::containingString('0.001 (ms)'))->shouldBeCalled();
+        $this->output->writeln(Argument::containingString('0.001ms'))->shouldBeCalled();
         $this->logger->variantEnd($this->variant->reveal());
     }
 
@@ -101,7 +101,7 @@ class TravisLoggerTest extends PhpBenchLoggerTest
         $this->subject->getName()->willReturn('benchFoo');
         $this->parameterSet->getIndex()->willReturn(0);
 
-        $this->output->writeln(Argument::containingString('1.000 (ops/μs)'))->shouldBeCalled();
+        $this->output->writeln(Argument::containingString('1.000ops/μs'))->shouldBeCalled();
         $this->logger->variantEnd($this->variant->reveal());
     }
 

--- a/tests/Unit/Progress/Logger/TravisLoggerTest.php
+++ b/tests/Unit/Progress/Logger/TravisLoggerTest.php
@@ -14,38 +14,28 @@ namespace PhpBench\Tests\Unit\Progress\Logger;
 
 use PhpBench\Assertion\VariantAssertionResults;
 use PhpBench\Progress\Logger\TravisLogger;
-use PhpBench\Util\TimeUnit;
-use Prophecy\Argument;
 
 class TravisLoggerTest extends PhpBenchLoggerTest
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
     public function getLogger()
     {
-        $timeUnit = new TimeUnit(TimeUnit::MICROSECONDS, TimeUnit::MILLISECONDS);
-
-        return new TravisLogger($this->output->reveal(), $timeUnit);
+        return new TravisLogger($this->output, $this->variantFormatter, $this->timeUnit);
     }
 
     /**
      * It should output when the benchmark starts.
      */
-    public function testBenchmarkStart()
+    public function testBenchmarkStart(): void
     {
         $this->benchmark->getClass()->willReturn('Benchmark');
-        $this->output->writeln('<comment>Benchmark</comment>')->shouldBeCalled();
-        $this->output->write(PHP_EOL)->shouldBeCalled();
         $this->logger->benchmarkStart($this->benchmark->reveal());
+        self::assertEquals("Benchmark\n\n", $this->output->fetch());
     }
 
     /**
      * It should output at the end of an iteration set.
      */
-    public function testIterationsEnd()
+    public function testIterationsEnd(): void
     {
         $this->variant->getRejectCount()->willReturn(0);
         $this->variant->hasErrorStack()->willReturn(false);
@@ -61,65 +51,7 @@ class TravisLoggerTest extends PhpBenchLoggerTest
         $this->subject->getOutputTimePrecision()->willReturn(null);
         $this->parameterSet->getIndex()->willReturn(0);
 
-        $this->output->writeln(Argument::containingString('0.001ms'))->shouldBeCalled();
         $this->logger->variantEnd($this->variant->reveal());
-    }
-
-    /**
-     * It should log errors.
-     */
-    public function testIterationsEndException()
-    {
-        $this->variant->hasErrorStack()->willReturn(true);
-        $this->variant->getRejectCount()->willReturn(0);
-        $this->variant->getSubject()->willReturn($this->subject->reveal());
-        $this->variant->count()->willReturn(10);
-        $this->variant->getAssertionResults()->willReturn(new VariantAssertionResults($this->variant->reveal(), []));
-        $this->subject->getName()->willReturn('benchFoo');
-
-        $this->output->writeln(Argument::containingString('ERROR'))->shouldBeCalled();
-        $this->logger->variantEnd($this->variant->reveal());
-    }
-
-    /**
-     * It should use the subject time unit.
-     * It should use the subject mode.
-     */
-    public function testUseSubjectTimeUnit()
-    {
-        $this->variant->getRejectCount()->willReturn(0);
-        $this->variant->hasErrorStack()->willReturn(false);
-        $this->variant->getStats()->willReturn($this->stats->reveal());
-        $this->variant->getSubject()->willReturn($this->subject->reveal());
-        $this->variant->count()->willReturn(10);
-        $this->variant->getParameterSet()->willReturn($this->parameterSet->reveal());
-        $this->variant->getAssertionResults()->willReturn(new VariantAssertionResults($this->variant->reveal(), []));
-        $this->subject->getVariants()->willReturn([$this->variant->reveal()]);
-        $this->subject->getOutputTimeUnit()->willReturn(TimeUnit::MICROSECONDS);
-        $this->subject->getOutputTimePrecision()->willReturn(null);
-        $this->subject->getOutputMode()->willReturn(TimeUnit::MODE_THROUGHPUT);
-        $this->subject->getName()->willReturn('benchFoo');
-        $this->parameterSet->getIndex()->willReturn(0);
-
-        $this->output->writeln(Argument::containingString('1.000ops/μs'))->shouldBeCalled();
-        $this->logger->variantEnd($this->variant->reveal());
-    }
-
-    /**
-     * It should output an empty line at the end of the suite.
-     */
-    public function testEndSuite()
-    {
-        $this->output->write(PHP_EOL)->shouldBeCalled();
-        parent::testEndSuite();
-    }
-
-    /**
-     * It should output an empty line at the end of the suite.
-     */
-    public function testEndSuiteErrors()
-    {
-        $this->output->write(PHP_EOL)->shouldBeCalled();
-        parent::testEndSuiteErrors();
+        self::assertStringContainsString('summary', $this->output->fetch());
     }
 }

--- a/tests/Unit/Progress/Logger/VerboseLoggerTest.php
+++ b/tests/Unit/Progress/Logger/VerboseLoggerTest.php
@@ -55,7 +55,7 @@ class VerboseLoggerTest extends PhpBenchLoggerTest
         $this->subject->getName()->willReturn('benchFoo');
         $this->parameterSet->getIndex()->willReturn(0);
 
-        $this->output->write(Argument::containingString('0.001 (ms)'))->shouldBeCalled();
+        $this->output->write(Argument::containingString('0.001ms'))->shouldBeCalled();
         $this->output->write(PHP_EOL)->shouldBeCalled();
         $this->logger->variantEnd($this->variant->reveal());
     }
@@ -78,7 +78,7 @@ class VerboseLoggerTest extends PhpBenchLoggerTest
         $this->subject->getName()->willReturn('benchFoo');
         $this->parameterSet->getIndex()->willReturn(0);
 
-        $this->output->write(Argument::containingString('1.000 (ops/μs)'))->shouldBeCalled();
+        $this->output->write(Argument::containingString('1.000ops/μs'))->shouldBeCalled();
         $this->output->write(PHP_EOL)->shouldBeCalled();
         $this->logger->variantEnd($this->variant->reveal());
     }
@@ -100,7 +100,7 @@ class VerboseLoggerTest extends PhpBenchLoggerTest
         $this->subject->getName()->willReturn('benchFoo');
         $this->parameterSet->getIndex()->willReturn(0);
 
-        $this->output->write(Argument::containingString('<error>'))->shouldBeCalled();
+        $this->output->write(Argument::containingString('<failure>'))->shouldBeCalled();
         $this->output->write(PHP_EOL)->shouldBeCalled();
         $this->logger->variantEnd($this->variant->reveal());
     }

--- a/tests/Unit/Progress/Logger/VerboseLoggerTest.php
+++ b/tests/Unit/Progress/Logger/VerboseLoggerTest.php
@@ -12,11 +12,9 @@
 
 namespace PhpBench\Tests\Unit\Progress\Logger;
 
-use PhpBench\Assertion\AssertionResult;
 use PhpBench\Assertion\VariantAssertionResults;
 use PhpBench\Progress\Logger\VerboseLogger;
 use PhpBench\Util\TimeUnit;
-use Prophecy\Argument;
 
 class VerboseLoggerTest extends PhpBenchLoggerTest
 {
@@ -24,18 +22,17 @@ class VerboseLoggerTest extends PhpBenchLoggerTest
     {
         $timeUnit = new TimeUnit(TimeUnit::MICROSECONDS, TimeUnit::MILLISECONDS);
 
-        return new VerboseLogger($this->output->reveal(), $timeUnit);
+        return new VerboseLogger($this->output, $this->variantFormatter, $timeUnit);
     }
 
     /**
      * It should output when the benchmark starts.
      */
-    public function testBenchmarkStart()
+    public function testBenchmarkStart(): void
     {
         $this->benchmark->getClass()->willReturn('Benchmark');
-        $this->output->writeln('<comment>Benchmark</comment>')->shouldBeCalled();
-        $this->output->write(PHP_EOL)->shouldBeCalled();
         $this->logger->benchmarkStart($this->benchmark->reveal());
+        self::assertStringContainsString('Benchmark', $this->output->fetch());
     }
 
     /**
@@ -55,76 +52,7 @@ class VerboseLoggerTest extends PhpBenchLoggerTest
         $this->subject->getName()->willReturn('benchFoo');
         $this->parameterSet->getIndex()->willReturn(0);
 
-        $this->output->write(Argument::containingString('0.001ms'))->shouldBeCalled();
-        $this->output->write(PHP_EOL)->shouldBeCalled();
         $this->logger->variantEnd($this->variant->reveal());
-    }
-
-    /**
-     * It should use the subject time unit.
-     * It should use the subject mode.
-     */
-    public function testUseSubjectTimeUnitAndMode()
-    {
-        $this->variant->hasErrorStack()->willReturn(false);
-        $this->variant->getRejectCount()->willReturn(0);
-        $this->variant->getStats()->willReturn($this->stats->reveal());
-        $this->variant->getSubject()->willReturn($this->subject->reveal());
-        $this->variant->getParameterSet()->willReturn($this->parameterSet->reveal());
-        $this->variant->getAssertionResults()->willReturn(new VariantAssertionResults($this->variant->reveal(), []));
-        $this->subject->getOutputTimeUnit()->willReturn(TimeUnit::MICROSECONDS);
-        $this->subject->getOutputMode()->willReturn(TimeUnit::MODE_THROUGHPUT);
-        $this->subject->getOutputTimePrecision()->willReturn(null);
-        $this->subject->getName()->willReturn('benchFoo');
-        $this->parameterSet->getIndex()->willReturn(0);
-
-        $this->output->write(Argument::containingString('1.000ops/μs'))->shouldBeCalled();
-        $this->output->write(PHP_EOL)->shouldBeCalled();
-        $this->logger->variantEnd($this->variant->reveal());
-    }
-
-    /**
-     * It should show failures.
-     */
-    public function testShowFailures()
-    {
-        $this->variant->hasErrorStack()->willReturn(false);
-        $this->variant->getRejectCount()->willReturn(0);
-        $this->variant->getStats()->willReturn($this->stats->reveal());
-        $this->variant->getSubject()->willReturn($this->subject->reveal());
-        $this->variant->getParameterSet()->willReturn($this->parameterSet->reveal());
-        $this->variant->getAssertionResults()->willReturn(new VariantAssertionResults($this->variant->reveal(), [AssertionResult::fail()]));
-        $this->subject->getOutputTimeUnit()->willReturn(TimeUnit::MICROSECONDS);
-        $this->subject->getOutputMode()->willReturn(TimeUnit::MODE_THROUGHPUT);
-        $this->subject->getOutputTimePrecision()->willReturn(null);
-        $this->subject->getName()->willReturn('benchFoo');
-        $this->parameterSet->getIndex()->willReturn(0);
-
-        $this->output->write(Argument::containingString('<failure>'))->shouldBeCalled();
-        $this->output->write(PHP_EOL)->shouldBeCalled();
-        $this->logger->variantEnd($this->variant->reveal());
-    }
-
-    /**
-     * It should log exceptions as ERROR.
-     */
-    public function testLogError()
-    {
-        $this->variant->hasErrorStack()->willReturn(true);
-        $this->variant->getSubject()->willReturn($this->subject->reveal());
-        $this->variant->getAssertionResults()->willReturn(new VariantAssertionResults($this->variant->reveal(), []));
-        $this->subject->getName()->willReturn('benchFoo');
-        $this->output->write(Argument::containingString('ERROR'))->shouldBeCalled();
-        $this->output->write(PHP_EOL)->shouldBeCalled();
-        $this->logger->variantEnd($this->variant->reveal());
-    }
-
-    /**
-     * It should output an empty line at the end of the suite.
-     */
-    public function testEndSuiteErrors()
-    {
-        $this->output->write(PHP_EOL)->shouldBeCalled();
-        parent::testEndSuiteErrors();
+        self::assertStringContainsString('summary', $this->output->fetch());
     }
 }

--- a/tests/Unit/Progress/VariantSummaryFormatterTest.php
+++ b/tests/Unit/Progress/VariantSummaryFormatterTest.php
@@ -4,7 +4,6 @@ namespace PhpBench\Tests\Unit\Progress;
 
 use Closure;
 use Generator;
-use PHPUnit\Framework\TestCase;
 use PhpBench\Assertion\AssertionResult;
 use PhpBench\Model\ParameterSet;
 use PhpBench\Model\Result\TimeResult;
@@ -12,29 +11,29 @@ use PhpBench\Model\Variant;
 use PhpBench\Progress\VariantSummaryFormatter;
 use PhpBench\Tests\Util\TestUtil;
 use PhpBench\Util\TimeUnit;
+use PHPUnit\Framework\TestCase;
 
 class VariantSummaryFormatterTest extends TestCase
 {
-        /**
-         * @dataProvider provideFormat
-         */
-        public function testFormat(Closure $factory, string $format, string $expected): void
-        {
-            $variant = $factory(TestUtil::getVariant());
-            $variant->getSubject()->setOutputTimePrecision(2);
-            self::assertEquals($expected, self::createFormatter(
+    /**
+     * @dataProvider provideFormat
+     */
+    public function testFormat(Closure $factory, string $format, string $expected): void
+    {
+        $variant = $factory(TestUtil::getVariant());
+        $variant->getSubject()->setOutputTimePrecision(2);
+        self::assertEquals($expected, self::createFormatter(
                 $format,
                 $format
             )->formatVariant($variant));
-
-        }
+    }
         
-        /**
-         * @return Generator<mixed>
-         */
-        public function provideFormat(): Generator
-        {
-            yield 'empty' => [
+    /**
+     * @return Generator<mixed>
+     */
+    public function provideFormat(): Generator
+    {
+        yield 'empty' => [
                 function (Variant $variant): Variant {
                     return $variant;
                 },
@@ -42,7 +41,7 @@ class VariantSummaryFormatterTest extends TestCase
                 ''
             ];
 
-            yield 'pre-calculated variant fields' => [
+        yield 'pre-calculated variant fields' => [
                 function (Variant $variant): Variant {
                     return $variant;
                 },
@@ -50,44 +49,48 @@ class VariantSummaryFormatterTest extends TestCase
                 '2.00 4.00 3.00 3.00 1.00'
             ];
 
-            yield 'difference to baseline' => [
+        yield 'difference to baseline' => [
                 function (Variant $variant): Variant {
                     $this->createBaseline($variant, 10);
+
                     return $variant;
                 },
                 '%percent_difference%',
                 '+200.00'
             ];
 
-            yield 'assertion ok' => [
+        yield 'result with no assertion' => [
                 function (Variant $variant): Variant {
                     $this->createBaseline($variant);
+
                     return $variant;
                 },
                 '<%result_style%>',
-                '<result-success>'
+                '<result-none>'
             ];
 
-            yield 'assertion tolerated' => [
+        yield 'assertion tolerated' => [
                 function (Variant $variant): Variant {
                     $variant->addAssertionResult(AssertionResult::tolerated('ok'));
                     $this->createBaseline($variant);
+
                     return $variant;
                 },
                 '%result_style%',
                 'result-neutral'
             ];
 
-            yield 'assertion fail' => [
+        yield 'assertion fail' => [
                 function (Variant $variant): Variant {
                     $variant->addAssertionResult(AssertionResult::fail('fail'));
                     $this->createBaseline($variant);
+
                     return $variant;
                 },
                 '%result_style%',
                 'result-failure'
             ];
-        }
+    }
 
     private static function createFormatter(string $format, string $baselineFormat): VariantSummaryFormatter
     {
@@ -104,6 +107,7 @@ class VariantSummaryFormatterTest extends TestCase
             new ParameterSet('no',[]), 10, 10, []
         );
         $baseline->spawnIterations(1);
+
         foreach ($baseline->getIterations() as $iteration) {
             $iteration->setResult(new TimeResult($time));
         }

--- a/tests/Unit/Progress/VariantSummaryFormatterTest.php
+++ b/tests/Unit/Progress/VariantSummaryFormatterTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace PhpBench\Tests\Unit\Progress;
+
+use Closure;
+use Generator;
+use PHPUnit\Framework\TestCase;
+use PhpBench\Assertion\AssertionResult;
+use PhpBench\Model\ParameterSet;
+use PhpBench\Model\Result\TimeResult;
+use PhpBench\Model\Variant;
+use PhpBench\Progress\VariantSummaryFormatter;
+use PhpBench\Tests\Util\TestUtil;
+use PhpBench\Util\TimeUnit;
+
+class VariantSummaryFormatterTest extends TestCase
+{
+        /**
+         * @dataProvider provideFormat
+         */
+        public function testFormat(Closure $factory, string $format, string $expected): void
+        {
+            $variant = $factory(TestUtil::getVariant());
+            $variant->getSubject()->setOutputTimePrecision(2);
+            self::assertEquals($expected, self::createFormatter(
+                $format,
+                $format
+            )->formatVariant($variant));
+
+        }
+        
+        /**
+         * @return Generator<mixed>
+         */
+        public function provideFormat(): Generator
+        {
+            yield 'empty' => [
+                function (Variant $variant): Variant {
+                    return $variant;
+                },
+                '',
+                ''
+            ];
+
+            yield 'pre-calculated variant fields' => [
+                function (Variant $variant): Variant {
+                    return $variant;
+                },
+                '%variant.min% %variant.max% %variant.mean% %variant.mode% %variant.stdev%',
+                '2.00 4.00 3.00 3.00 1.00'
+            ];
+
+            yield 'difference to baseline' => [
+                function (Variant $variant): Variant {
+                    $this->createBaseline($variant, 10);
+                    return $variant;
+                },
+                '%percent_difference%',
+                '+200.00'
+            ];
+
+            yield 'assertion ok' => [
+                function (Variant $variant): Variant {
+                    $this->createBaseline($variant);
+                    return $variant;
+                },
+                '<%result_style%>',
+                '<result-success>'
+            ];
+
+            yield 'assertion tolerated' => [
+                function (Variant $variant): Variant {
+                    $variant->addAssertionResult(AssertionResult::tolerated('ok'));
+                    $this->createBaseline($variant);
+                    return $variant;
+                },
+                '%result_style%',
+                'result-neutral'
+            ];
+
+            yield 'assertion fail' => [
+                function (Variant $variant): Variant {
+                    $variant->addAssertionResult(AssertionResult::fail('fail'));
+                    $this->createBaseline($variant);
+                    return $variant;
+                },
+                '%result_style%',
+                'result-failure'
+            ];
+        }
+
+    private static function createFormatter(string $format, string $baselineFormat): VariantSummaryFormatter
+    {
+        return new VariantSummaryFormatter(
+            new TimeUnit(),
+            $format,
+            $baselineFormat
+        );
+    }
+
+    private function createBaseline(Variant $variant, int $time = 30): void
+    {
+        $baseline = $variant->getSubject()->createVariant(
+            new ParameterSet('no',[]), 10, 10, []
+        );
+        $baseline->spawnIterations(1);
+        foreach ($baseline->getIterations() as $iteration) {
+            $iteration->setResult(new TimeResult($time));
+        }
+        $baseline->computeStats();
+        $variant->attachBaseline($baseline);
+    }
+}

--- a/tests/Util/TestUtil.php
+++ b/tests/Util/TestUtil.php
@@ -19,7 +19,9 @@ use PhpBench\Model\Result\RejectionCountResult;
 use PhpBench\Model\Result\TimeResult;
 use PhpBench\Model\Suite;
 use PhpBench\Model\SuiteCollection;
+use PhpBench\Model\Variant;
 use Prophecy\Prophecy\ObjectProphecy;
+use RuntimeException;
 
 /**
  * Utility class for configuring benchmarking prophecy objects.
@@ -58,6 +60,18 @@ class TestUtil
         $subject->getParamProviders()->willReturn($options['paramProviders']);
         $subject->getOutputTimeUnit()->willReturn($options['outputTimeUnit']);
         $subject->getOutputMode()->willReturn($options['outputMode']);
+    }
+
+    public static function getVariant(): Variant
+    {
+        $variants = self::createSuite()->getVariants();
+        $variant = reset($variants);
+        if (!$variant) {
+            throw new RuntimeException(sprintf(
+                'Could not find a variant in test suite'
+            ));
+        }
+        return $variant;
     }
 
     public static function configureBenchmarkMetadata(ObjectProphecy $benchmark, array $options = [])

--- a/tests/Util/TestUtil.php
+++ b/tests/Util/TestUtil.php
@@ -66,11 +66,13 @@ class TestUtil
     {
         $variants = self::createSuite()->getVariants();
         $variant = reset($variants);
+
         if (!$variant) {
             throw new RuntimeException(sprintf(
                 'Could not find a variant in test suite'
             ));
         }
+
         return $variant;
     }
 


### PR DESCRIPTION
Improve the progress output when using a baseline (and make the output more succinct)

- By default only show the mode and relative deviation (the KDE mode has consistently been a better indicator than the mean)
- When baseline is present, show comparison in output
- Will allow custom formatting (e.g. add more fields to the output)

![image](https://user-images.githubusercontent.com/530801/103304476-a5f9d080-4a00-11eb-95d4-2788ebf90e18.png)
