### PR TITLE
Make collected environment data  available in reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Features:
   pipe the output)
 - Allow `--theme=` selection and configuration.
 - Allow benchmarks to be configued in the config (`runner.{iterations,revs,time_unit,mode,etc}`)
+- Include collected environmental information in the report data #789
+- Allow providers to be enabled/disabled via. `env.enabled_providers` #789
 
 Improvements:
 

--- a/docs/report-generators.rst
+++ b/docs/report-generators.rst
@@ -121,6 +121,10 @@ Yielding:
   :language: bash
   :section: 2
 
+Note that any additional result and :doc:`envronment <environment>` data will
+also be included in the form `result_<type>_<metric>` and
+`env_<type>_<metric>`.
+
 ``composite``
 -------------
 

--- a/examples/Command/report-generators-data
+++ b/examples/Command/report-generators-data
@@ -1,4 +1,5 @@
 {
+    "env.enabled_providers": ["test"]
 }
 ---
 phpbench run --report='extends:bare,vertical:true' --executor=debug NothingBench.php --progress=none
@@ -23,6 +24,8 @@ phpbench run --report='extends:bare,vertical:true' --executor=debug NothingBench
 | suite_date             | xxxx-xx-xx    |
 | suite_time             | xx-xx-xx      |
 | iteration_index        | 0             |
+| env_test_example1      | 1             |
+| env_test_example2      | 2             |
 | result_mem_peak        | 100           |
 | result_mem_real        | 100           |
 | result_mem_final       | 100           |

--- a/lib/Environment/Provider/TestProvider.php
+++ b/lib/Environment/Provider/TestProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PhpBench\Environment\Provider;
+
+use PhpBench\Environment\Information;
+use PhpBench\Environment\ProviderInterface;
+
+class TestProvider implements ProviderInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function isApplicable(): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getInformation(): Information
+    {
+        return new Information('test', [
+            'example1' => 1,
+            'example2' => 2,
+        ]);
+    }
+}

--- a/lib/Report/Transform/SuiteCollectionTransformer.php
+++ b/lib/Report/Transform/SuiteCollectionTransformer.php
@@ -118,7 +118,7 @@ final class SuiteCollectionTransformer
      */
     private function createRow(Subject $subject, Variant $variant, Suite $suite, int $itNum): array
     {
-        return [
+        return array_merge([
             'benchmark_name' => $subject->getBenchmark()->getName(),
             'benchmark_class' => $subject->getBenchmark()->getClass(),
             'subject_name' => $subject->getName(),
@@ -134,6 +134,24 @@ final class SuiteCollectionTransformer
             'suite_date' => $suite->getDate()->format('Y-m-d'),
             'suite_time' => $suite->getDate()->format('H:i:s'),
             'iteration_index' => $itNum,
-        ];
+        ], $this->envData($suite));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function envData(Suite $suite): array
+    {
+        $data = [];
+
+        foreach ($suite->getEnvInformations() as $info) {
+            $name = $info->getName();
+
+            foreach ($info as $key => $value) {
+                $data[sprintf('env_%s_%s', $name, $key)] = $value;
+            }
+        }
+
+        return $data;
     }
 }


### PR DESCRIPTION
For the purposes of disabling them in approval tests, possibly also for
increasing the speed of the tests.

This allows, for example, for the PHP version to be included in the report:

```
ParserBench-benchEvaluate
+-----------+--------+--------+-------------+----------------+----------------+
| tag       | xdebug | php    | set         | mode           | rstdev         |
+-----------+--------+--------+-------------+----------------+----------------+
| master    |        | 7.4.14 | comp. w/tol | 0.073ms        | ±2.24%         |
| <current> | false  | 8.0.1  | comp. w/tol | 0.075ms +2.79% | ±1.96% -12.33% |
| master    |        | 7.4.14 | comp.       | 0.065ms        | ±2.25%         |
| <current> | false  | 8.0.1  | comp.       | 0.064ms -2.31% | ±2.17% -3.61%  |
+-----------+--------+--------+-------------+----------------+----------------+

AssertionProcessorBench-benchAssert
+-----------+--------+--------+-----+----------------+---------------+
| tag       | xdebug | php    | set | mode           | rstdev        |
+-----------+--------+--------+-----+----------------+---------------+
| master    |        | 7.4.14 | 0   | 0.329ms        | ±1.61%        |
| <current> | false  | 8.0.1  | 0   | 0.325ms -1.14% | ±1.58% -2.05% |
+-----------+--------+--------+-----+----------------+---------------+

ExpressionGeneratorBench-benchGenerate
+-----------+--------+--------+-----+-----------------+----------------+
| tag       | xdebug | php    | set | mode            | rstdev         |
+-----------+--------+--------+-----+-----------------+----------------+
| master    |        | 7.4.14 | 0   | 14.222ms        | ±2.14%         |
| <current> | false  | 8.0.1  | 0   | 13.542ms -4.78% | ±1.51% -29.20% |
+-----------+--------+--------+-----+-----------------+----------------+

VariantSummaryFormatterBench-benchFormat
+-----------+--------+--------+-----+----------------+----------------+
| tag       | xdebug | php    | set | mode           | rstdev         |
+-----------+--------+--------+-----+----------------+----------------+
| master    |        | 7.4.14 | 0   | 0.536ms        | ±2.21%         |
| <current> | false  | 8.0.1  | 0   | 0.513ms -4.32% | ±1.51% -31.67% |
+-----------+--------+--------+-----+----------------+----------------+
```