### PR TITLE
Config runner config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Features:
 - Progress output is sent to STDERR, report output to STDOUT (enable you to
   pipe the output)
 - Allow `--theme=` selection and configuration.
+- Allow benchmarks to be configued in the config (`runner.{iterations,revs,time_unit,mode,etc}`)
 
 Improvements:
 

--- a/lib/Benchmark/Metadata/Driver/ConfigDriver.php
+++ b/lib/Benchmark/Metadata/Driver/ConfigDriver.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace PhpBench\Benchmark\Metadata\Driver;
+
+use PhpBench\Benchmark\Metadata\BenchmarkMetadata;
+use PhpBench\Benchmark\Metadata\DriverInterface;
+use PhpBench\Benchmark\Metadata\ExecutorMetadata;
+use PhpBench\Benchmark\Metadata\SubjectMetadata;
+use PhpBench\Reflection\ReflectionHierarchy;
+
+class ConfigDriver implements DriverInterface
+{
+    /**
+     * @var array|null
+     */
+    private $assert;
+    /**
+     * @var array|null
+     */
+    private $revs;
+    /**
+     * @var string|null
+     */
+    private $executor;
+    /**
+     * @var array
+     */
+    private $warmup;
+    /**
+     * @var float|null
+     */
+    private $timeout;
+
+    /**
+     * @var string|null
+     */
+    private $timeUnit;
+    /**
+     * @var string|null
+     */
+    private $mode;
+    /**
+     * @var array|null
+     */
+    private $iterations;
+    /**
+     * @var string|null
+     */
+    private $format;
+
+    /**
+     * @var DriverInterface
+     */
+    private $innerDriver;
+
+    /**
+     * @param string[] $assert
+     * @param int[] $iterations
+     * @param int[] $revs
+     */
+    public function __construct(
+        DriverInterface $innerDriver,
+        ?array $assert,
+        ?string $executor,
+        ?string $format,
+        ?array $iterations,
+        ?string $mode,
+        ?string $timeUnit,
+        ?array $revs,
+        ?float $timeout,
+        ?array $warmup
+    ) {
+        $this->assert = $assert;
+        $this->executor = $executor;
+        $this->format = $format;
+        $this->iterations = $iterations;
+        $this->mode = $mode;
+        $this->timeUnit = $timeUnit;
+        $this->revs = $revs;
+        $this->timeout = $timeout;
+        $this->warmup = $warmup;
+        $this->innerDriver = $innerDriver;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getMetadataForHierarchy(ReflectionHierarchy $classHierarchy): BenchmarkMetadata
+    {
+        $metadata = $this->innerDriver->getMetadataForHierarchy($classHierarchy);
+
+        foreach ($metadata->getSubjects() as $subject) {
+            $this->setDefaults($subject);
+        }
+
+        return $metadata;
+    }
+
+    private function setDefaults(SubjectMetadata $subject): void
+    {
+        if (empty($subject->getAssertions())) {
+            $subject->setAssertions($this->assert);
+        }
+
+        if ($this->executor && null === $subject->getExecutor()) {
+            $subject->setExecutor(new ExecutorMetadata($this->executor, []));
+        }
+
+        if ($this->format && null === $subject->getFormat()) {
+            $subject->setFormat($this->format);
+        }
+
+        // TODO: Make this empty and set default in config
+        if ($this->iterations && [1] === $subject->getIterations()) {
+            $subject->setIterations($this->iterations);
+        }
+
+        // TODO: Make this empty and set default in config
+        if ($this->revs && [1] === $subject->getRevs()) {
+            $subject->setRevs($this->revs);
+        }
+
+        if ($this->mode && null === $subject->getOutputMode()) {
+            $subject->setOutputMode($this->mode);
+        }
+
+        if ($this->timeUnit && null === $subject->getOutputTimeUnit()) {
+            $subject->setOutputTimeUnit($this->timeUnit);
+        }
+
+        if ($this->timeout && null === $subject->getTimeout()) {
+            $subject->setTimeout($this->timeout);
+        }
+
+        if ($this->warmup && [0] === $subject->getWarmup()) {
+            $subject->setWarmup($this->warmup);
+        }
+    }
+}

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -21,6 +21,7 @@ use PhpBench\Benchmark\Metadata\AnnotationReader;
 use PhpBench\Benchmark\Metadata\Driver\AnnotationDriver;
 use PhpBench\Benchmark\Metadata\Driver\AttributeDriver;
 use PhpBench\Benchmark\Metadata\Driver\ChainDriver;
+use PhpBench\Benchmark\Metadata\Driver\ConfigDriver;
 use PhpBench\Benchmark\Metadata\MetadataFactory;
 use PhpBench\Benchmark\Runner;
 use PhpBench\Console\Application;
@@ -130,6 +131,15 @@ class CoreExtension implements ExtensionInterface
     public const PARAM_ANNOTATIONS = 'annotations';
     public const PARAM_ATTRIBUTES = 'attributes';
     public const PARAM_DEBUG = 'debug';
+    public const PARAM_RUNNER_ASSERT = 'runner.assert';
+    public const PARAM_RUNNER_EXECUTOR = 'runner.executor';
+    public const PARAM_RUNNER_FORMAT = 'runner.format';
+    public const PARAM_RUNNER_ITERATIONS = 'runner.iterations';
+    public const PARAM_RUNNER_OUTPUT_MODE = 'runner.output_mode';
+    public const PARAM_RUNNER_OUTPUT_TIME_UNIT = 'runner.time_unit';
+    public const PARAM_RUNNER_REVS = 'runner.revs';
+    public const PARAM_RUNNER_TIMEOUT = 'runner.timeout';
+    public const PARAM_RUNNER_WARMUP = 'runner.warmup';
 
     public const TAG_EXECUTOR = 'benchmark_executor';
     public const TAG_CONSOLE_COMMAND = 'console.command';
@@ -183,6 +193,17 @@ class CoreExtension implements ExtensionInterface
             self::PARAM_DEBUG => false,
             self::PARAM_CONSOLE_OUTPUT_STREAM => 'php://stdout',
             self::PARAM_CONSOLE_ERROR_STREAM => 'php://stderr',
+
+            self::PARAM_RUNNER_ASSERT => null,
+            self::PARAM_RUNNER_EXECUTOR => null,
+            self::PARAM_RUNNER_FORMAT => null,
+            self::PARAM_RUNNER_ITERATIONS => null,
+            self::PARAM_RUNNER_OUTPUT_MODE => null,
+            self::PARAM_RUNNER_OUTPUT_TIME_UNIT => null,
+            self::PARAM_RUNNER_REVS => null,
+            self::PARAM_RUNNER_TIMEOUT => null,
+            self::PARAM_RUNNER_WARMUP => null,
+
         ]);
 
         $resolver->setAllowedTypes(self::PARAM_DEBUG, ['bool']);
