### PR TITLE
Preserve the types of env metrics in storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Features:
 
 Improvements:
 
+- Preserve types in env information
 - Make default true color theme compatible with light backgrounds.
 - Added `vertical` layout to `bare` report (`vertical: true`).
 - Removed `best` and `worst` columns by default from default report.

--- a/lib/Environment/Provider/template/opcache.template
+++ b/lib/Environment/Provider/template/opcache.template
@@ -7,6 +7,7 @@ function get_stats()
 {
     $stats = [
         'extension_loaded' => extension_loaded('Zend OPcache'),
+        'enabled' => false,
     ];
 
     if (false === $stats['extension_loaded']) {

--- a/lib/Serializer/XmlDecoder.php
+++ b/lib/Serializer/XmlDecoder.php
@@ -90,11 +90,17 @@ class XmlDecoder
             $name = $envEl->nodeName;
             $info = [];
 
-            foreach ($envEl->childNodes as $value) {
-                if (!$value instanceof Element) {
-                    continue;
+            if ($envEl->childNodes->count()) {
+                foreach ($envEl->childNodes as $value) {
+                    if (!$value instanceof Element) {
+                        continue;
+                    }
+                    $info[$value->getAttribute('name')] = $this->resolveEnvType($value->getAttribute('type'), $value->nodeValue);
                 }
-                $info[$value->getAttribute('name')] = $this->resolveEnvType($value->getAttribute('type'), $value->nodeValue);
+            } else { // legacy format
+                foreach ($envEl->attributes as $iName => $valueAttr) {
+                    $info[$iName] = $valueAttr->nodeValue;
+                }
             }
 
             $informations[$name] = new Information($name, $info);

--- a/lib/Serializer/XmlDecoder.php
+++ b/lib/Serializer/XmlDecoder.php
@@ -86,11 +86,15 @@ class XmlDecoder
         $informations = [];
 
         foreach ($suiteEl->query('./env/*') as $envEl) {
+            assert($envEl instanceof Element);
             $name = $envEl->nodeName;
             $info = [];
 
-            foreach ($envEl->attributes as $iName => $valueAttr) {
-                $info[$iName] = $valueAttr->nodeValue;
+            foreach ($envEl->childNodes as $value) {
+                if (!$value instanceof Element) {
+                    continue;
+                }
+                $info[$value->getAttribute('name')] = $this->resolveEnvType($value->getAttribute('type'), $value->nodeValue);
             }
 
             $informations[$name] = new Information($name, $info);
@@ -284,5 +288,19 @@ class XmlDecoder
 
         // TODO: Serialize statistics ..
         $variant->computeStats();
+    }
+
+    /**
+     * @return mixed
+     *
+     * @param mixed $value
+     */
+    private function resolveEnvType(string $type, $value)
+    {
+        if ($type === 'boolean') {
+            return (bool)$value;
+        }
+
+        return $value;
     }
 }

--- a/lib/Serializer/XmlEncoder.php
+++ b/lib/Serializer/XmlEncoder.php
@@ -61,7 +61,10 @@ class XmlEncoder
                 $infoEl = $envEl->appendElement($information->getName());
 
                 foreach ($information as $key => $value) {
-                    $infoEl->setAttribute($key, $value);
+                    $valueEl = $infoEl->appendElement('value');
+                    $valueEl->setAttribute('name', $key);
+                    $valueEl->setAttribute('type', gettype($value));
+                    $valueEl->nodeValue = $value;
                 }
             }
 

--- a/tests/Unit/Serializer/XmlDecoderTest.php
+++ b/tests/Unit/Serializer/XmlDecoderTest.php
@@ -144,6 +144,31 @@ EOT
         self::assertIsBool($env->offsetGet('foo'));
     }
 
+    public function testDecodeLegacyEnv(): void
+    {
+        $dom = new Document(1.0);
+        $dom->loadXML(<<<EOT
+<phpbench>
+  <suite>
+    <env>
+<uname os="Linux" host="x1-debian" release="5.4.0-4-amd64" version="#1 SMP Debian 5.4.19-1 (2020-02-13)" machine="x86_64"/><php xdebug="1" version="7.3.15-3" ini="/etc/php/7.3/cli/php.ini" extensions="Core, date, libxml, openssl, pcre, zlib, filter, hash, pcntl, Reflection, SPL, session, sodium, standard, mysqlnd, PDO, xml, apcu, bcmath, bz2, calendar, ctype, curl, dom, mbstring, fileinfo, ftp, gd, gettext, iconv, igbinary, imagick, intl, json, ldap, exif, mysqli, pdo_mysql, pdo_pgsql, pdo_sqlite, pgsql, apc, posix, readline, redis, shmop, SimpleXML, sockets, sqlite3, sysvmsg, sysvsem, sysvshm, tokenizer, wddx, xmlreader, xmlwriter, xsl, zip, Phar, blackfire, Zend OPcache, xdebug"/><opcache extension_loaded="1" enabled=""/>
+    </env>
+  </suite>
+</phpbench>
+EOT
+        );
+        $decoder = new XmlDecoder();
+        $collection = $decoder->decode($dom);
+        $suite = $collection->getSuites()[0];
+        assert($suite instanceof Suite);
+        $envs = $suite->getEnvInformations();
+        self::assertCount(3, $envs);
+        $env = reset($envs);
+        self::assertInstanceOf(Information::class, $env);
+        assert($env instanceof Information);
+        self::assertCount(5, $env);
+    }
+
     private function encode(SuiteCollection $collection)
     {
         $xmlEncoder = new XmlEncoder();

--- a/tests/Unit/Serializer/XmlDecoderTest.php
+++ b/tests/Unit/Serializer/XmlDecoderTest.php
@@ -13,6 +13,8 @@
 namespace PhpBench\Tests\Unit\Serializer;
 
 use PhpBench\Dom\Document;
+use PhpBench\Environment\Information;
+use PhpBench\Model\Suite;
 use PhpBench\Model\SuiteCollection;
 use PhpBench\Serializer\XmlDecoder;
 use PhpBench\Serializer\XmlEncoder;
@@ -113,6 +115,33 @@ EOT
         );
         $decoder = new XmlDecoder();
         $collection = $decoder->decode($dom);
+    }
+
+    public function testDecodeBoolValue(): void
+    {
+        $dom = new Document(1.0);
+        $dom->loadXML(<<<EOT
+<phpbench>
+  <suite>
+    <env>
+      <info1>
+        <value name="foo" type="boolean">1</value>
+      </info1>
+    </env>
+  </suite>
+</phpbench>
+EOT
+        );
+        $decoder = new XmlDecoder();
+        $collection = $decoder->decode($dom);
+        $suite = $collection->getSuites()[0];
+        assert($suite instanceof Suite);
+        $envs = $suite->getEnvInformations();
+        self::assertCount(1, $envs);
+        $env = reset($envs);
+        self::assertInstanceOf(Information::class, $env);
+        assert($env instanceof Information);
+        self::assertIsBool($env->offsetGet('foo'));
     }
 
     private function encode(SuiteCollection $collection)

--- a/tests/Unit/Serializer/XmlTestCase.php
+++ b/tests/Unit/Serializer/XmlTestCase.php
@@ -155,7 +155,9 @@ class XmlTestCase extends TestCase
 <phpbench xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="PHPBENCH_VERSION">
   <suite tag="test" context="test" date="2015-01-01T00:00:00+00:00" config-path="/path/to/config.json" uuid="1234">
     <env>
-      <info1 foo="bar"/>
+      <info1>
+        <value name="foo" type="string">bar</value>
+      </info1>
     </env>
     <benchmark class="Bench1">
       <subject name="subjectName">
@@ -190,7 +192,9 @@ EOT
 <phpbench xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="PHPBENCH_VERSION">
   <suite tag="test" context="test" date="2015-01-01T00:00:00+00:00" config-path="/path/to/config.json" uuid="1234">
     <env>
-      <info1 foo="bar"/>
+      <info1>
+        <value name="foo" type="string">bar</value>
+      </info1>
     </env>
     <benchmark class="Bench1">
       <subject name="subjectName">
@@ -215,7 +219,9 @@ EOT
 <phpbench xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="PHPBENCH_VERSION">
   <suite tag="test" context="test" date="2015-01-01T00:00:00+00:00" config-path="/path/to/config.json" uuid="1234">
     <env>
-      <info1 foo="bar"/>
+      <info1>
+        <value name="foo" type="string">bar</value>
+      </info1>
     </env>
     <benchmark class="Bench1">
       <subject name="subjectName">


### PR DESCRIPTION
All env values were previously decoded as strings - which made the env report look inconsistent.