### PR TITLE
Minor Bug Fixes

### DIFF
--- a/lib/Assertion/ParameterProvider.php
+++ b/lib/Assertion/ParameterProvider.php
@@ -2,6 +2,7 @@
 
 namespace PhpBench\Assertion;
 
+use PhpBench\Expression\NodePrinter\DisplayAsPrinter;
 use PhpBench\Model\Variant;
 
 class ParameterProvider
@@ -15,6 +16,8 @@ class ParameterProvider
             return [
                 'variant' => $variantData,
                 'baseline' => $variant->getBaseline() ? $this->buildVariantData($variant->getBaseline()) : $variantData,
+                DisplayAsPrinter::PARAM_OUTPUT_TIME_UNIT => $variant->getSubject()->getOutputTimeUnit(),
+                DisplayAsPrinter::PARAM_OUTPUT_TIME_PRECISION => $variant->getSubject()->getOutputTimePrecision(),
             ];
         })($this->buildVariantData($variant));
     }

--- a/lib/Expression/NodePrinter/DisplayAsPrinter.php
+++ b/lib/Expression/NodePrinter/DisplayAsPrinter.php
@@ -13,9 +13,10 @@ use PhpBench\Util\TimeUnit;
 
 class DisplayAsPrinter implements NodePrinter
 {
+    public const PARAM_OUTPUT_TIME_UNIT = 'output_time_unit';
+    public const PARAM_OUTPUT_TIME_PRECISION = 'output_time_precision';
+
     private const DEFAULT_TIME_UNIT = 'time';
-    const PARAM_OUTPUT_TIME_UNIT = 'output_time_unit';
-    const PARAM_OUTPUT_TIME_PRECISION = 'output_time_precision';
 
 
     /**
@@ -79,7 +80,7 @@ class DisplayAsPrinter implements NodePrinter
 
     private function timeUnit(float $value, ?string $unit, ?int $precision): string
     {
-        return $this->timeUnit->format($value, $unit, TimeUnit::MODE_TIME, $precision);
+        return $this->timeUnit->format($value, $unit, null, $precision);
     }
 
     /**

--- a/lib/Expression/NodePrinter/DisplayAsPrinter.php
+++ b/lib/Expression/NodePrinter/DisplayAsPrinter.php
@@ -49,7 +49,7 @@ class DisplayAsPrinter implements NodePrinter
             return $this->timeUnit(
                 $value->value(),
                 isset($params[self::PARAM_OUTPUT_TIME_UNIT]) ? $params[self::PARAM_OUTPUT_TIME_UNIT] : null,
-                isset($params[self::PARAM_OUTPUT_TIME_PRECISION]) ? $params[self::PARAM_OUTPUT_TIME_UNIT] : null
+                isset($params[self::PARAM_OUTPUT_TIME_PRECISION]) ? $params[self::PARAM_OUTPUT_TIME_PRECISION] : null
             );
         }
 

--- a/lib/Expression/NodePrinter/DisplayAsPrinter.php
+++ b/lib/Expression/NodePrinter/DisplayAsPrinter.php
@@ -14,6 +14,9 @@ use PhpBench\Util\TimeUnit;
 class DisplayAsPrinter implements NodePrinter
 {
     private const DEFAULT_TIME_UNIT = 'time';
+    const PARAM_OUTPUT_TIME_UNIT = 'output_time_unit';
+    const PARAM_OUTPUT_TIME_PRECISION = 'output_time_precision';
+
 
     /**
      * @var TimeUnit
@@ -42,11 +45,15 @@ class DisplayAsPrinter implements NodePrinter
         }
 
         if ($unit === self::DEFAULT_TIME_UNIT) {
-            return $this->timeUnit($value->value(), null);
+            return $this->timeUnit(
+                $value->value(),
+                isset($params[self::PARAM_OUTPUT_TIME_UNIT]) ? $params[self::PARAM_OUTPUT_TIME_UNIT] : null,
+                isset($params[self::PARAM_OUTPUT_TIME_PRECISION]) ? $params[self::PARAM_OUTPUT_TIME_UNIT] : null
+            );
         }
 
         if (TimeUnit::isTimeUnit($unit)) {
-            return $this->timeUnit($value->value(), $unit);
+            return $this->timeUnit($value->value(), $unit, null);
         }
 
         if (MemoryUnit::isMemoryUnit($unit)) {
@@ -70,9 +77,9 @@ class DisplayAsPrinter implements NodePrinter
         );
     }
 
-    private function timeUnit(float $value, ?string $unit): string
+    private function timeUnit(float $value, ?string $unit, ?int $precision): string
     {
-        return $this->timeUnit->format($value, $unit);
+        return $this->timeUnit->format($value, $unit, TimeUnit::MODE_TIME, $precision);
     }
 
     /**

--- a/lib/Extension/ExpressionExtension.php
+++ b/lib/Extension/ExpressionExtension.php
@@ -100,7 +100,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ExpressionExtension implements ExtensionInterface
 {
-    const PARAM_SYNTAX_HIGHLIGHTING = 'expression.syntax_highlighting';
+    public const PARAM_SYNTAX_HIGHLIGHTING = 'expression.syntax_highlighting';
+    public const SERVICE_PLAIN_PRINTER = Printer::class . '.plain';
 
     /**
      * {@inheritDoc}
@@ -181,8 +182,8 @@ class ExpressionExtension implements ExtensionInterface
         $container->register(Evaluator::class, function (Container $container) {
             return new PrettyErrorEvaluator(
                 new MainEvaluator(new MemoisedNodeEvaluator($container->get(NodeEvaluator::class))),
-                $container->get(Printer::class),
-                new UnderlinePrinterFactory($container->get(NodePrinter::class))
+                $container->get(self::SERVICE_PLAIN_PRINTER),
+                new UnderlinePrinterFactory($container->get(NodePrinters::class))
             );
         });
 
@@ -224,6 +225,10 @@ class ExpressionExtension implements ExtensionInterface
 
         $container->register(Printer::class, function (Container $container) {
             return new NormalizingPrinter($container->get(NodePrinter::class));
+        });
+
+        $container->register(self::SERVICE_PLAIN_PRINTER, function (Container $container) {
+            return new NormalizingPrinter($container->get(NodePrinters::class));
         });
 
         $container->register(EvaluatingPrinter::class, function (Container $container) {

--- a/lib/Extension/ExpressionExtension.php
+++ b/lib/Extension/ExpressionExtension.php
@@ -101,7 +101,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class ExpressionExtension implements ExtensionInterface
 {
     public const PARAM_SYNTAX_HIGHLIGHTING = 'expression.syntax_highlighting';
-    public const SERVICE_PLAIN_PRINTER = Printer::class . '.plain';
+
+    private const SERVICE_PLAIN_PRINTER = Printer::class . '.plain';
+
 
     /**
      * {@inheritDoc}

--- a/lib/Report/Generator/ExpressionGenerator.php
+++ b/lib/Report/Generator/ExpressionGenerator.php
@@ -64,7 +64,7 @@ class ExpressionGenerator implements GeneratorInterface
             'title' => null,
             'description' => null,
             'cols' => [
-                'benchmark' => 'first(benchmark_class)',
+                'benchmark' => 'first(benchmark_clas)',
                 'subject' => 'first(subject_name)',
                 'set' => 'first(variant_name)',
                 'revs' => 'first(variant_revs)',

--- a/lib/Report/Generator/ExpressionGenerator.php
+++ b/lib/Report/Generator/ExpressionGenerator.php
@@ -64,7 +64,7 @@ class ExpressionGenerator implements GeneratorInterface
             'title' => null,
             'description' => null,
             'cols' => [
-                'benchmark' => 'first(benchmark_clas)',
+                'benchmark' => 'first(benchmark_class)',
                 'subject' => 'first(subject_name)',
                 'set' => 'first(variant_name)',
                 'revs' => 'first(variant_revs)',

--- a/tests/Unit/Expression/Parselet/DisplayAsParseletTest.php
+++ b/tests/Unit/Expression/Parselet/DisplayAsParseletTest.php
@@ -6,6 +6,7 @@ use Generator;
 use PhpBench\Expression\Ast\DisplayAsNode;
 use PhpBench\Expression\Ast\IntegerNode;
 use PhpBench\Expression\Ast\UnitNode;
+use PhpBench\Expression\NodePrinter\DisplayAsPrinter;
 use PhpBench\Tests\Unit\Expression\ParseletTestCase;
 
 class DisplayAsParseletTest extends ParseletTestCase
@@ -43,5 +44,14 @@ class DisplayAsParseletTest extends ParseletTestCase
         yield ['100000 as seconds < 1 second', [], '0.100s < 1 second'];
 
         yield 'default unit' => ['100000 as time < 1 second', [], '100,000.000μs < 1 second'];
+
+        yield 'default unit from parameters' => [
+            '100000 as time < 1 second',
+            [
+                DisplayAsPrinter::PARAM_OUTPUT_TIME_UNIT => 'minutes',
+                DisplayAsPrinter::PARAM_OUTPUT_TIME_PRECISION => 6,
+            ],
+            '100,000.000μs < 1 second'
+        ];
     }
 }

--- a/tests/Unit/Expression/Parselet/DisplayAsParseletTest.php
+++ b/tests/Unit/Expression/Parselet/DisplayAsParseletTest.php
@@ -48,10 +48,10 @@ class DisplayAsParseletTest extends ParseletTestCase
         yield 'default unit from parameters' => [
             '100000 as time < 1 second',
             [
-                DisplayAsPrinter::PARAM_OUTPUT_TIME_UNIT => 'minutes',
+                DisplayAsPrinter::PARAM_OUTPUT_TIME_UNIT => 'milliseconds',
                 DisplayAsPrinter::PARAM_OUTPUT_TIME_PRECISION => 6,
             ],
-            '100,000.000μs < 1 second'
+            '100.000000ms < 1 second'
         ];
     }
 }

--- a/tests/Unit/Expression/ParseletTestCase.php
+++ b/tests/Unit/Expression/ParseletTestCase.php
@@ -62,7 +62,7 @@ abstract class ParseletTestCase extends ParserTestCase
      */
     public function testPrint(string $expr, array $params = [], string $expected = null): void
     {
-        $result = $this->print($this->parse($expr));
+        $result = $this->print($this->parse($expr), $params);
         self::assertEquals($expected ?: $expr, $result);
     }
 


### PR DESCRIPTION
- Do not use decorated printer for error messages
- Allow time unit to be inferred from parameters (i.e. permit `@OutputTimeUnit` to be passed to the expression printer)