@@ -213,6 +234,15 @@ class CoreExtension implements ExtensionInterface
         $resolver->setAllowedTypes(self::PARAM_PROGRESS_SUMMARY_FORMAT, ['string']);
         $resolver->setAllowedTypes(self::PARAM_PROGRESS_SUMMARY_BASELINE_FORMAT, ['string']);
         $resolver->setAllowedTypes(self::PARAM_CONSOLE_OUTPUT_STREAM, ['string']);
+        $resolver->setAllowedTypes(self::PARAM_RUNNER_ASSERT, ['null', 'string', 'array']);
+        $resolver->setAllowedTypes(self::PARAM_RUNNER_EXECUTOR, ['null', 'string']);
+        $resolver->setAllowedTypes(self::PARAM_RUNNER_FORMAT, ['null', 'string']);
+        $resolver->setAllowedTypes(self::PARAM_RUNNER_ITERATIONS, ['null', 'int', 'array']);
+        $resolver->setAllowedTypes(self::PARAM_RUNNER_OUTPUT_MODE, ['null', 'string']);
+        $resolver->setAllowedTypes(self::PARAM_RUNNER_OUTPUT_TIME_UNIT, ['null', 'string']);
+        $resolver->setAllowedTypes(self::PARAM_RUNNER_REVS, ['null', 'int', 'array']);
+        $resolver->setAllowedTypes(self::PARAM_RUNNER_TIMEOUT, ['null', 'float', 'int']);
+        $resolver->setAllowedTypes(self::PARAM_RUNNER_WARMUP, ['null', 'int', 'array']);
     }
 
     public function load(Container $container): void
