### PR TITLE
Add support for specifying display precision in expr language

### DIFF
--- a/docs/expression.rst
+++ b/docs/expression.rst
@@ -124,6 +124,10 @@ unit. You can use ``as`` to display these values in a specified unit:
 This will force the unit conversion to happen only when displaying the
 evaluated expression.
 
+You can also specify the precision:
+
+.. literalinclude:: ../examples/Expression/time_unit_3
+
 .. _expr_tolerance:
 
 Tolerance

--- a/docs/expression.rst
+++ b/docs/expression.rst
@@ -128,6 +128,9 @@ You can also specify the precision:
 
 .. literalinclude:: ../examples/Expression/time_unit_3
 
+Will ensure that the result is displayed with the given number of digits
+after the decimal point.
+
 .. _expr_tolerance:
 
 Tolerance

--- a/examples/Expression/time_unit_3
+++ b/examples/Expression/time_unit_3
@@ -1,0 +1,1 @@
+1000000 as seconds precision 4 = 1 second

--- a/lib/Expression/Ast/DisplayAsNode.php
+++ b/lib/Expression/Ast/DisplayAsNode.php
@@ -16,10 +16,16 @@ class DisplayAsNode implements NumberValue
      */
     private $value;
 
-    public function __construct(Node $value, UnitNode $as)
+    /**
+     * @var Node|null
+     */
+    private $precision;
+
+    public function __construct(Node $value, UnitNode $as, ?Node $precision = null)
     {
         $this->as = $as;
         $this->value = $value;
+        $this->precision = $precision;
     }
 
     public function node(): Node

--- a/lib/Expression/Parselet/DisplayAsParselet.php
+++ b/lib/Expression/Parselet/DisplayAsParselet.php
@@ -27,13 +27,7 @@ class DisplayAsParselet implements InfixParselet
         if ($tokens->current()->type === Token::T_UNIT) {
             $unit = new StringNode($tokens->chomp()->value);
         } else {
-            $unit = $parser->parseExpression($tokens);
-
-            if (!$unit instanceof StringNode) {
-                throw SyntaxError::forToken($tokens, $tokens->current(), 'Expected unit expression to evaluate to string');
-            }
-
-            $unit = $unit;
+            $unit = $parser->parseExpression($tokens, Precedence::AS);
         }
 
         return new DisplayAsNode($left, new UnitNode($unit));
@@ -41,6 +35,6 @@ class DisplayAsParselet implements InfixParselet
 
     public function precedence(): int
     {
-        return Precedence::TOLERANCE;
+        return Precedence::AS;
     }
 }

--- a/lib/Expression/Parselet/DisplayAsParselet.php
+++ b/lib/Expression/Parselet/DisplayAsParselet.php
@@ -6,7 +6,6 @@ use PhpBench\Expression\Ast\DisplayAsNode;
 use PhpBench\Expression\Ast\Node;
 use PhpBench\Expression\Ast\StringNode;
 use PhpBench\Expression\Ast\UnitNode;
-use PhpBench\Expression\Exception\SyntaxError;
 use PhpBench\Expression\InfixParselet;
 use PhpBench\Expression\Parser;
 use PhpBench\Expression\Precedence;

--- a/lib/Expression/Precedence.php
+++ b/lib/Expression/Precedence.php
@@ -4,6 +4,7 @@ namespace PhpBench\Expression;
 
 final class Precedence
 {
+    public const AS = 110;
     public const PRODUCT = 100;
     public const SUM = 90;
     public const TOLERANCE = 90;

--- a/tests/Unit/Expression/Parselet/DisplayAsParseletTest.php
+++ b/tests/Unit/Expression/Parselet/DisplayAsParseletTest.php
@@ -3,8 +3,10 @@
 namespace PhpBench\Tests\Unit\Expression\Parselet;
 
 use Generator;
+use PhpBench\Expression\Ast\ArithmeticOperatorNode;
 use PhpBench\Expression\Ast\DisplayAsNode;
 use PhpBench\Expression\Ast\IntegerNode;
+use PhpBench\Expression\Ast\ParameterNode;
 use PhpBench\Expression\Ast\StringNode;
 use PhpBench\Expression\Ast\UnitNode;
 use PhpBench\Expression\Ast\ValueWithUnitNode;
@@ -31,6 +33,26 @@ class DisplayAsParseletTest extends ParseletTestCase
             new DisplayAsNode(
                 new ValueWithUnitNode(new IntegerNode(1), new UnitNode(new StringNode('ms'))),
                 new UnitNode(new StringNode('microseconds'))
+            )
+        ];
+
+        yield [
+            '1 ms as parameter',
+            new DisplayAsNode(
+                new ValueWithUnitNode(new IntegerNode(1), new UnitNode(new StringNode('ms'))),
+                new UnitNode(new ParameterNode(['parameter']))
+            )
+        ];
+
+        yield [
+            '1 ms as parameter * 2',
+            new ArithmeticOperatorNode(
+                new DisplayAsNode(
+                    new ValueWithUnitNode(new IntegerNode(1), new UnitNode(new StringNode('ms'))),
+                    new UnitNode(new ParameterNode(['parameter']))
+                ),
+                '*',
+                new IntegerNode(2)
             )
         ];
     }