@@ -389,7 +419,22 @@ class CoreExtension implements ExtensionInterface
         $container->register(MetadataFactory::class, function (Container $container) {
             return new MetadataFactory(
                 $container->get(RemoteReflector::class),
-                $container->get(ChainDriver::class)
+                $container->get(ConfigDriver::class)
+            );
+        });
+
+        $container->register(ConfigDriver::class, function (Container $container) {
+            return new ConfigDriver(
+                $container->get(ChainDriver::class),
+                (array)$container->getParameter(self::PARAM_RUNNER_ASSERT),
+                $container->getParameter(self::PARAM_RUNNER_EXECUTOR),
+                $container->getParameter(self::PARAM_RUNNER_FORMAT),
+                (array)$container->getParameter(self::PARAM_RUNNER_ITERATIONS),
+                $container->getParameter(self::PARAM_RUNNER_OUTPUT_MODE),
+                $container->getParameter(self::PARAM_RUNNER_OUTPUT_TIME_UNIT),
+                (array)$container->getParameter(self::PARAM_RUNNER_REVS),
+                $container->getParameter(self::PARAM_RUNNER_TIMEOUT),
+                (array)$container->getParameter(self::PARAM_RUNNER_WARMUP)
             );
         });
 

--- a/phpbench.json.dist
+++ b/phpbench.json.dist
@@ -4,6 +4,10 @@
     "php_config": {
         "memory_limit": "1G"
     },