--- a/tests/Unit/Expression/Parselet/DisplayAsParseletTest.php
+++ b/tests/Unit/Expression/Parselet/DisplayAsParseletTest.php
@@ -112,6 +112,5 @@ class DisplayAsParseletTest extends ParseletTestCase
         ];
 
         yield 'default memory unit' => ['100000 as memory < 1 second', [], '100000 bytes < 1 second'];
-
     }
 }

--- a/tests/Unit/Expression/Parselet/DisplayAsParseletTest.php
+++ b/tests/Unit/Expression/Parselet/DisplayAsParseletTest.php
@@ -45,6 +45,15 @@ class DisplayAsParseletTest extends ParseletTestCase
         ];
 
         yield [
+            '1 ms as parameter precision 5',
+            new DisplayAsNode(
+                new ValueWithUnitNode(new IntegerNode(1), new UnitNode(new StringNode('ms'))),
+                new UnitNode(new ParameterNode(['parameter'])),
+                new IntegerNode(5)
+            )
+        ];
+
+        yield 'precedence' => [
             '1 ms as parameter * 2',
             new ArithmeticOperatorNode(
                 new DisplayAsNode(

--- a/tests/Unit/Expression/Parselet/DisplayAsParseletTest.php
+++ b/tests/Unit/Expression/Parselet/DisplayAsParseletTest.php
@@ -45,15 +45,6 @@ class DisplayAsParseletTest extends ParseletTestCase
         ];
 
         yield [
-            '1 ms as parameter precision 5',
-            new DisplayAsNode(
-                new ValueWithUnitNode(new IntegerNode(1), new UnitNode(new StringNode('ms'))),
-                new UnitNode(new ParameterNode(['parameter'])),
-                new IntegerNode(5)
-            )
-        ];
-
-        yield 'precedence' => [
             '1 ms as parameter * 2',
             new ArithmeticOperatorNode(
                 new DisplayAsNode(
@@ -62,6 +53,28 @@ class DisplayAsParseletTest extends ParseletTestCase
                 ),
                 '*',
                 new IntegerNode(2)
+            )
+        ];
+
+        yield [
+            '1 ms as parameter precision 5',
+            new DisplayAsNode(
+                new ValueWithUnitNode(new IntegerNode(1), new UnitNode(new StringNode('ms'))),
+                new UnitNode(new ParameterNode(['parameter'])),
+                new IntegerNode(5)
+            )
+        ];
+
+        yield [
+            '1 ms as parameter precision 5 * 5',
+            new ArithmeticOperatorNode(
+                new DisplayAsNode(
+                    new ValueWithUnitNode(new IntegerNode(1), new UnitNode(new StringNode('ms'))),
+                    new UnitNode(new ParameterNode(['parameter'])),
+                    new IntegerNode(5)
+                ),
+                '*',
+                new IntegerNode(5)
             )
         ];
     }
@@ -99,5 +112,6 @@ class DisplayAsParseletTest extends ParseletTestCase
         ];
 
         yield 'default memory unit' => ['100000 as memory < 1 second', [], '100000 bytes < 1 second'];
+
     }
 }


### PR DESCRIPTION
Necessary for the `OutputTimePrecision` annotation to have any meaning after merging the new expression report.