+    "runner.iterations": 10,
+    "runner.revs": 10,
+    "runner.time_unit": "milliseconds",
+    "runner.assert": "mode(variant.time.avg) as ms <= mode(baseline.time.avg) as ms +/- 5%",
     "reports": {
         "all": {
             "generator": "composite",

--- a/tests/Benchmark/Assertion/AssertionProcessorBench.php
+++ b/tests/Benchmark/Assertion/AssertionProcessorBench.php
@@ -9,10 +9,6 @@ use PhpBench\Model\Variant;
 use PhpBench\Tests\Benchmark\IntegrationBenchCase;
 use PhpBench\Tests\Util\VariantBuilder;
 
-/**
- * @OutputTimeUnit("milliseconds")
- * @Assert("mode(variant.time.avg) as ms <= mode(baseline.time.avg) as ms +/- 5%")
- */
 class AssertionProcessorBench extends IntegrationBenchCase
 {
     /**

--- a/tests/Benchmark/Expression/ParserBench.php
+++ b/tests/Benchmark/Expression/ParserBench.php
@@ -9,11 +9,7 @@ use PhpBench\Expression\Parser;
 use PhpBench\Extension\ExpressionExtension;
 
 /**
- * @Revs(10)
- * @Iterations(10)
  * @BeforeMethods({"setUp"})
- * @OutputTimeUnit("microseconds")
- * @Assert("mode(variant.time.avg) as ms < mode(baseline.time.avg) as ms +/- 5%")
  */
 class ParserBench
 {

--- a/tests/Benchmark/IntegrationBenchCase.php
+++ b/tests/Benchmark/IntegrationBenchCase.php
@@ -7,9 +7,6 @@ use PhpBench\Extension\CoreExtension;
 use PhpBench\Extension\ExpressionExtension;
 use Psr\Container\ContainerInterface;
 
-/**
- * @Iterations(10)
- */
 abstract class IntegrationBenchCase
 {
     protected function container(): ContainerInterface

--- a/tests/Benchmark/Progress/VariantSummaryFormatterBench.php
+++ b/tests/Benchmark/Progress/VariantSummaryFormatterBench.php
@@ -9,10 +9,6 @@ use PhpBench\Progress\VariantFormatter;
 use PhpBench\Tests\Benchmark\IntegrationBenchCase;
 use PhpBench\Tests\Util\VariantBuilder;
 
-/**
- * @OutputTimeUnit("milliseconds")
- * @Assert("mode(variant.time.avg) as ms <= mode(baseline.time.avg) as ms +/- 5%")
- */
 class VariantSummaryFormatterBench extends IntegrationBenchCase
 {
     /**

--- a/tests/Benchmark/Report/Generator/ExpressionGeneratorBench.php
+++ b/tests/Benchmark/Report/Generator/ExpressionGeneratorBench.php
@@ -12,9 +12,7 @@ use PhpBench\Tests\Util\TestUtil;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * @OutputTimeUnit("milliseconds")
  * @Assert("mode(variant.time.avg) as ms <= mode(baseline.time.avg) as ms +/- 5%")
- * @Iterations(10)
  */
 class ExpressionGeneratorBench extends IntegrationBenchCase
 {

--- a/tests/Unit/Benchmark/Metadata/Driver/ConfigDriverTest.php
+++ b/tests/Unit/Benchmark/Metadata/Driver/ConfigDriverTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace PhpBench\Tests\Unit\Benchmark\Metadata\Driver;
+
+use DTL\Invoke\Invoke;
+use Generator;
+use PhpBench\Benchmark\Metadata\BenchmarkMetadata;
+use PhpBench\Benchmark\Metadata\Driver\ConfigDriver;
+use PhpBench\Benchmark\Metadata\DriverInterface;
+use PhpBench\Benchmark\Metadata\SubjectMetadata;
+use PhpBench\Reflection\ReflectionHierarchy;
+use PhpBench\Tests\ProphecyTrait;
+use PHPUnit\Framework\TestCase;
+
+class ConfigDriverTest extends TestCase
+{
+    const EXAMPLE_SUBJECT = 'testSubject';
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<DriverInterface>
+     */
+    private $innerDriver;
+
+    /**
+     * @var ReflectionHierarchy
+     */
+    private $hierarchy;
+
+    protected function setUp(): void
+    {
+        $this->hierarchy = new ReflectionHierarchy([]);
+        $this->innerDriver = $this->prophesize(DriverInterface::class);
+    }
+
+    /**
+     * @dataProvider provideDriver
+     */
+    public function testDriver(array $config, callable $assertion): void
+    {
+        $driver = Invoke::new(ConfigDriver::class, array_merge([
+            'innerDriver' => $this->innerDriver->reveal(),
+        ], $config));
+
+        $metadata = new BenchmarkMetadata(__DIR__, 'Foo');
+        $metadata->getOrCreateSubject(self::EXAMPLE_SUBJECT);
+
+        $this->innerDriver->getMetadataForHierarchy($this->hierarchy)->willReturn($metadata);
+
+        assert($driver instanceof DriverInterface);
+        $assertion($driver->getMetadataForHierarchy($this->hierarchy)->getOrCreateSubject(self::EXAMPLE_SUBJECT));
+    }
+
+    public function provideDriver(): Generator
+    {
+        yield [
+            [
+                'assert' => ['example_assert'],
+                'executor' => 'example_executor',
+                'format' => 'example_format',
+                'iterations' => [5],
+                'mode' => 'example_mode',
+                'timeUnit' => 'example_time_unit',
+                'revs' => [10],
+                'timeout' => 20.1,
+                'warmup' => [30],
+            ],
+            function (SubjectMetadata $subject): void {
+                self::assertEquals(['example_assert'], $subject->getAssertions());
+                self::assertEquals('example_executor', $subject->getExecutor()->getName());
+                self::assertEquals('example_format', $subject->getFormat());
+                self::assertEquals([5], $subject->getIterations());
+                self::assertEquals('example_mode', $subject->getOutputMode());
+                self::assertEquals('example_time_unit', $subject->getOutputTimeUnit());
+                self::assertEquals([10], $subject->getRevs());
+                self::assertEquals(20.1, $subject->getTimeout());
+                self::assertEquals([30], $subject->getWarmup());
+            }
+        ];
+    }
+}

--- a/tests/Unit/Extension/CoreExtensionTest.php
+++ b/tests/Unit/Extension/CoreExtensionTest.php
@@ -12,10 +12,12 @@
 
 namespace PhpBench\Tests\Unit\Extension;
 
+use PhpBench\Benchmark\Metadata\Driver\ConfigDriver;
 use PhpBench\DependencyInjection\Container;
-use PhpBench\Tests\TestCase;
+use PhpBench\Extension\CoreExtension;
+use PhpBench\Tests\IntegrationTestCase;
 
-class CoreExtensionTest extends TestCase
+class CoreExtensionTest extends IntegrationTestCase
 {
     protected function tearDown(): void
     {
@@ -49,5 +51,22 @@ class CoreExtensionTest extends TestCase
         ]);
         $container->init();
         $this->assertEquals('travis', $container->getParameter('progress'));
+    }
+
+    public function testConfigDriver(): void
+    {
+        $container = $this->container([
+            CoreExtension::PARAM_RUNNER_ASSERT => 'foobar',
+            CoreExtension::PARAM_RUNNER_EXECUTOR => 'foobar',
+            CoreExtension::PARAM_RUNNER_FORMAT => 'foobar',
+            CoreExtension::PARAM_RUNNER_ITERATIONS => 12,
+            CoreExtension::PARAM_RUNNER_OUTPUT_MODE => 'mode',
+            CoreExtension::PARAM_RUNNER_OUTPUT_TIME_UNIT => 'foobar',
+            CoreExtension::PARAM_RUNNER_REVS => 32,
+            CoreExtension::PARAM_RUNNER_TIMEOUT => 12,
+            CoreExtension::PARAM_RUNNER_WARMUP => 12,
+        ]);
+        $container->get(ConfigDriver::class);
+        $this->addToAssertionCount(1);
     }
 }


### PR DESCRIPTION
Allow certain metadata to be set in the config, e.g. `iterations`, `revs`, `time_unit` etc.