### PR TITLE
Renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ master
 
 B/C breaks:
 
+- Most configuration option names have changed. All options are now prefixed
+  by their extension name, e.g. `bootstrap` => `runner.bootstrap`, `path` =>
+  `runner.path`, `extensions` => `core.extensions`. See the configuration
+  [documentation(https://phpbench.readthedocs.io/en/latest/configuration.html)
+  for a full reference.
+- Removed `time_unit` and `time_mode` configuration settings, as they are
+  replaced by `runner.time_unit` and `runner.time_mode`.
 - Environment provider `baseline` renamed to `sampler` to avoid
   concept-conflict with the runner baselines.
 

--- a/docs/benchmark-runner.rst
+++ b/docs/benchmark-runner.rst
@@ -70,7 +70,7 @@ You may specify these options multiple times.
 Overriding the Bootstrap
 ------------------------
 
-You can override or set the :ref:`configuration_bootstrap` using the
+You can override or set the :ref:`configuration_runner_bootstrap` using the
 ``--bootstrap`` option:
 
 .. code-block:: bash
@@ -140,7 +140,7 @@ but the longer it will take for a set of iterations to be resolved.
 By default the retry threshold is disabled.
 
 You may also set the retry threshold in the
-:ref:`configuration <configuration_retry_threshold>`.
+:ref:`configuration <configuration_runner_retry_threshold>`.
 
 Changing the Output Format
 --------------------------

--- a/docs/configuration-prelude.rst
+++ b/docs/configuration-prelude.rst
@@ -6,16 +6,15 @@ that order and use one if it exists.
 .. code-block:: json
 
     {
-        "bootstrap": "vendor/autoload.php",
-        "path": "path/to/benchmarks",
-        "outputs": {
-             "my_output": {
-                 "extends": "html",
-                 "file": "my_report.html",
-                 "title": "Hello World"
+        "runner.bootstrap": "vendor/autoload.php",
+        "runner.path": "path/to/benchmarks",
+        "report.outputs": {
+             "my_csv_output": {
+                 "extends": "delimited",
+                 "delimiter": ",",
              }
         },
-        "reports": {
+        "report.generators": {
             "my_report": {
                 "extends": "aggregate"
             }

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -486,10 +486,10 @@ Storage
 
 Extension class: ``PhpBench\Extension\StorageExtension``
 
-.. _configuration_storage:
+.. _configuration_storage_driver:
 
-storage
-~~~~~~~
+storage.driver
+~~~~~~~~~~~~~~
 
 Storage driver to use
 
@@ -497,10 +497,10 @@ Default: ``"xml"``
 
 Types: ``["string"]``
 
-.. _configuration_xml_storage_path:
+.. _configuration_storage_xml_storage_path:
 
-xml_storage_path
-~~~~~~~~~~~~~~~~
+storage.xml_storage_path
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Path to store benchmark runs when they are stored with ``--store`` or ``--tag=foo``
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -12,50 +12,6 @@ Core
 
 Extension class: ``PhpBench\Extension\CoreExtension``
 
-.. _configuration_console_ansi:
-
-console.ansi
-~~~~~~~~~~~~
-
-Enable or disable ANSI control characters (e.g. console colors)
-
-Default: ``true``
-
-Types: ``["bool"]``
-
-.. _configuration_console_disable_output:
-
-console_disable_output
-~~~~~~~~~~~~~~~~~~~~~~
-
-Do not output anything
-
-Default: ``false``
-
-Types: ``["bool"]``
-
-.. _configuration_console_output_stream:
-
-console_output_stream
-~~~~~~~~~~~~~~~~~~~~~
-
-Change the normal output stream - the output stream used for reports
-
-Default: ``"php:\/\/stdout"``
-
-Types: ``["string"]``
-
-.. _configuration_console_error_stream:
-
-console_error_stream
-~~~~~~~~~~~~~~~~~~~~
-
-Change the error output stream - the output stream used for diagnostics (e.g. progress loggers use this stream)
-
-Default: ``"php:\/\/stderr"``
-
-Types: ``["string"]``
-
 .. _configuration_debug:
 
 debug
@@ -551,6 +507,55 @@ xdebug.command.handler.output_dir
 Output directory for generated XDebug profiles
 
 Default: ``".phpbench\/xdebug-profile"``
+
+Types: ``["string"]``
+
+Console
+-------
+
+Extension class: ``PhpBench\Extension\ConsoleExtension``
+
+.. _configuration_console_ansi:
+
+console.ansi
+~~~~~~~~~~~~
+
+Enable or disable ANSI control characters (e.g. console colors)
+
+Default: ``true``
+
+Types: ``["bool"]``
+
+.. _configuration_console_disable_output:
+
+console.disable_output
+~~~~~~~~~~~~~~~~~~~~~~
+
+
+
+Default: ``false``
+
+Types: ``["bool"]``
+
+.. _configuration_console_output_stream:
+
+console.output_stream
+~~~~~~~~~~~~~~~~~~~~~
+
+Change the normal output stream - the output stream used for reports
+
+Default: ``"php:\/\/stdout"``
+
+Types: ``["string"]``
+
+.. _configuration_console_error_stream:
+
+console.error_stream
+~~~~~~~~~~~~~~~~~~~~
+
+Change the error output stream - the output stream used for diagnostics (e.g. progress loggers use this stream)
+
+Default: ``"php:\/\/stderr"``
 
 Types: ``["string"]``
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -34,28 +34,6 @@ Default: ``[]``
 
 Types: ``["array"]``
 
-.. _configuration_core_output_mode:
-
-core.output_mode
-~~~~~~~~~~~~~~~~
-
-Default output mode (e.g. throughput or net time)
-
-Default: ``"time"``
-
-Types: ``["string"]``
-
-.. _configuration_core_time_unit:
-
-core.time_unit
-~~~~~~~~~~~~~~
-
-Default time unit
-
-Default: ``"microseconds"``
-
-Types: ``["string"]``
-
 .. _configuration_core_working_dir:
 
 core.working_dir
@@ -86,14 +64,14 @@ core.profiles
 Alternative configurations::
 
     {
-        "profiles": {
+        "core.profiles": {
             "php8": {
                 "runner.php_bin": "/bin/php8"
             }
         }
     }
 
-The named configuration will be merged with the default configuration, and can be used via::
+The named configuration will be merged with the default configuration, and can be used via:
 
 .. code-block:: bash
 
@@ -163,10 +141,10 @@ Default: ``["sampler","git","opcache","php","uname","unix_sysload"]``
 
 Types: ``["array"]``
 
-.. _configuration_runner_env_baselines:
+.. _configuration_runner_env_samplers:
 
-runner.env_baselines
-~~~~~~~~~~~~~~~~~~~~
+runner.env_samplers
+~~~~~~~~~~~~~~~~~~~
 
 Environment baselines (not to be confused with baseline comparisons when running benchmarks) are small benchmarks which run to sample the speed of the system (e.g. file I/O, computation etc). This setting enables or disables these baselines
 
@@ -174,10 +152,10 @@ Default: ``["nothing","md5","file_rw"]``
 
 Types: ``["array"]``
 
-.. _configuration_runner_env_baseline_callables:
+.. _configuration_runner_env_sampler_callables:
 
-runner.env_baseline_callables
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+runner.env_sampler_callables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Map of baseline callables (adds you to register a new environemntal baseline)
 
@@ -515,7 +493,7 @@ Extension class: ``PhpBench\Extensions\XDebug\XDebugExtension``
 
 .. _configuration_xdebug_command_handler_output_dir:
 
-xdebug.command.handler.output_dir
+xdebug.command_handler_output_dir
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Output directory for generated XDebug profiles

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -83,10 +83,10 @@ Runner
 
 Extension class: ``PhpBench\Extension\RunnerExtension``
 
-.. _configuration_annotations:
+.. _configuration_runner_annotations:
 
-annotations
-~~~~~~~~~~~
+runner.annotations
+~~~~~~~~~~~~~~~~~~
 
 Read metadata from annotations
 
@@ -94,10 +94,10 @@ Default: ``true``
 
 Types: ``["bool"]``
 
-.. _configuration_annotation_import_use:
+.. _configuration_runner_annotation_import_use:
 
-annotation_import_use
-~~~~~~~~~~~~~~~~~~~~~
+runner.annotation_import_use
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Require that annotations be imported before use
 
@@ -105,10 +105,10 @@ Default: ``false``
 
 Types: ``["bool"]``
 
-.. _configuration_attributes:
+.. _configuration_runner_attributes:
 
-attributes
-~~~~~~~~~~
+runner.attributes
+~~~~~~~~~~~~~~~~~
 
 Read metadata from PHP 8 attributes
 
@@ -116,10 +116,10 @@ Default: ``true``
 
 Types: ``["bool"]``
 
-.. _configuration_bootstrap:
+.. _configuration_runner_bootstrap:
 
-bootstrap
-~~~~~~~~~
+runner.bootstrap
+~~~~~~~~~~~~~~~~
 
 Path to bootstrap (e.g. ``vendor/autoload.php``)
 
@@ -127,10 +127,10 @@ Default: ``null``
 
 Types: ``["string","null"]``
 
-.. _configuration_env_enabled_providers:
+.. _configuration_runner_env_enabled_providers:
 
-env.enabled_providers
-~~~~~~~~~~~~~~~~~~~~~
+runner.env_enabled_providers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Select which environment samplers to use
 
@@ -138,10 +138,10 @@ Default: ``["sampler","git","opcache","php","uname","unix_sysload"]``
 
 Types: ``["array"]``
 
-.. _configuration_env_baselines:
+.. _configuration_runner_env_baselines:
 
-env_baselines
-~~~~~~~~~~~~~
+runner.env_baselines
+~~~~~~~~~~~~~~~~~~~~
 
 Environment baselines (not to be confused with baseline comparisons when running benchmarks) are small benchmarks which run to sample the speed of the system (e.g. file I/O, computation etc). This setting enables or disables these baselines
 
@@ -149,10 +149,10 @@ Default: ``["nothing","md5","file_rw"]``
 
 Types: ``["array"]``
 
-.. _configuration_env_baseline_callables:
+.. _configuration_runner_env_baseline_callables:
 
-env_baseline_callables
-~~~~~~~~~~~~~~~~~~~~~~
+runner.env_baseline_callables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Map of baseline callables (adds you to register a new environemntal baseline)
 
@@ -160,10 +160,10 @@ Default: ``[]``
 
 Types: ``["array"]``
 
-.. _configuration_executors:
+.. _configuration_runner_executors:
 
-executors
-~~~~~~~~~
+runner.executors
+~~~~~~~~~~~~~~~~
 
 Add new executor configurations
 
@@ -171,10 +171,10 @@ Default: ``[]``
 
 Types: ``["array"]``
 
-.. _configuration_path:
+.. _configuration_runner_path:
 
-path
-~~~~
+runner.path
+~~~~~~~~~~~
 
 Path or paths to the benchmarks
 
@@ -182,10 +182,10 @@ Default: ``null``
 
 Types: ``["string","array","null"]``
 
-.. _configuration_php_binary:
+.. _configuration_runner_php_binary:
 
-php_binary
-~~~~~~~~~~
+runner.php_binary
+~~~~~~~~~~~~~~~~~
 
 Specify a PHP binary to use when executing out-of-band benchmarks, e.g. ``/usr/bin/php6``, defaults to the version of PHP used to invoke PHPBench
 
@@ -193,10 +193,10 @@ Default: ``null``
 
 Types: ``["string","null"]``
 
-.. _configuration_php_config:
+.. _configuration_runner_php_config:
 
-php_config
-~~~~~~~~~~
+runner.php_config
+~~~~~~~~~~~~~~~~~
 
 Map of PHP ini settings to use when executing out-of-band benchmarks
 
@@ -204,10 +204,10 @@ Default: ``[]``
 
 Types: ``["array"]``
 
-.. _configuration_php_disable_ini:
+.. _configuration_runner_php_disable_ini:
 
-php_disable_ini
-~~~~~~~~~~~~~~~
+runner.php_disable_ini
+~~~~~~~~~~~~~~~~~~~~~~
 
 Disable reading the default PHP configuration
 
@@ -215,10 +215,10 @@ Default: ``false``
 
 Types: ``["bool"]``
 
-.. _configuration_php_wrapper:
+.. _configuration_runner_php_wrapper:
 
-php_wrapper
-~~~~~~~~~~~
+runner.php_wrapper
+~~~~~~~~~~~~~~~~~~
 
 Wrap the PHP binary with this command (e.g. ``blackfire run``)
 
@@ -226,10 +226,10 @@ Default: ``null``
 
 Types: ``["string","null"]``
 
-.. _configuration_progress:
+.. _configuration_runner_progress:
 
-progress
-~~~~~~~~
+runner.progress
+~~~~~~~~~~~~~~~
 
 Default progress logger to use
 
@@ -237,10 +237,10 @@ Default: ``"verbose"``
 
 Types: ``["string"]``
 
-.. _configuration_progress_summary_variant_format:
+.. _configuration_runner_progress_summary_variant_format:
 
-progress_summary_variant_format
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+runner.progress_summary_variant_format
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Expression used to render the summary text default progress loggers
 
@@ -248,10 +248,10 @@ Default: ``"\"Mo\" ~ display_as_time(mode(variant.time.avg), coalesce(subject.ti
 
 Types: ``["string"]``
 
-.. _configuration_progress_summary_baseline_format:
+.. _configuration_runner_progress_summary_baseline_format:
 
-progress_summary_baseline_format
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+runner.progress_summary_baseline_format
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When the a comparison benchmark is referenced, alternative expression used to render the summary text default progress loggers
 
@@ -259,10 +259,10 @@ Default: ``"\"[\" ~ \n\"Mo\" ~ display_as_time(mode(variant.time.avg), coalesce(
 
 Types: ``["string"]``
 
-.. _configuration_remote_script_path:
+.. _configuration_runner_remote_script_path:
 
-remote_script_path
-~~~~~~~~~~~~~~~~~~
+runner.remote_script_path
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 PHPBench generates a PHP file for out-of-band benchmarks which is executed, this setting specifies the path to this file. When NULL a file in the systems temporary directory will be used
 
@@ -270,27 +270,16 @@ Default: ``null``
 
 Types: ``["string","null"]``
 
-.. _configuration_remote_script_remove:
+.. _configuration_runner_remote_script_remove:
 
-remote_script_remove
-~~~~~~~~~~~~~~~~~~~~
+runner.remote_script_remove
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the generated file should be removed after it has been executed (useful for debugging)
 
 Default: ``true``
 
 Types: ``["bool"]``
-
-.. _configuration_retry_threshold:
-
-retry_threshold
-~~~~~~~~~~~~~~~
-
-DEPRECATED: use :ref:`configuration_runner_retry_threshold` instead
-
-Default: ``null``
-
-Types: ``["null","int","float"]``
 
 .. _configuration_runner_assert:
 
@@ -402,10 +391,10 @@ Default: ``null``
 
 Types: ``["null","int","array"]``
 
-.. _configuration_subject_pattern:
+.. _configuration_runner_subject_pattern:
 
-subject_pattern
-~~~~~~~~~~~~~~~
+runner.subject_pattern
+~~~~~~~~~~~~~~~~~~~~~~
 
 Subject prefix to use when finding benchmarks
 
@@ -418,10 +407,10 @@ Report
 
 Extension class: ``PhpBench\Extension\ReportExtension``
 
-.. _configuration_reports:
+.. _configuration_report_generators:
 
-reports
-~~~~~~~
+report.generators
+~~~~~~~~~~~~~~~~~
 
 Report generator configurations, see :doc:`report-generators`
 
@@ -429,10 +418,10 @@ Default: ``[]``
 
 Types: ``["array"]``
 
-.. _configuration_outputs:
+.. _configuration_report_outputs:
 
-outputs
-~~~~~~~
+report.outputs
+~~~~~~~~~~~~~~
 
 Report renderer configurations, see :doc:`report-renderers`
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -12,10 +12,10 @@ Core
 
 Extension class: ``PhpBench\Extension\CoreExtension``
 
-.. _configuration_debug:
+.. _configuration_core_debug:
 
-debug
-~~~~~
+core.debug
+~~~~~~~~~~
 
 If enabled output debug messages (e.g. the commands being executed when running benchamrks). Same as ``-vvv``
 
@@ -23,10 +23,10 @@ Default: ``false``
 
 Types: ``["bool"]``
 
-.. _configuration_extensions:
+.. _configuration_core_extensions:
 
-extensions
-~~~~~~~~~~
+core.extensions
+~~~~~~~~~~~~~~~
 
 List of additional extensions to enable
 
@@ -34,10 +34,10 @@ Default: ``[]``
 
 Types: ``["array"]``
 
-.. _configuration_output_mode:
+.. _configuration_core_output_mode:
 
-output_mode
-~~~~~~~~~~~
+core.output_mode
+~~~~~~~~~~~~~~~~
 
 Default output mode (e.g. throughput or net time)
 
@@ -45,10 +45,10 @@ Default: ``"time"``
 
 Types: ``["string"]``
 
-.. _configuration_time_unit:
+.. _configuration_core_time_unit:
 
-time_unit
-~~~~~~~~~
+core.time_unit
+~~~~~~~~~~~~~~
 
 Default time unit
 
@@ -56,10 +56,10 @@ Default: ``"microseconds"``
 
 Types: ``["string"]``
 
-.. _configuration_working_dir:
+.. _configuration_core_working_dir:
 
-working_dir
-~~~~~~~~~~~
+core.working_dir
+~~~~~~~~~~~~~~~~
 
 Working directory to use
 
@@ -67,16 +67,41 @@ Default: ``"\/home\/daniel\/www\/phpbench\/phpbench"``
 
 Types: ``["string"]``
 
-.. _configuration_config_path:
+.. _configuration_core_config_path:
 
-config_path
-~~~~~~~~~~~
+core.config_path
+~~~~~~~~~~~~~~~~
 
 Alternative path to a PHPBench configuration file (default is ``phpbench.json``
 
 Default: ``null``
 
 Types: ``["string","null"]``
+
+.. _configuration_core_profiles:
+
+core.profiles
+~~~~~~~~~~~~~
+
+Alternative configurations::
+
+    {
+        "profiles": {
+            "php8": {
+                "runner.php_bin": "/bin/php8"
+            }
+        }
+    }
+
+The named configuration will be merged with the default configuration, and can be used via::
+
+.. code-block:: bash
+
+    $ phpbench run --profile=php8
+
+Default: ``[]``
+
+Types: ``["array"]``
 
 Runner
 ------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -523,7 +523,7 @@ Types: ``["bool"]``
 console.disable_output
 ~~~~~~~~~~~~~~~~~~~~~~
 
-
+Disable output from both STDOUT and STDERR
 
 Default: ``false``
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -25,7 +25,7 @@ Types: ``["bool"]``
 
 .. _configuration_console_disable_output:
 
-console.disable_output
+console_disable_output
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Do not output anything
@@ -36,7 +36,7 @@ Types: ``["bool"]``
 
 .. _configuration_console_output_stream:
 
-console.output_stream
+console_output_stream
 ~~~~~~~~~~~~~~~~~~~~~
 
 Change the normal output stream - the output stream used for reports
@@ -47,7 +47,7 @@ Types: ``["string"]``
 
 .. _configuration_console_error_stream:
 
-console.error_stream
+console_error_stream
 ~~~~~~~~~~~~~~~~~~~~
 
 Change the error output stream - the output stream used for diagnostics (e.g. progress loggers use this stream)

--- a/docs/development/debugging.rst
+++ b/docs/development/debugging.rst
@@ -17,8 +17,8 @@ render this template in a local directory and ensure that it is not deleted.
 .. code-block:: json
 
     {
-        "remote_script_path": ".phpbench/script",
-        "remote_script_remove": false
+        "runner.remote_script_path": ".phpbench/script",
+        "runner.remote_script_remove": false
     }
 
 Each remove will be rendered in this directory and can be executed with ``php

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -62,7 +62,7 @@ Create a ``phpbench.json`` file in the projects root directory:
 .. code-block:: json
 
     {
-        "bootstrap": "vendor/autoload.php"
+        "runner.bootstrap": "vendor/autoload.php"
     }
 
 .. note::
@@ -247,8 +247,8 @@ To finish off, add the path and new report to the configuration file:
 .. code-block:: json
 
     {
-        "path": "tests/Benchmark",
-        "reports": {
+        "runner.path": "tests/Benchmark",
+        "report.generators": {
             "consumation_of_time": {
                 "extends": "default",
                 "title": "The Consumation of Time",

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -75,7 +75,7 @@ Create a ``phpbench.json`` file in the projects root directory:
 
     Some PHP extensions such as Xdebug will affect the performance of your
     benchmark subjects and you may want to disable them, see :ref:`Disabling
-    the PHP INI file <configuration_php_disable_ini>`.
+    the PHP INI file <configuration_runner_php_disable_ini>`.
 
 Creating and running a benchmark
 --------------------------------
@@ -280,7 +280,7 @@ In this tutorial you learnt to
 - :doc:`Configure <configuration>` PHPBench for a project
 - Create a benchmarking class
 - Use :ref:`revolutions <metadata_revolutions>` and :ref:`iterations <metadata_iterations>` to more accurately profile your code
-- Increase stability with the :ref:`retry threshold <configuration_retry_threshold>`
+- Increase stability with the :ref:`retry threshold <configuration_runner_retry_threshold>`
 - Use :doc:`reports <reports>`
 
 .. _Composer: http://getcomposer.org

--- a/docs/reports.rst
+++ b/docs/reports.rst
@@ -37,7 +37,7 @@ Configuring Reports
 -------------------
 
 All reports can be configured either in the :ref:`report configuration
-<configuration_reports>` or directly on the command line using a simplified
+<configuration_report_generators>` or directly on the command line using a simplified
 JSON encoded string instead of the report name:
 
 To configure a report in ``phpbench.json``:

--- a/docs/writing-benchmarks.rst
+++ b/docs/writing-benchmarks.rst
@@ -52,7 +52,7 @@ placed in the class docblock, or on individual methods docblocks.
 .. note::
 
     Instead of prefixing a method with ``bench`` you can use the
-    ``@Subject`` annotation or specify a :ref:`custom pattern <configuration_subject_pattern>`.
+    ``@Subject`` annotation or specify a :ref:`custom pattern <configuration_runner_subject_pattern>`.
 
 Benchmark Configuration
 -----------------------

--- a/examples/Benchmark/Macro/BaseBenchCase.php
+++ b/examples/Benchmark/Macro/BaseBenchCase.php
@@ -13,6 +13,7 @@
 namespace PhpBench\Examples\Benchmark\Macro;
 
 use PhpBench\DependencyInjection\Container;
+use PhpBench\Extension\ConsoleExtension;
 use PhpBench\Extension\CoreExtension;
 use PhpBench\Extension\ExpressionExtension;
 use PhpBench\Extension\ReportExtension;
@@ -43,6 +44,7 @@ class BaseBenchCase
         ReportExtension::class,
         StorageExtension::class,
         ExpressionExtension::class,
+        ConsoleExtension::class,
     ];
 
     private $config = [];
@@ -83,7 +85,7 @@ class BaseBenchCase
     protected function getContainer()
     {
         $container = new Container($this->extensions, array_merge([
-            CoreExtension::PARAM_DISABLE_OUTPUT => true,
+            ConsoleExtension::PARAM_DISABLE_OUTPUT => true,
         ], $this->config));
         $container->init();
 

--- a/examples/Command/report-generators-break
+++ b/examples/Command/report-generators-break
@@ -1,5 +1,5 @@
 {
-    "reports": {
+    "report.generators": {
          "my-report": {
              "generator": "expression",
              "break": ["benchmark"],

--- a/examples/Command/report-generators-column-override
+++ b/examples/Command/report-generators-column-override
@@ -1,5 +1,5 @@
 {
-    "reports": {
+    "report.generators": {
          "my-report": {
              "generator": "expression",
              "cols": {

--- a/examples/Command/report-generators-column-visibility
+++ b/examples/Command/report-generators-column-visibility
@@ -1,5 +1,5 @@
 {
-    "reports": {
+    "report.generators": {
          "my-report": {
              "generator": "expression",
              "cols": ["subject", "mode"]

--- a/examples/Command/report-generators-composite
+++ b/examples/Command/report-generators-composite
@@ -1,8 +1,8 @@
 {
-    "path": "NothingBench.php",
+    "runner.path": "NothingBench.php",
     "runner.executor": "debug",
-    "env.enabled_providers": ["test"],
-    "reports": {
+    "runner.env_enabled_providers": ["test"],
+    "report.generators": {
         "all": {
             "generator": "composite",
             "reports": [ "default", "aggregate", "env" ]

--- a/examples/Command/report-generators-data
+++ b/examples/Command/report-generators-data
@@ -1,5 +1,5 @@
 {
-    "env.enabled_providers": ["test"]
+    "runner.env_enabled_providers": ["test"]
 }
 ---
 phpbench run --report='extends:bare,vertical:true' --executor=debug NothingBench.php --progress=none

--- a/examples/Command/report-generators-expressions
+++ b/examples/Command/report-generators-expressions
@@ -1,5 +1,5 @@
 {
-    "reports": {
+    "report.generators": {
          "my-report": {
              "generator": "expression",
              "expressions": {

--- a/examples/Command/report-ref-latest-and-aggregate
+++ b/examples/Command/report-ref-latest-and-aggregate
@@ -1,5 +1,5 @@
 {
-    "path": "NothingBench.php",
+    "runner.path": "NothingBench.php",
     "runner.executor": "debug"
 }
 ---

--- a/examples/Command/run-configuring-reports
+++ b/examples/Command/run-configuring-reports
@@ -1,5 +1,5 @@
 {
-    "path": "NothingBench.php",
+    "runner.path": "NothingBench.php",
     "runner.executor": "debug"
 }
 ---

--- a/examples/Command/run-configuring-reports-extend
+++ b/examples/Command/run-configuring-reports-extend
@@ -1,5 +1,5 @@
 {
-    "path": "NothingBench.php",
+    "runner.path": "NothingBench.php",
     "runner.executor": "debug"
 }
 ---

--- a/examples/Command/run-configuring-reports-phpbenchjson
+++ b/examples/Command/run-configuring-reports-phpbenchjson
@@ -1,7 +1,7 @@
 {
-    "path": "NothingBench.php",
+    "runner.path": "NothingBench.php",
     "runner.executor": "debug",
-    "reports": {
+    "report.generators": {
         "my-report": {
             "generator": "expression",
             "cols": [ "benchmark", "tag", "subject", "mean" ],

--- a/examples/Command/run-reports-aggregate
+++ b/examples/Command/run-reports-aggregate
@@ -1,5 +1,5 @@
 {
-    "path": "NothingBench.php",
+    "runner.path": "NothingBench.php",
     "runner.executor": "debug"
 }
 ---

--- a/examples/Command/run-reports-aggregate-and-env
+++ b/examples/Command/run-reports-aggregate-and-env
@@ -1,5 +1,5 @@
 {
-    "path": "NothingBench.php",
+    "runner.path": "NothingBench.php",
     "runner.executor": "debug"
 }
 ---

--- a/examples/Command/run-reports-default
+++ b/examples/Command/run-reports-default
@@ -1,5 +1,5 @@
 {
-    "path": "NothingBench.php",
+    "runner.path": "NothingBench.php",
     "runner.executor": "debug"
 }
 ---

--- a/examples/Command/run-reports-env
+++ b/examples/Command/run-reports-env
@@ -1,7 +1,7 @@
 {
-    "path": "NothingBench.php",
+    "runner.path": "NothingBench.php",
     "runner.executor": "debug",
-    "env.enabled_providers": ["test"]
+    "runner.env_enabled_providers": ["test"]
 }
 ---
 phpbench run --report=env

--- a/examples/Extension/AcmeExtension.php
+++ b/examples/Extension/AcmeExtension.php
@@ -8,6 +8,7 @@ use PhpBench\Examples\Extension\Command\CatsCommand;
 use PhpBench\Examples\Extension\Executor\AcmeExecutor;
 use PhpBench\Examples\Extension\ProgressLogger\CatLogger;
 use PhpBench\Examples\Extension\Report\AcmeGenerator;
+use PhpBench\Extension\ConsoleExtension;
 use PhpBench\Extension\CoreExtension;
 use PhpBench\Extension\ReportExtension;
 use PhpBench\Extension\RunnerExtension;
@@ -42,17 +43,17 @@ class AcmeExtension implements ExtensionInterface
         $container->register(CatsCommand::class, function (Container $container) {
             return new CatsCommand($container->getParameter(self::PARAM_NUMBER_OF_CATS));
         }, [
-            CoreExtension::TAG_CONSOLE_COMMAND => []
+            ConsoleExtension::TAG_CONSOLE_COMMAND => []
         ]);
         // endsection: command_di
         
         // section: progress_logger_di
         $container->register(CatLogger::class, function (Container $container) {
             return new CatLogger(
-                $container->get(CoreExtension::SERVICE_OUTPUT_ERR)
+                $container->get(ConsoleExtension::SERVICE_OUTPUT_ERR)
             );
         }, [
-            CoreExtension::TAG_PROGRESS_LOGGER => [
+            RunnerExtension::TAG_PROGRESS_LOGGER => [
                 'name' => 'cats',
             ]
         ]);

--- a/extensions/xdebug/lib/XDebugExtension.php
+++ b/extensions/xdebug/lib/XDebugExtension.php
@@ -74,6 +74,6 @@ class XDebugExtension implements ExtensionInterface
             ]
         ]);
 
-        $container->mergeParameter('executors', require(__DIR__ . '/config/executors.php'));
+        $container->mergeParameter(RunnerExtension::PARAM_EXECUTORS, require(__DIR__ . '/config/executors.php'));
     }
 }

--- a/extensions/xdebug/lib/XDebugExtension.php
+++ b/extensions/xdebug/lib/XDebugExtension.php
@@ -29,7 +29,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class XDebugExtension implements ExtensionInterface
 {
-    const PARAM_OUTPUT_DIR = 'xdebug.command.handler.output_dir';
+    const PARAM_OUTPUT_DIR = 'xdebug.command_handler_output_dir';
 
     public function configure(OptionsResolver $resolver): void
     {

--- a/extensions/xdebug/lib/XDebugExtension.php
+++ b/extensions/xdebug/lib/XDebugExtension.php
@@ -19,6 +19,7 @@ use PhpBench\DependencyInjection\ExtensionInterface;
 use PhpBench\Executor\Benchmark\RemoteExecutor;
 use PhpBench\Executor\CompositeExecutor;
 use PhpBench\Executor\Method\RemoteMethodExecutor;
+use PhpBench\Extension\ConsoleExtension;
 use PhpBench\Extension\CoreExtension;
 use PhpBench\Extension\RunnerExtension;
 use PhpBench\Extensions\XDebug\Command\Handler\OutputDirHandler;
@@ -49,7 +50,7 @@ class XDebugExtension implements ExtensionInterface
                 $container->get(self::PARAM_OUTPUT_DIR)
             );
         }, [
-            CoreExtension::TAG_CONSOLE_COMMAND => []
+            ConsoleExtension::TAG_CONSOLE_COMMAND => []
         ]);
 
         $container->register(self::PARAM_OUTPUT_DIR, function (Container $container) {

--- a/lib/Extension/ConsoleExtension.php
+++ b/lib/Extension/ConsoleExtension.php
@@ -46,22 +46,22 @@ class ConsoleExtension implements ExtensionInterface
             self::PARAM_ERROR_STREAM => 'php://stderr',
         ]);
 
-        $resolver->setAllowedTypes(self::PARAM_CONSOLE_ANSI, ['bool']);
+        $resolver->setAllowedTypes(self::PARAM_ANSI, ['bool']);
         $resolver->setAllowedTypes(self::PARAM_DISABLE_OUTPUT, ['bool']);
         $resolver->setAllowedTypes(self::PARAM_ERROR_STREAM, ['string']);
         $resolver->setAllowedTypes(self::PARAM_OUTPUT_STREAM, ['string']);
         SymfonyOptionsResolverCompat::setInfos($resolver, [
-            self::PARAM_CONSOLE_ANSI => 'Enable or disable ANSI control characters (e.g. console colors)',
+            self::PARAM_ANSI => 'Enable or disable ANSI control characters (e.g. console colors)',
             self::PARAM_OUTPUT_STREAM => 'Change the normal output stream - the output stream used for reports',
             self::PARAM_ERROR_STREAM => 'Change the error output stream - the output stream used for diagnostics (e.g. progress loggers use this stream)',
-            self::PARAM_DISABLE_OUTPUT=> 'Disable output from both STDOUT and STDERR',
+            self::PARAM_DISABLE_OUTPUT => 'Disable output from both STDOUT and STDERR',
         ]);
     }
 
     public function load(Container $container): void
     {
         $container->register(self::SERVICE_OUTPUT_STD, function (Container $container) {
-            return $this->createOutput($container, self::PARAM_CONSOLE_OUTPUT_STREAM);
+            return $this->createOutput($container, self::PARAM_OUTPUT_STREAM);
         });
 
         $container->register(self::SERVICE_OUTPUT_ERR, function (Container $container) {
@@ -92,7 +92,7 @@ class ConsoleExtension implements ExtensionInterface
             return new StreamOutput($resource);
         })($container->getParameter($type));
 
-        if (false === $container->getParameter(self::PARAM_CONSOLE_ANSI)) {
+        if (false === $container->getParameter(self::PARAM_ANSI)) {
             $output->setDecorated(false);
         }
 

--- a/lib/Extension/ConsoleExtension.php
+++ b/lib/Extension/ConsoleExtension.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace PhpBench\Extension;
+
+use PhpBench\Compat\SymfonyOptionsResolverCompat;
+use PhpBench\DependencyInjection\Container;
+use PhpBench\DependencyInjection\ExtensionInterface;
+use RuntimeException;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ConsoleExtension implements ExtensionInterface
+{
+    public const PARAM_CONSOLE_ANSI = 'console.ansi';
+    public const PARAM_CONSOLE_ERROR_STREAM = 'console_error_stream';
+    public const PARAM_CONSOLE_OUTPUT_STREAM = 'console_output_stream';
+    public const PARAM_DISABLE_OUTPUT = 'console_disable_output';
+
+    public const TAG_CONSOLE_COMMAND = 'console_command';
+
+    public const SERVICE_OUTPUT_ERR = 'console_stream_err';
+    public const SERVICE_OUTPUT_STD = 'console_stream_std';
+
+    public function configure(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+
+            self::PARAM_CONSOLE_ANSI => true,
+            self::PARAM_DISABLE_OUTPUT => false,
+            self::PARAM_CONSOLE_OUTPUT_STREAM => 'php://stdout',
+            self::PARAM_CONSOLE_ERROR_STREAM => 'php://stderr',
+        ]);
+
+        $resolver->setAllowedTypes(self::PARAM_CONSOLE_ANSI, ['bool']);
+        $resolver->setAllowedTypes(self::PARAM_DISABLE_OUTPUT, ['bool']);
+        $resolver->setAllowedTypes(self::PARAM_CONSOLE_ERROR_STREAM, ['string']);
+        $resolver->setAllowedTypes(self::PARAM_CONSOLE_OUTPUT_STREAM, ['string']);
+        SymfonyOptionsResolverCompat::setInfos($resolver, [
+            self::PARAM_CONSOLE_ANSI => 'Enable or disable ANSI control characters (e.g. console colors)',
+            self::PARAM_CONSOLE_OUTPUT_STREAM => 'Change the normal output stream - the output stream used for reports',
+            self::PARAM_CONSOLE_ERROR_STREAM => 'Change the error output stream - the output stream used for diagnostics (e.g. progress loggers use this stream)',
+        ]);
+    }
+
+    public function load(Container $container): void
+    {
+        $container->register(self::SERVICE_OUTPUT_STD, function (Container $container) {
+            return $this->createOutput($container, self::PARAM_CONSOLE_OUTPUT_STREAM);
+        });
+
+        $container->register(self::SERVICE_OUTPUT_ERR, function (Container $container) {
+            return $this->createOutput($container, self::PARAM_CONSOLE_ERROR_STREAM);
+        });
+
+        $container->register(InputInterface::class, function (Container $container) {
+            return new ArgvInput();
+        });
+    }
+
+    private function createOutput(Container $container, string $type): OutputInterface
+    {
+        if ($container->getParameter(self::PARAM_DISABLE_OUTPUT)) {
+            return new NullOutput();
+        }
+
+        $output = (function (string $name): OutputInterface {
+            $resource = fopen($name, 'w');
+
+            if (false === $resource) {
+                throw new RuntimeException(sprintf(
+                    'Could not open stream "%s"',
+                    $name
+                ));
+            }
+
+            return new StreamOutput($resource);
+        })($container->getParameter($type));
+
+        if (false === $container->getParameter(self::PARAM_CONSOLE_ANSI)) {
+            $output->setDecorated(false);
+        }
+
+        $output->getFormatter()->setStyle('success', new OutputFormatterStyle('black', 'green', []));
+        $output->getFormatter()->setStyle('baseline', new OutputFormatterStyle('cyan', null, []));
+        $output->getFormatter()->setStyle('result-neutral', new OutputFormatterStyle('cyan', null, []));
+        $output->getFormatter()->setStyle('result-good', new OutputFormatterStyle('green', null, []));
+        $output->getFormatter()->setStyle('result-none', new OutputFormatterStyle(null, null, []));
+        $output->getFormatter()->setStyle('result-failure', new OutputFormatterStyle('white', 'red', []));
+        $output->getFormatter()->setStyle('title', new OutputFormatterStyle('white', null, ['bold']));
+        $output->getFormatter()->setStyle('subtitle', new OutputFormatterStyle('white', null, []));
+        $output->getFormatter()->setStyle('description', new OutputFormatterStyle(null, null, []));
+
+        return $output;
+    }
+}

--- a/lib/Extension/ConsoleExtension.php
+++ b/lib/Extension/ConsoleExtension.php
@@ -27,14 +27,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class ConsoleExtension implements ExtensionInterface
 {
     public const PARAM_CONSOLE_ANSI = 'console.ansi';
-    public const PARAM_CONSOLE_ERROR_STREAM = 'console_error_stream';
-    public const PARAM_CONSOLE_OUTPUT_STREAM = 'console_output_stream';
-    public const PARAM_DISABLE_OUTPUT = 'console_disable_output';
+    public const PARAM_CONSOLE_ERROR_STREAM = 'console.error_stream';
+    public const PARAM_CONSOLE_OUTPUT_STREAM = 'console.output_stream';
+    public const PARAM_DISABLE_OUTPUT = 'console.disable_output';
 
-    public const TAG_CONSOLE_COMMAND = 'console_command';
+    public const TAG_CONSOLE_COMMAND = 'console.command';
 
-    public const SERVICE_OUTPUT_ERR = 'console_stream_err';
-    public const SERVICE_OUTPUT_STD = 'console_stream_std';
+    public const SERVICE_OUTPUT_ERR = 'console.stream_err';
+    public const SERVICE_OUTPUT_STD = 'console.stream_std';
 
     public function configure(OptionsResolver $resolver): void
     {

--- a/lib/Extension/ConsoleExtension.php
+++ b/lib/Extension/ConsoleExtension.php
@@ -54,6 +54,7 @@ class ConsoleExtension implements ExtensionInterface
             self::PARAM_CONSOLE_ANSI => 'Enable or disable ANSI control characters (e.g. console colors)',
             self::PARAM_CONSOLE_OUTPUT_STREAM => 'Change the normal output stream - the output stream used for reports',
             self::PARAM_CONSOLE_ERROR_STREAM => 'Change the error output stream - the output stream used for diagnostics (e.g. progress loggers use this stream)',
+            self::PARAM_DISABLE_OUTPUT=> 'Disable output from both STDOUT and STDERR',
         ]);
     }
 

--- a/lib/Extension/ConsoleExtension.php
+++ b/lib/Extension/ConsoleExtension.php
@@ -26,9 +26,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ConsoleExtension implements ExtensionInterface
 {
-    public const PARAM_CONSOLE_ANSI = 'console.ansi';
-    public const PARAM_CONSOLE_ERROR_STREAM = 'console.error_stream';
-    public const PARAM_CONSOLE_OUTPUT_STREAM = 'console.output_stream';
+    public const PARAM_ANSI = 'console.ansi';
+    public const PARAM_ERROR_STREAM = 'console.error_stream';
+    public const PARAM_OUTPUT_STREAM = 'console.output_stream';
     public const PARAM_DISABLE_OUTPUT = 'console.disable_output';
 
     public const TAG_CONSOLE_COMMAND = 'console.command';
@@ -40,20 +40,20 @@ class ConsoleExtension implements ExtensionInterface
     {
         $resolver->setDefaults([
 
-            self::PARAM_CONSOLE_ANSI => true,
+            self::PARAM_ANSI => true,
             self::PARAM_DISABLE_OUTPUT => false,
-            self::PARAM_CONSOLE_OUTPUT_STREAM => 'php://stdout',
-            self::PARAM_CONSOLE_ERROR_STREAM => 'php://stderr',
+            self::PARAM_OUTPUT_STREAM => 'php://stdout',
+            self::PARAM_ERROR_STREAM => 'php://stderr',
         ]);
 
         $resolver->setAllowedTypes(self::PARAM_CONSOLE_ANSI, ['bool']);
         $resolver->setAllowedTypes(self::PARAM_DISABLE_OUTPUT, ['bool']);
-        $resolver->setAllowedTypes(self::PARAM_CONSOLE_ERROR_STREAM, ['string']);
-        $resolver->setAllowedTypes(self::PARAM_CONSOLE_OUTPUT_STREAM, ['string']);
+        $resolver->setAllowedTypes(self::PARAM_ERROR_STREAM, ['string']);
+        $resolver->setAllowedTypes(self::PARAM_OUTPUT_STREAM, ['string']);
         SymfonyOptionsResolverCompat::setInfos($resolver, [
             self::PARAM_CONSOLE_ANSI => 'Enable or disable ANSI control characters (e.g. console colors)',
-            self::PARAM_CONSOLE_OUTPUT_STREAM => 'Change the normal output stream - the output stream used for reports',
-            self::PARAM_CONSOLE_ERROR_STREAM => 'Change the error output stream - the output stream used for diagnostics (e.g. progress loggers use this stream)',
+            self::PARAM_OUTPUT_STREAM => 'Change the normal output stream - the output stream used for reports',
+            self::PARAM_ERROR_STREAM => 'Change the error output stream - the output stream used for diagnostics (e.g. progress loggers use this stream)',
             self::PARAM_DISABLE_OUTPUT=> 'Disable output from both STDOUT and STDERR',
         ]);
     }
@@ -65,7 +65,7 @@ class ConsoleExtension implements ExtensionInterface
         });
 
         $container->register(self::SERVICE_OUTPUT_ERR, function (Container $container) {
-            return $this->createOutput($container, self::PARAM_CONSOLE_ERROR_STREAM);
+            return $this->createOutput($container, self::PARAM_ERROR_STREAM);
         });
 
         $container->register(InputInterface::class, function (Container $container) {

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -34,7 +34,6 @@ class CoreExtension implements ExtensionInterface
     public const PARAM_DEBUG = 'core.debug';
     public const PARAM_WORKING_DIR = 'core.working_dir';
 
-    public const PARAM_OUTPUT_MODE = 'core.output_mode';
     public const PARAM_TIME_UNIT = 'core.time_unit';
 
     public function configure(OptionsResolver $resolver): void
@@ -42,8 +41,6 @@ class CoreExtension implements ExtensionInterface
         $resolver->setDefaults([
             self::PARAM_DEBUG => false,
             self::PARAM_EXTENSIONS => [],
-            self::PARAM_OUTPUT_MODE => TimeUnit::MODE_TIME,
-            self::PARAM_TIME_UNIT => TimeUnit::MICROSECONDS,
             self::PARAM_WORKING_DIR => getcwd(),
             self::PARAM_CONFIG_PATH => null,
             self::PARAM_PROFILES => [],
@@ -52,8 +49,6 @@ class CoreExtension implements ExtensionInterface
         $resolver->setAllowedTypes(self::PARAM_PROFILES, ['array']);
         $resolver->setAllowedTypes(self::PARAM_DEBUG, ['bool']);
         $resolver->setAllowedTypes(self::PARAM_CONFIG_PATH, ['string', 'null']);
-        $resolver->setAllowedTypes(self::PARAM_TIME_UNIT, ['string']);
-        $resolver->setAllowedTypes(self::PARAM_OUTPUT_MODE, ['string']);
         $resolver->setAllowedTypes(self::PARAM_EXTENSIONS, ['array']);
         $resolver->setAllowedTypes(self::PARAM_WORKING_DIR, ['string']);
         SymfonyOptionsResolverCompat::setInfos($resolver, [
@@ -61,14 +56,14 @@ class CoreExtension implements ExtensionInterface
 Alternative configurations::
 
     {
-        "profiles": {
+        "core.profiles": {
             "php8": {
                 "runner.php_bin": "/bin/php8"
             }
         }
     }
 
-The named configuration will be merged with the default configuration, and can be used via::
+The named configuration will be merged with the default configuration, and can be used via:
 
 .. code-block:: bash
 
@@ -77,8 +72,6 @@ EOT
             ,
             self::PARAM_DEBUG => 'If enabled output debug messages (e.g. the commands being executed when running benchamrks). Same as ``-vvv``',
             self::PARAM_EXTENSIONS => 'List of additional extensions to enable',
-            self::PARAM_OUTPUT_MODE => 'Default output mode (e.g. throughput or net time)',
-            self::PARAM_TIME_UNIT => 'Default time unit',
             self::PARAM_CONFIG_PATH => 'Alternative path to a PHPBench configuration file (default is ``phpbench.json``',
             self::PARAM_WORKING_DIR => 'Working directory to use',
         ]);
@@ -104,7 +97,7 @@ EOT
         });
 
         $container->register(TimeUnit::class, function (Container $container) {
-            return new TimeUnit(TimeUnit::MICROSECONDS, $container->getParameter(self::PARAM_TIME_UNIT));
+            return new TimeUnit(TimeUnit::MICROSECONDS, TimeUnit::MICROSECONDS);
         });
 
         $this->registerJson($container);

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -36,20 +36,20 @@ class CoreExtension implements ExtensionInterface
 {
     public const PARAM_CONFIG_PATH = 'config_path';
     public const PARAM_CONSOLE_ANSI = 'console.ansi';
-    public const PARAM_CONSOLE_ERROR_STREAM = 'console.error_stream';
-    public const PARAM_CONSOLE_OUTPUT_STREAM = 'console.output_stream';
+    public const PARAM_CONSOLE_ERROR_STREAM = 'console_error_stream';
+    public const PARAM_CONSOLE_OUTPUT_STREAM = 'console_output_stream';
     public const PARAM_DEBUG = 'debug';
-    public const PARAM_DISABLE_OUTPUT = 'console.disable_output';
+    public const PARAM_DISABLE_OUTPUT = 'console_disable_output';
     public const PARAM_EXTENSIONS = 'extensions';
     public const PARAM_OUTPUT_MODE = 'output_mode';
     public const PARAM_WORKING_DIR = 'working_dir';
 
     public const PARAM_TIME_UNIT = 'time_unit';
 
-    public const SERVICE_OUTPUT_ERR = 'console.stream.err';
-    public const SERVICE_OUTPUT_STD = 'console.stream.std';
-    public const SERVICE_REGISTRY_LOGGER = 'progress_logger.registry';
-    public const TAG_CONSOLE_COMMAND = 'console.command';
+    public const SERVICE_OUTPUT_ERR = 'console_stream_err';
+    public const SERVICE_OUTPUT_STD = 'console_stream_std';
+
+    public const TAG_CONSOLE_COMMAND = 'console_command';
     public const TAG_PROGRESS_LOGGER = 'progress_logger';
 
     public function configure(OptionsResolver $resolver): void

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -23,68 +23,35 @@ use PhpBench\Json\JsonDecoder;
 use PhpBench\Logger\ConsoleLogger;
 use PhpBench\Util\TimeUnit;
 use Psr\Log\LoggerInterface;
-use RuntimeException;
-use Symfony\Component\Console\Formatter\OutputFormatterStyle;
-use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\NullOutput;
-use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CoreExtension implements ExtensionInterface
 {
     public const PARAM_CONFIG_PATH = 'config_path';
-    public const PARAM_CONSOLE_ANSI = 'console.ansi';
-    public const PARAM_CONSOLE_ERROR_STREAM = 'console_error_stream';
-    public const PARAM_CONSOLE_OUTPUT_STREAM = 'console_output_stream';
     public const PARAM_DEBUG = 'debug';
-    public const PARAM_DISABLE_OUTPUT = 'console_disable_output';
     public const PARAM_EXTENSIONS = 'extensions';
     public const PARAM_OUTPUT_MODE = 'output_mode';
     public const PARAM_WORKING_DIR = 'working_dir';
-
     public const PARAM_TIME_UNIT = 'time_unit';
-
-    public const SERVICE_OUTPUT_ERR = 'console_stream_err';
-    public const SERVICE_OUTPUT_STD = 'console_stream_std';
-
-    public const TAG_CONSOLE_COMMAND = 'console_command';
-    public const TAG_PROGRESS_LOGGER = 'progress_logger';
 
     public function configure(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-
-            self::PARAM_CONSOLE_ANSI => true,
-            self::PARAM_DISABLE_OUTPUT => false,
-            self::PARAM_CONSOLE_OUTPUT_STREAM => 'php://stdout',
-            self::PARAM_CONSOLE_ERROR_STREAM => 'php://stderr',
             self::PARAM_DEBUG => false,
             self::PARAM_EXTENSIONS => [],
             self::PARAM_OUTPUT_MODE => TimeUnit::MODE_TIME,
             self::PARAM_TIME_UNIT => TimeUnit::MICROSECONDS,
             self::PARAM_WORKING_DIR => getcwd(),
-
             self::PARAM_CONFIG_PATH => null,
         ]);
 
         $resolver->setAllowedTypes(self::PARAM_DEBUG, ['bool']);
         $resolver->setAllowedTypes(self::PARAM_CONFIG_PATH, ['string', 'null']);
-        $resolver->setAllowedTypes(self::PARAM_CONSOLE_ANSI, ['bool']);
-        $resolver->setAllowedTypes(self::PARAM_CONSOLE_ERROR_STREAM, ['string']);
-        $resolver->setAllowedTypes(self::PARAM_CONSOLE_OUTPUT_STREAM, ['string']);
         $resolver->setAllowedTypes(self::PARAM_TIME_UNIT, ['string']);
         $resolver->setAllowedTypes(self::PARAM_OUTPUT_MODE, ['string']);
-        $resolver->setAllowedTypes(self::PARAM_DISABLE_OUTPUT, ['bool']);
-        $resolver->setAllowedTypes(self::PARAM_CONSOLE_OUTPUT_STREAM, ['string']);
         $resolver->setAllowedTypes(self::PARAM_EXTENSIONS, ['array']);
         $resolver->setAllowedTypes(self::PARAM_WORKING_DIR, ['string']);
         SymfonyOptionsResolverCompat::setInfos($resolver, [
-            self::PARAM_CONSOLE_ANSI => 'Enable or disable ANSI control characters (e.g. console colors)',
-            self::PARAM_DISABLE_OUTPUT => 'Do not output anything',
-            self::PARAM_CONSOLE_OUTPUT_STREAM => 'Change the normal output stream - the output stream used for reports',
-            self::PARAM_CONSOLE_ERROR_STREAM => 'Change the error output stream - the output stream used for diagnostics (e.g. progress loggers use this stream)',
             self::PARAM_DEBUG => 'If enabled output debug messages (e.g. the commands being executed when running benchamrks). Same as ``-vvv``',
             self::PARAM_EXTENSIONS => 'List of additional extensions to enable',
             self::PARAM_OUTPUT_MODE => 'Default output mode (e.g. throughput or net time)',
@@ -96,22 +63,10 @@ class CoreExtension implements ExtensionInterface
 
     public function load(Container $container): void
     {
-        $container->register(self::SERVICE_OUTPUT_STD, function (Container $container) {
-            return $this->createOutput($container, self::PARAM_CONSOLE_OUTPUT_STREAM);
-        });
-
-        $container->register(self::SERVICE_OUTPUT_ERR, function (Container $container) {
-            return $this->createOutput($container, self::PARAM_CONSOLE_ERROR_STREAM);
-        });
-
-        $container->register(InputInterface::class, function (Container $container) {
-            return new ArgvInput();
-        });
-
         $container->register(Application::class, function (Container $container) {
             $application = new Application();
 
-            foreach (array_keys($container->getServiceIdsForTag(self::TAG_CONSOLE_COMMAND)) as $serviceId) {
+            foreach (array_keys($container->getServiceIdsForTag(ConsoleExtension::TAG_CONSOLE_COMMAND)) as $serviceId) {
                 $command = $container->get($serviceId);
                 $application->add($command);
             }
@@ -152,44 +107,8 @@ class CoreExtension implements ExtensionInterface
             $container->register(SelfUpdateCommand::class, function (Container $container) {
                 return new SelfUpdateCommand();
             }, [
-                self::TAG_CONSOLE_COMMAND => []
+                ConsoleExtension::TAG_CONSOLE_COMMAND => []
             ]);
         }
-    }
-
-    private function createOutput(Container $container, string $type): OutputInterface
-    {
-        if ($container->getParameter(self::PARAM_DISABLE_OUTPUT)) {
-            return new NullOutput();
-        }
-
-        $output = (function (string $name): OutputInterface {
-            $resource = fopen($name, 'w');
-
-            if (false === $resource) {
-                throw new RuntimeException(sprintf(
-                    'Could not open stream "%s"',
-                    $name
-                ));
-            }
-
-            return new StreamOutput($resource);
-        })($container->getParameter($type));
-
-        if (false === $container->getParameter(self::PARAM_CONSOLE_ANSI)) {
-            $output->setDecorated(false);
-        }
-
-        $output->getFormatter()->setStyle('success', new OutputFormatterStyle('black', 'green', []));
-        $output->getFormatter()->setStyle('baseline', new OutputFormatterStyle('cyan', null, []));
-        $output->getFormatter()->setStyle('result-neutral', new OutputFormatterStyle('cyan', null, []));
-        $output->getFormatter()->setStyle('result-good', new OutputFormatterStyle('green', null, []));
-        $output->getFormatter()->setStyle('result-none', new OutputFormatterStyle(null, null, []));
-        $output->getFormatter()->setStyle('result-failure', new OutputFormatterStyle('white', 'red', []));
-        $output->getFormatter()->setStyle('title', new OutputFormatterStyle('white', null, ['bold']));
-        $output->getFormatter()->setStyle('subtitle', new OutputFormatterStyle('white', null, []));
-        $output->getFormatter()->setStyle('description', new OutputFormatterStyle(null, null, []));
-
-        return $output;
     }
 }

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -27,13 +27,15 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CoreExtension implements ExtensionInterface
 {
-    public const PARAM_CONFIG_PATH = 'config_path';
-    public const PARAM_DEBUG = 'debug';
-    public const PARAM_EXTENSIONS = 'extensions';
-    public const PARAM_WORKING_DIR = 'working_dir';
+    public const PARAM_EXTENSIONS = 'core.extensions';
+    public const PARAM_PROFILES = 'core.profiles';
 
-    public const PARAM_OUTPUT_MODE = 'output_mode';
-    public const PARAM_TIME_UNIT = 'time_unit';
+    public const PARAM_CONFIG_PATH = 'core.config_path';
+    public const PARAM_DEBUG = 'core.debug';
+    public const PARAM_WORKING_DIR = 'core.working_dir';
+
+    public const PARAM_OUTPUT_MODE = 'core.output_mode';
+    public const PARAM_TIME_UNIT = 'core.time_unit';
 
     public function configure(OptionsResolver $resolver): void
     {
@@ -44,8 +46,10 @@ class CoreExtension implements ExtensionInterface
             self::PARAM_TIME_UNIT => TimeUnit::MICROSECONDS,
             self::PARAM_WORKING_DIR => getcwd(),
             self::PARAM_CONFIG_PATH => null,
+            self::PARAM_PROFILES => [],
         ]);
 
+        $resolver->setAllowedTypes(self::PARAM_PROFILES, ['array']);
         $resolver->setAllowedTypes(self::PARAM_DEBUG, ['bool']);
         $resolver->setAllowedTypes(self::PARAM_CONFIG_PATH, ['string', 'null']);
         $resolver->setAllowedTypes(self::PARAM_TIME_UNIT, ['string']);
@@ -53,6 +57,24 @@ class CoreExtension implements ExtensionInterface
         $resolver->setAllowedTypes(self::PARAM_EXTENSIONS, ['array']);
         $resolver->setAllowedTypes(self::PARAM_WORKING_DIR, ['string']);
         SymfonyOptionsResolverCompat::setInfos($resolver, [
+            self::PARAM_PROFILES => <<<'EOT'
+Alternative configurations::
+
+    {
+        "profiles": {
+            "php8": {
+                "runner.php_bin": "/bin/php8"
+            }
+        }
+    }
+
+The named configuration will be merged with the default configuration, and can be used via::
+
+.. code-block:: bash
+
+    $ phpbench run --profile=php8
+EOT
+            ,
             self::PARAM_DEBUG => 'If enabled output debug messages (e.g. the commands being executed when running benchamrks). Same as ``-vvv``',
             self::PARAM_EXTENSIONS => 'List of additional extensions to enable',
             self::PARAM_OUTPUT_MODE => 'Default output mode (e.g. throughput or net time)',

--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -30,8 +30,9 @@ class CoreExtension implements ExtensionInterface
     public const PARAM_CONFIG_PATH = 'config_path';
     public const PARAM_DEBUG = 'debug';
     public const PARAM_EXTENSIONS = 'extensions';
-    public const PARAM_OUTPUT_MODE = 'output_mode';
     public const PARAM_WORKING_DIR = 'working_dir';
+
+    public const PARAM_OUTPUT_MODE = 'output_mode';
     public const PARAM_TIME_UNIT = 'time_unit';
 
     public function configure(OptionsResolver $resolver): void

--- a/lib/Extension/DevelopmentExtension.php
+++ b/lib/Extension/DevelopmentExtension.php
@@ -18,9 +18,9 @@ class DevelopmentExtension implements ExtensionInterface
         $container->register(ConfigReferenceCommand::class, function (Container $container) {
             return new ConfigReferenceCommand(new ConfigDumper(
                 $container->getExtensionClasses()
-            ), $container->get(CoreExtension::SERVICE_OUTPUT_STD));
+            ), $container->get(ConsoleExtension::SERVICE_OUTPUT_STD));
         }, [
-            CoreExtension::TAG_CONSOLE_COMMAND => []
+            ConsoleExtension::TAG_CONSOLE_COMMAND => []
         ]);
     }
 

--- a/lib/Extension/ExpressionExtension.php
+++ b/lib/Extension/ExpressionExtension.php
@@ -109,11 +109,13 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class ExpressionExtension implements ExtensionInterface
 {
     public const PARAM_SYNTAX_HIGHLIGHTING = 'expression.syntax_highlighting';
-
-    public const SERVICE_PLAIN_PRINTER = Printer::class . '.plain';
-    public const SERVICE_BARE_PRINTER = Printer::class . '.bare';
-    public const TAG_THEME = self::PARAM_THEME;
     public const PARAM_THEME = 'expression.theme';
+
+    public const SERVICE_PLAIN_PRINTER = 'expression.printer.plain';
+    public const SERVICE_BARE_PRINTER = 'expression.printer.bare';
+
+    public const TAG_THEME = 'expression.theme';
+
     public const THEME_BASIC = 'basic';
     public const THEME_SOLARIZED = 'solarized';
 

--- a/lib/Extension/ExpressionExtension.php
+++ b/lib/Extension/ExpressionExtension.php
@@ -129,10 +129,10 @@ class ExpressionExtension implements ExtensionInterface
                 $container->get(Parser::class),
                 $container->get(Printer::class),
                 $container->get(EvaluatingPrinter::class),
-                $container->get(CoreExtension::SERVICE_OUTPUT_STD)
+                $container->get(ConsoleExtension::SERVICE_OUTPUT_STD)
             );
         }, [
-            CoreExtension::TAG_CONSOLE_COMMAND => []
+            ConsoleExtension::TAG_CONSOLE_COMMAND => []
         ]);
         $container->register(Parser::class, function (Container $container) {
             return new Parser(

--- a/lib/Extension/ReportExtension.php
+++ b/lib/Extension/ReportExtension.php
@@ -32,12 +32,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ReportExtension implements ExtensionInterface
 {
-    public const PARAM_OUTPUTS = 'outputs';
-    public const PARAM_REPORTS = 'reports';
-    public const TAG_REPORT_GENERATOR = 'report_generator';
-    public const TAG_REPORT_RENDERER = 'report_renderer';
-    public const SERVICE_REGISTRY_GENERATOR = 'report_registry.generator';
-    public const SERVICE_REGISTRY_RENDERER = 'report_registry.renderer';
+    public const PARAM_OUTPUTS = 'report.outputs';
+    public const PARAM_REPORTS = 'report.generators';
+
+    public const SERVICE_REGISTRY_GENERATOR = 'report.registry_generator';
+    public const SERVICE_REGISTRY_RENDERER = 'report.registry_renderer';
+
+    public const TAG_REPORT_GENERATOR = 'report.generator';
+    public const TAG_REPORT_RENDERER = 'report.renderer';
 
     public function configure(OptionsResolver $resolver): void
     {
@@ -111,14 +113,14 @@ class ReportExtension implements ExtensionInterface
     private function registerRegistries(Container $container): void
     {
         foreach (['generator' => self::PARAM_REPORTS, 'renderer' => self::PARAM_OUTPUTS] as $registryType => $optionName) {
-            $container->register('report_registry.' . $registryType, function (Container $container) use ($registryType, $optionName) {
+            $container->register('report.registry_' . $registryType, function (Container $container) use ($registryType, $optionName) {
                 $registry = new ConfigurableRegistry(
                     $registryType,
                     $container,
                     $container->get(JsonDecoder::class)
                 );
 
-                foreach ($container->getServiceIdsForTag('report_' . $registryType) as $serviceId => $attributes) {
+                foreach ($container->getServiceIdsForTag('report.' . $registryType) as $serviceId => $attributes) {
                     $registry->registerService($attributes['name'], $serviceId);
                 }
 

--- a/lib/Extension/ReportExtension.php
+++ b/lib/Extension/ReportExtension.php
@@ -36,8 +36,8 @@ class ReportExtension implements ExtensionInterface
     public const PARAM_REPORTS = 'reports';
     public const TAG_REPORT_GENERATOR = 'report_generator';
     public const TAG_REPORT_RENDERER = 'report_renderer';
-    public const SERVICE_REGISTRY_GENERATOR = 'report.registry.generator';
-    public const SERVICE_REGISTRY_RENDERER = 'report.registry.renderer';
+    public const SERVICE_REGISTRY_GENERATOR = 'report_registry.generator';
+    public const SERVICE_REGISTRY_RENDERER = 'report_registry.renderer';
 
     public function configure(OptionsResolver $resolver): void
     {
@@ -92,7 +92,7 @@ class ReportExtension implements ExtensionInterface
                 $container->get(DumpHandler::class)
             );
         }, [
-            CoreExtension::TAG_CONSOLE_COMMAND => []
+            ConsoleExtension::TAG_CONSOLE_COMMAND => []
         ]);
 
         $container->register(ShowCommand::class, function (Container $container) {
@@ -104,14 +104,14 @@ class ReportExtension implements ExtensionInterface
                 $container->get(UuidResolver::class)
             );
         }, [
-            CoreExtension::TAG_CONSOLE_COMMAND => []
+            ConsoleExtension::TAG_CONSOLE_COMMAND => []
         ]);
     }
 
     private function registerRegistries(Container $container): void
     {
         foreach (['generator' => self::PARAM_REPORTS, 'renderer' => self::PARAM_OUTPUTS] as $registryType => $optionName) {
-            $container->register('report.registry.' . $registryType, function (Container $container) use ($registryType, $optionName) {
+            $container->register('report_registry.' . $registryType, function (Container $container) use ($registryType, $optionName) {
                 $registry = new ConfigurableRegistry(
                     $registryType,
                     $container,
@@ -169,13 +169,13 @@ class ReportExtension implements ExtensionInterface
     {
         $container->register(ConsoleRenderer::class, function (Container $container) {
             return new ConsoleRenderer(
-                $container->get(CoreExtension::SERVICE_OUTPUT_STD),
+                $container->get(ConsoleExtension::SERVICE_OUTPUT_STD),
                 $container->get(Printer::class)
             );
         }, [self::TAG_REPORT_RENDERER => ['name' => 'console']]);
         $container->register(DelimitedRenderer::class, function (Container $container) {
             return new DelimitedRenderer(
-                $container->get(CoreExtension::SERVICE_OUTPUT_STD),
+                $container->get(ConsoleExtension::SERVICE_OUTPUT_STD),
                 $container->get(ExpressionExtension::SERVICE_BARE_PRINTER)
             );
         }, [self::TAG_REPORT_RENDERER => ['name' => 'delimited']]);

--- a/lib/Extension/RunnerExtension.php
+++ b/lib/Extension/RunnerExtension.php
@@ -69,25 +69,24 @@ class RunnerExtension implements ExtensionInterface
     public const ENV_PROVIDER_UNAME = 'uname';
     public const ENV_PROVIDER_UNIX_SYSLOAD = 'unix_sysload';
 
-    public const PARAM_ANNOTATIONS = 'annotations';
-    public const PARAM_ANNOTATION_IMPORT_USE = 'annotation_import_use';
-    public const PARAM_ATTRIBUTES = 'attributes';
-    public const PARAM_BOOTSTRAP = 'bootstrap';
-    public const PARAM_ENABLED_PROVIDERS = 'env.enabled_providers';
-    public const PARAM_ENV_BASELINES = 'env_baselines';
-    public const PARAM_ENV_BASELINE_CALLABLES = 'env_baseline_callables';
-    public const PARAM_EXECUTORS = 'executors';
-    public const PARAM_PATH = 'path';
-    public const PARAM_PHP_BINARY = 'php_binary';
-    public const PARAM_PHP_CONFIG = 'php_config';
-    public const PARAM_PHP_DISABLE_INI = 'php_disable_ini';
-    public const PARAM_PHP_WRAPPER = 'php_wrapper';
-    public const PARAM_PROGRESS = 'progress';
-    public const PARAM_PROGRESS_SUMMARY_BASELINE_FORMAT = 'progress_summary_baseline_format';
-    public const PARAM_PROGRESS_SUMMARY_FORMAT = 'progress_summary_variant_format';
-    public const PARAM_REMOTE_SCRIPT_PATH = 'remote_script_path';
-    public const PARAM_REMOTE_SCRIPT_REMOVE = 'remote_script_remove';
-    public const PARAM_RETRY_THRESHOLD = 'retry_threshold';
+    public const PARAM_ANNOTATIONS = 'runner.annotations';
+    public const PARAM_ANNOTATION_IMPORT_USE = 'runner.annotation_import_use';
+    public const PARAM_ATTRIBUTES = 'runner.attributes';
+    public const PARAM_BOOTSTRAP = 'runner.bootstrap';
+    public const PARAM_ENABLED_PROVIDERS = 'runner.env_enabled_providers';
+    public const PARAM_ENV_BASELINES = 'runner.env_baselines';
+    public const PARAM_ENV_BASELINE_CALLABLES = 'runner.env_baseline_callables';
+    public const PARAM_EXECUTORS = 'runner.executors';
+    public const PARAM_PATH = 'runner.path';
+    public const PARAM_PHP_BINARY = 'runner.php_binary';
+    public const PARAM_PHP_CONFIG = 'runner.php_config';
+    public const PARAM_PHP_DISABLE_INI = 'runner.php_disable_ini';
+    public const PARAM_PHP_WRAPPER = 'runner.php_wrapper';
+    public const PARAM_PROGRESS = 'runner.progress';
+    public const PARAM_PROGRESS_SUMMARY_BASELINE_FORMAT = 'runner.progress_summary_baseline_format';
+    public const PARAM_PROGRESS_SUMMARY_FORMAT = 'runner.progress_summary_variant_format';
+    public const PARAM_REMOTE_SCRIPT_PATH = 'runner.remote_script_path';
+    public const PARAM_REMOTE_SCRIPT_REMOVE = 'runner.remote_script_remove';
     public const PARAM_RUNNER_ASSERT = 'runner.assert';
     public const PARAM_RUNNER_EXECUTOR = 'runner.executor';
     public const PARAM_RUNNER_FORMAT = 'runner.format';
@@ -98,15 +97,15 @@ class RunnerExtension implements ExtensionInterface
     public const PARAM_RUNNER_REVS = 'runner.revs';
     public const PARAM_RUNNER_TIMEOUT = 'runner.timeout';
     public const PARAM_RUNNER_WARMUP = 'runner.warmup';
-    public const PARAM_SUBJECT_PATTERN = 'subject_pattern';
+    public const PARAM_SUBJECT_PATTERN = 'runner.subject_pattern';
 
-    public const SERVICE_REGISTRY_EXECUTOR = 'benchmark.registry.executor';
-    public const SERVICE_VARIANT_SUMMARY_FORMATTER = 'progress_logger.variant_summary_formatter';
-    public const SERVICE_REGISTRY_LOGGER = 'progress_logger_registry';
+    public const SERVICE_REGISTRY_EXECUTOR = 'runner.benchmark_registry.executor';
+    public const SERVICE_VARIANT_SUMMARY_FORMATTER = 'runner.progress_logger_variant_summary_formatter';
+    public const SERVICE_REGISTRY_LOGGER = 'runner.progress_logger_registry';
 
-    public const TAG_ENV_PROVIDER = 'environment_provider';
-    public const TAG_EXECUTOR = 'benchmark_executor';
-    public const TAG_PROGRESS_LOGGER = 'progress_logger';
+    public const TAG_ENV_PROVIDER = 'runner.environment_provider';
+    public const TAG_EXECUTOR = 'runner.benchmark_executor';
+    public const TAG_PROGRESS_LOGGER = 'runner.progress_logger';
 
     public function configure(OptionsResolver $resolver): void
     {
@@ -136,7 +135,6 @@ class RunnerExtension implements ExtensionInterface
             self::PARAM_PROGRESS_SUMMARY_BASELINE_FORMAT => VariantSummaryFormatter::BASELINE_FORMAT,
             self::PARAM_REMOTE_SCRIPT_PATH => null,
             self::PARAM_REMOTE_SCRIPT_REMOVE => true,
-            self::PARAM_RETRY_THRESHOLD => null,
             self::PARAM_RUNNER_ASSERT => null,
             self::PARAM_RUNNER_EXECUTOR => null,
             self::PARAM_RUNNER_FORMAT => null,
@@ -168,7 +166,6 @@ class RunnerExtension implements ExtensionInterface
         $resolver->setAllowedTypes(self::PARAM_PROGRESS_SUMMARY_FORMAT, ['string']);
         $resolver->setAllowedTypes(self::PARAM_REMOTE_SCRIPT_PATH, ['string', 'null']);
         $resolver->setAllowedTypes(self::PARAM_REMOTE_SCRIPT_REMOVE, ['bool']);
-        $resolver->setAllowedTypes(self::PARAM_RETRY_THRESHOLD, ['null', 'int', 'float']);
         $resolver->setAllowedTypes(self::PARAM_RUNNER_ASSERT, ['null', 'string', 'array']);
         $resolver->setAllowedTypes(self::PARAM_RUNNER_EXECUTOR, ['null', 'string']);
         $resolver->setAllowedTypes(self::PARAM_RUNNER_FORMAT, ['null', 'string']);
@@ -200,7 +197,6 @@ class RunnerExtension implements ExtensionInterface
             self::PARAM_PROGRESS_SUMMARY_BASELINE_FORMAT => 'When the a comparison benchmark is referenced, alternative expression used to render the summary text default progress loggers',
             self::PARAM_REMOTE_SCRIPT_PATH => 'PHPBench generates a PHP file for out-of-band benchmarks which is executed, this setting specifies the path to this file. When NULL a file in the systems temporary directory will be used',
             self::PARAM_REMOTE_SCRIPT_REMOVE => 'If the generated file should be removed after it has been executed (useful for debugging)',
-            self::PARAM_RETRY_THRESHOLD => 'DEPRECATED: use :ref:`configuration_runner_retry_threshold` instead',
             self::PARAM_RUNNER_ASSERT => 'Default :ref:`metadata_assertions`',
             self::PARAM_RUNNER_EXECUTOR => 'Default executor',
             self::PARAM_RUNNER_FORMAT => 'Default :ref:`metadata_format`',
@@ -311,7 +307,7 @@ class RunnerExtension implements ExtensionInterface
                 $container->get(self::SERVICE_REGISTRY_EXECUTOR),
                 $container->get(Supplier::class),
                 $container->get(AssertionProcessor::class),
-                $container->getParameter(self::PARAM_RETRY_THRESHOLD),
+                $container->getParameter(self::PARAM_RUNNER_RETRY_THRESHOLD),
                 $container->getParameter(CoreExtension::PARAM_CONFIG_PATH)
             );
         });
@@ -601,7 +597,7 @@ class RunnerExtension implements ExtensionInterface
                 (array)$container->getParameter(self::PARAM_RUNNER_REVS),
                 $container->getParameter(self::PARAM_RUNNER_TIMEOUT),
                 (array)$container->getParameter(self::PARAM_RUNNER_WARMUP),
-                (float)($container->getParameter(self::PARAM_RUNNER_RETRY_THRESHOLD) ?: $container->getParameter(self::PARAM_RETRY_THRESHOLD))
+                (float)$container->getParameter(self::PARAM_RUNNER_RETRY_THRESHOLD)
             );
         });
 

--- a/lib/Extension/RunnerExtension.php
+++ b/lib/Extension/RunnerExtension.php
@@ -419,7 +419,7 @@ class RunnerExtension implements ExtensionInterface
                 $container->get(StorageExtension::SERVICE_REGISTRY_DRIVER)
             );
         }, [
-            CoreExtension::TAG_CONSOLE_COMMAND => []
+            ConsoleExtension::TAG_CONSOLE_COMMAND => []
         ]);
     }
 
@@ -449,7 +449,7 @@ class RunnerExtension implements ExtensionInterface
 
         $container->register(DotsLogger::class, function (Container $container) {
             return new DotsLogger(
-                $container->get(CoreExtension::SERVICE_OUTPUT_ERR),
+                $container->get(ConsoleExtension::SERVICE_OUTPUT_ERR),
                 $container->get(VariantFormatter::class),
                 $container->get(TimeUnit::class)
             );
@@ -457,7 +457,7 @@ class RunnerExtension implements ExtensionInterface
 
         $container->register(DotsLogger::class .'.show', function (Container $container) {
             return new DotsLogger(
-                $container->get(CoreExtension::SERVICE_OUTPUT_ERR),
+                $container->get(ConsoleExtension::SERVICE_OUTPUT_ERR),
                 $container->get(VariantFormatter::class),
                 $container->get(TimeUnit::class),
                 true
@@ -466,7 +466,7 @@ class RunnerExtension implements ExtensionInterface
 
         $container->register(VerboseLogger::class, function (Container $container) {
             return new VerboseLogger(
-                $container->get(CoreExtension::SERVICE_OUTPUT_ERR),
+                $container->get(ConsoleExtension::SERVICE_OUTPUT_ERR),
                 $container->get(VariantFormatter::class),
                 $container->get(TimeUnit::class)
             );
@@ -474,7 +474,7 @@ class RunnerExtension implements ExtensionInterface
 
         $container->register(TravisLogger::class, function (Container $container) {
             return new TravisLogger(
-                $container->get(CoreExtension::SERVICE_OUTPUT_ERR),
+                $container->get(ConsoleExtension::SERVICE_OUTPUT_ERR),
                 $container->get(VariantFormatter::class),
                 $container->get(TimeUnit::class)
             );
@@ -486,7 +486,7 @@ class RunnerExtension implements ExtensionInterface
 
         $container->register(BlinkenLogger::class, function (Container $container) {
             return new BlinkenLogger(
-                $container->get(CoreExtension::SERVICE_OUTPUT_ERR),
+                $container->get(ConsoleExtension::SERVICE_OUTPUT_ERR),
                 $container->get(VariantFormatter::class),
                 $container->get(TimeUnit::class)
             );
@@ -494,7 +494,7 @@ class RunnerExtension implements ExtensionInterface
 
         $container->register(HistogramLogger::class, function (Container $container) {
             return new HistogramLogger(
-                $container->get(CoreExtension::SERVICE_OUTPUT_ERR),
+                $container->get(ConsoleExtension::SERVICE_OUTPUT_ERR),
                 $container->get(VariantFormatter::class),
                 $container->get(TimeUnit::class)
             );

--- a/lib/Extension/RunnerExtension.php
+++ b/lib/Extension/RunnerExtension.php
@@ -102,6 +102,7 @@ class RunnerExtension implements ExtensionInterface
 
     public const SERVICE_REGISTRY_EXECUTOR = 'benchmark.registry.executor';
     public const SERVICE_VARIANT_SUMMARY_FORMATTER = 'progress_logger.variant_summary_formatter';
+    public const SERVICE_REGISTRY_LOGGER = 'progress_logger_registry';
 
     public const TAG_ENV_PROVIDER = 'environment_provider';
     public const TAG_EXECUTOR = 'benchmark_executor';
@@ -401,7 +402,7 @@ class RunnerExtension implements ExtensionInterface
         $container->register(RunnerHandler::class, function (Container $container) {
             return new RunnerHandler(
                 $container->get(Runner::class),
-                $container->get(CoreExtension::SERVICE_REGISTRY_LOGGER),
+                $container->get(self::SERVICE_REGISTRY_LOGGER),
                 $container->get(BenchmarkFinder::class),
                 $container->getParameter(self::PARAM_PROGRESS),
                 $container->getParameter(self::PARAM_PATH)
@@ -433,7 +434,7 @@ class RunnerExtension implements ExtensionInterface
                 $container->getParameter(self::PARAM_PROGRESS_SUMMARY_BASELINE_FORMAT)
             );
         });
-        $container->register(CoreExtension::SERVICE_REGISTRY_LOGGER, function (Container $container) {
+        $container->register(self::SERVICE_REGISTRY_LOGGER, function (Container $container) {
             $registry = new LoggerRegistry();
 
             foreach ($container->getServiceIdsForTag(self::TAG_PROGRESS_LOGGER) as $serviceId => $attributes) {

--- a/lib/Extension/RunnerExtension.php
+++ b/lib/Extension/RunnerExtension.php
@@ -74,8 +74,8 @@ class RunnerExtension implements ExtensionInterface
     public const PARAM_ATTRIBUTES = 'runner.attributes';
     public const PARAM_BOOTSTRAP = 'runner.bootstrap';
     public const PARAM_ENABLED_PROVIDERS = 'runner.env_enabled_providers';
-    public const PARAM_ENV_BASELINES = 'runner.env_baselines';
-    public const PARAM_ENV_BASELINE_CALLABLES = 'runner.env_baseline_callables';
+    public const PARAM_ENV_SAMPLERS = 'runner.env_samplers';
+    public const PARAM_ENV_SAMPLER_CALLABLES = 'runner.env_sampler_callables';
     public const PARAM_EXECUTORS = 'runner.executors';
     public const PARAM_PATH = 'runner.path';
     public const PARAM_PHP_BINARY = 'runner.php_binary';
@@ -122,8 +122,8 @@ class RunnerExtension implements ExtensionInterface
                 self::ENV_PROVIDER_UNAME,
                 self::ENV_PROVIDER_UNIX_SYSLOAD,
             ],
-            self::PARAM_ENV_BASELINES => ['nothing', 'md5', 'file_rw'],
-            self::PARAM_ENV_BASELINE_CALLABLES => [],
+            self::PARAM_ENV_SAMPLERS => ['nothing', 'md5', 'file_rw'],
+            self::PARAM_ENV_SAMPLER_CALLABLES => [],
             self::PARAM_EXECUTORS => [],
             self::PARAM_PATH => null,
             self::PARAM_PHP_BINARY => null,
@@ -153,8 +153,8 @@ class RunnerExtension implements ExtensionInterface
         $resolver->setAllowedTypes(self::PARAM_ATTRIBUTES, ['bool']);
         $resolver->setAllowedTypes(self::PARAM_BOOTSTRAP, ['string', 'null']);
         $resolver->setAllowedTypes(self::PARAM_ENABLED_PROVIDERS, ['array']);
-        $resolver->setAllowedTypes(self::PARAM_ENV_BASELINES, ['array']);
-        $resolver->setAllowedTypes(self::PARAM_ENV_BASELINE_CALLABLES, ['array']);
+        $resolver->setAllowedTypes(self::PARAM_ENV_SAMPLERS, ['array']);
+        $resolver->setAllowedTypes(self::PARAM_ENV_SAMPLER_CALLABLES, ['array']);
         $resolver->setAllowedTypes(self::PARAM_EXECUTORS, ['array']);
         $resolver->setAllowedTypes(self::PARAM_PATH, ['string', 'array', 'null']);
         $resolver->setAllowedTypes(self::PARAM_PHP_BINARY, ['string', 'null']);
@@ -184,8 +184,8 @@ class RunnerExtension implements ExtensionInterface
             self::PARAM_ATTRIBUTES => 'Read metadata from PHP 8 attributes',
             self::PARAM_BOOTSTRAP => 'Path to bootstrap (e.g. ``vendor/autoload.php``)',
             self::PARAM_ENABLED_PROVIDERS => 'Select which environment samplers to use',
-            self::PARAM_ENV_BASELINES => 'Environment baselines (not to be confused with baseline comparisons when running benchmarks) are small benchmarks which run to sample the speed of the system (e.g. file I/O, computation etc). This setting enables or disables these baselines',
-            self::PARAM_ENV_BASELINE_CALLABLES => 'Map of baseline callables (adds you to register a new environemntal baseline)',
+            self::PARAM_ENV_SAMPLERS => 'Environment baselines (not to be confused with baseline comparisons when running benchmarks) are small benchmarks which run to sample the speed of the system (e.g. file I/O, computation etc). This setting enables or disables these baselines',
+            self::PARAM_ENV_SAMPLER_CALLABLES => 'Map of baseline callables (adds you to register a new environemntal baseline)',
             self::PARAM_EXECUTORS => 'Add new executor configurations',
             self::PARAM_PATH => 'Path or paths to the benchmarks',
             self::PARAM_PHP_BINARY => 'Specify a PHP binary to use when executing out-of-band benchmarks, e.g. ``/usr/bin/php6``, defaults to the version of PHP used to invoke PHPBench',
@@ -265,7 +265,7 @@ class RunnerExtension implements ExtensionInterface
         $container->register(Provider\Sampler::class, function (Container $container) {
             return new Provider\Sampler(
                 $container->get(SamplerManager::class),
-                $container->getParameter(self::PARAM_ENV_BASELINES)
+                $container->getParameter(self::PARAM_ENV_SAMPLERS)
             );
         }, [self::TAG_ENV_PROVIDER => [
             'name' => self::ENV_PROVIDER_SAMPLER,
@@ -614,7 +614,7 @@ class RunnerExtension implements ExtensionInterface
                 'nothing' => '\PhpBench\Benchmark\Baseline\Baselines::nothing',
                 'md5' => '\PhpBench\Benchmark\Baseline\Baselines::md5',
                 'file_rw' => '\PhpBench\Benchmark\Baseline\Baselines::fwriteFread',
-            ], $container->getParameter(self::PARAM_ENV_BASELINE_CALLABLES));
+            ], $container->getParameter(self::PARAM_ENV_SAMPLER_CALLABLES));
 
             foreach ($callables as $name => $callable) {
                 $manager->addSamplerCallable($name, $callable);

--- a/lib/Extension/StorageExtension.php
+++ b/lib/Extension/StorageExtension.php
@@ -84,7 +84,7 @@ class StorageExtension implements ExtensionInterface
         $container->register(DumpHandler::class, function (Container $container) {
             return new DumpHandler(
                 $container->get(XmlEncoder::class),
-                $container->get(CoreExtension::SERVICE_OUTPUT_STD)
+                $container->get(ConsoleExtension::SERVICE_OUTPUT_STD)
             );
         });
 
@@ -94,10 +94,10 @@ class StorageExtension implements ExtensionInterface
                 $container->get(TimeUnit::class),
                 $container->get(TimeUnitHandler::class),
                 null,
-                $container->get(CoreExtension::SERVICE_OUTPUT_STD)
+                $container->get(ConsoleExtension::SERVICE_OUTPUT_STD)
             );
         }, [
-            CoreExtension::TAG_CONSOLE_COMMAND => []
+            ConsoleExtension::TAG_CONSOLE_COMMAND => []
         ]);
     }
 

--- a/lib/Extension/StorageExtension.php
+++ b/lib/Extension/StorageExtension.php
@@ -34,13 +34,13 @@ use Webmozart\PathUtil\Path;
 
 class StorageExtension implements ExtensionInterface
 {
-    public const PARAM_STORAGE = 'storage';
-    public const PARAM_XML_STORAGE_PATH = 'xml_storage_path';
+    public const PARAM_STORAGE = 'storage.driver';
+    public const PARAM_XML_STORAGE_PATH = 'storage.xml_storage_path';
 
     public const SERVICE_REGISTRY_DRIVER = 'storage.driver_registry';
 
-    public const TAG_STORAGE_DRIVER = 'storage_driver';
-    public const TAG_UUID_RESOLVER = 'uuid_resolver';
+    public const TAG_STORAGE_DRIVER = 'storage.driver';
+    public const TAG_UUID_RESOLVER = 'storage.uuid_resolver';
 
     public function configure(OptionsResolver $resolver): void
     {

--- a/lib/PhpBench.php
+++ b/lib/PhpBench.php
@@ -67,7 +67,7 @@ class PhpBench
             StorageExtension::class,
             XDebugExtension::class,
             ConsoleExtension::class,
-        ], $config['extensions']);
+        ], $config[CoreExtension::PARAM_EXTENSIONS]);
 
         $container = new Container(array_unique($extensions), $config);
         $container->init();
@@ -178,7 +178,7 @@ class PhpBench
                 $config,
                 json_decode($configRaw, true)
             );
-            $config['config_path'] = $configPath;
+            $config[CoreExtension::PARAM_CONFIG_PATH] = $configPath;
 
             break;
         }
@@ -197,11 +197,11 @@ class PhpBench
         if (null !== $profile) {
             $config = self::mergeProfile($config, $profile);
         }
-        unset($config['profiles']);
+        unset($config[CoreExtension::PARAM_PROFILES]);
 
         // add any manually specified extensions
         foreach ($extensions as $extension) {
-            $config['extensions'][] = $extension;
+            $config[CoreExtension::PARAM_EXTENSIONS][] = $extension;
         }
 
         return $config;
@@ -209,14 +209,14 @@ class PhpBench
 
     private static function mergeProfile(array $config, string $profile): array
     {
-        if (!isset($config['profiles'][$profile])) {
+        if (!isset($config[CoreExtension::PARAM_PROFILES][$profile])) {
             throw new ConfigurationPreProcessingError(sprintf(
                 'Unknown profile "%s" specified, defined profiles: "%s"',
-                $profile, implode('", "', array_keys($config['profiles'] ?? []))
+                $profile, implode('", "', array_keys($config[CoreExtension::PARAM_PROFILES] ?? []))
             ));
         }
 
-        return array_merge($config, $config['profiles'][$profile]);
+        return array_merge($config, $config[CoreExtension::PARAM_PROFILES][$profile]);
     }
 
     private static function registerErrorHandler(): void

--- a/lib/PhpBench.php
+++ b/lib/PhpBench.php
@@ -54,9 +54,9 @@ class PhpBench
         );
     }
 
-    public static function loadContainer(InputInterface $input): Container
+    public static function loadContainer(InputInterface $input, ?string $cwd = null): Container
     {
-        $config = self::loadConfig($input);
+        $config = self::loadConfig($input, $cwd ?: getcwd());
 
         $extensions = array_merge([
             CoreExtension::class,
@@ -76,14 +76,13 @@ class PhpBench
     /**
      * @return array<string,mixed>
      */
-    private static function loadConfig(InputInterface $input): array
+    private static function loadConfig(InputInterface $input, string $cwd): array
     {
         $configPaths = [];
         $extensions = [];
         $configOverride = [];
         $profile = null;
         $argBootstrap = null;
-        $cwd = getcwd();
 
         if ($value = $input->getParameterOption(['--working-dir'])) {
             $cwd = Path::makeAbsolute($value, getcwd());

--- a/lib/PhpBench.php
+++ b/lib/PhpBench.php
@@ -15,6 +15,7 @@ namespace PhpBench;
 use PhpBench\Console\Application;
 use PhpBench\DependencyInjection\Container;
 use PhpBench\Exception\ConfigurationPreProcessingError;
+use PhpBench\Extension\ConsoleExtension;
 use PhpBench\Extension\CoreExtension;
 use PhpBench\Extension\ExpressionExtension;
 use PhpBench\Extension\ReportExtension;
@@ -50,7 +51,7 @@ class PhpBench
         $container = self::loadContainer($input);
         $container->get(Application::class)->run(
             $input,
-            $output ?? $container->get(CoreExtension::SERVICE_OUTPUT_ERR)
+            $output ?? $container->get(ConsoleExtension::SERVICE_OUTPUT_ERR)
         );
     }
 
@@ -65,6 +66,7 @@ class PhpBench
             ExpressionExtension::class,
             StorageExtension::class,
             XDebugExtension::class,
+            ConsoleExtension::class,
         ], $config['extensions']);
 
         $container = new Container(array_unique($extensions), $config);
@@ -105,7 +107,7 @@ class PhpBench
         }
 
         if ($input->getParameterOption(['--no-ansi'])) {
-            $configOverride[CoreExtension::PARAM_CONSOLE_ANSI] = false;
+            $configOverride[ConsoleExtension::PARAM_CONSOLE_ANSI] = false;
         }
 
         if ($value = $input->getParameterOption(['--extension'])) {

--- a/lib/PhpBench.php
+++ b/lib/PhpBench.php
@@ -103,7 +103,7 @@ class PhpBench
 
         if ($value = $input->getParameterOption(['--bootstrap', '-b='])) {
             $argBootstrap = $value;
-            $configOverride['bootstrap'] = $value;
+            $configOverride[RunnerExtension::PARAM_BOOTSTRAP] = $value;
         }
 
         if ($input->getParameterOption(['--no-ansi'])) {
@@ -115,21 +115,21 @@ class PhpBench
         }
 
         if ($value = $input->getParameterOption(['--php-binary'])) {
-            $configOverride['php_binary'] = $value;
+            $configOverride[RunnerExtension::PARAM_PHP_BINARY] = $value;
         }
 
         if ($value = $input->getParameterOption(['--php-wrapper'])) {
-            $configOverride['php_wrapper'] = $value;
+            $configOverride[RunnerExtension::PARAM_PHP_WRAPPER] = $value;
         }
 
         if ($value = $input->getParameterOption(['--php-config'])) {
             $jsonParser = new JsonDecoder();
             $value = $jsonParser->decode($value);
-            $configOverride['php_config'] = $value;
+            $configOverride[RunnerExtension::PARAM_PHP_CONFIG] = $value;
         }
 
         if ($input->hasParameterOption(['--php-disable-ini'])) {
-            $configOverride['php_disable_ini'] = true;
+            $configOverride[RunnerExtension::PARAM_PHP_DISABLE_INI] = true;
         }
 
         if ($value = $input->getParameterOption(['--profile'])) {
@@ -188,10 +188,10 @@ class PhpBench
             $configOverride
         );
 
-        if ($configFile && !$argBootstrap && $config['bootstrap']) {
-            $config['bootstrap'] = Path::makeAbsolute($config['bootstrap'], dirname($configFile));
-        } elseif ($config['bootstrap']) {
-            $config['bootstrap'] = Path::makeAbsolute($config['bootstrap'], $cwd);
+        if ($configFile && !$argBootstrap && $config[RunnerExtension::PARAM_BOOTSTRAP]) {
+            $config[RunnerExtension::PARAM_BOOTSTRAP] = Path::makeAbsolute($config[RunnerExtension::PARAM_BOOTSTRAP], dirname($configFile));
+        } elseif ($config[RunnerExtension::PARAM_BOOTSTRAP]) {
+            $config[RunnerExtension::PARAM_BOOTSTRAP] = Path::makeAbsolute($config[RunnerExtension::PARAM_BOOTSTRAP], $cwd);
         }
 
         if (null !== $profile) {

--- a/lib/PhpBench.php
+++ b/lib/PhpBench.php
@@ -107,7 +107,7 @@ class PhpBench
         }
 
         if ($input->getParameterOption(['--no-ansi'])) {
-            $configOverride[ConsoleExtension::PARAM_CONSOLE_ANSI] = false;
+            $configOverride[ConsoleExtension::PARAM_ANSI] = false;
         }
 
         if ($value = $input->getParameterOption(['--extension'])) {

--- a/phpbench.json.dist
+++ b/phpbench.json.dist
@@ -2,16 +2,16 @@
     "extensions": [
         "PhpBench\\Extension\\DevelopmentExtension"
     ],
-    "bootstrap": "vendor/autoload.php",
-    "path": "tests/Benchmark",
-    "php_config": {
+    "runner.bootstrap": "vendor/autoload.php",
+    "runner.path": "tests/Benchmark",
+    "runner.php_config": {
         "memory_limit": "1G"
     },
     "runner.iterations": 10,
     "runner.revs": 10,
     "runner.time_unit": "milliseconds",
     "runner.assert": "mode(variant.time.avg) as ms <= mode(baseline.time.avg) as ms +/- 5%",
-    "reports": {
+    "report.generators": {
         "all": {
             "generator": "composite",
             "reports": [
@@ -26,7 +26,7 @@
             "extensions": [
                 "PhpBench\\Examples\\Extension\\AcmeExtension"
             ],
-            "path": "examples/Benchmark",
+            "runner.path": "examples/Benchmark",
             "php_disable_ini": true,
             "php_config": {
                 "extension": [

--- a/phpbench.json.dist
+++ b/phpbench.json.dist
@@ -27,8 +27,8 @@
                 "PhpBench\\Examples\\Extension\\AcmeExtension"
             ],
             "runner.path": "examples/Benchmark",
-            "php_disable_ini": true,
-            "php_config": {
+            "runner.php_disable_ini": true,
+            "runner.php_config": {
                 "extension": [
                     "tokenizer.so",
                     "dom.so",

--- a/phpbench.json.dist
+++ b/phpbench.json.dist
@@ -1,5 +1,5 @@
 {
-    "extensions": [
+    "core.extensions": [
         "PhpBench\\Extension\\DevelopmentExtension"
     ],
     "runner.bootstrap": "vendor/autoload.php",
@@ -21,9 +21,9 @@
             ]
         }
     },
-    "profiles": {
+    "core.profiles": {
         "examples": {
-            "extensions": [
+            "core.extensions": [
                 "PhpBench\\Examples\\Extension\\AcmeExtension"
             ],
             "runner.path": "examples/Benchmark",

--- a/tests/Benchmark/Console/Command/RunCommandBench.php
+++ b/tests/Benchmark/Console/Command/RunCommandBench.php
@@ -4,7 +4,6 @@ namespace PhpBench\Tests\Benchmark\Console\Command;
 
 use PhpBench\Console\Command\RunCommand;
 use PhpBench\Extension\ConsoleExtension;
-use PhpBench\Extension\CoreExtension;
 use PhpBench\Extension\RunnerExtension;
 use PhpBench\Tests\Benchmark\IntegrationBenchCase;
 use PHPUnit\Framework\Assert;

--- a/tests/Benchmark/Console/Command/RunCommandBench.php
+++ b/tests/Benchmark/Console/Command/RunCommandBench.php
@@ -3,7 +3,7 @@
 namespace PhpBench\Tests\Benchmark\Console\Command;
 
 use PhpBench\Console\Command\RunCommand;
-use PhpBench\Extension\CoreExtension;
+use PhpBench\Extension\ConsoleExtension;
 use PhpBench\Tests\Benchmark\IntegrationBenchCase;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -62,7 +62,7 @@ EOT
     {
         chdir($this->workspace()->path());
         $command = $this->container(array_merge([
-            CoreExtension::PARAM_DISABLE_OUTPUT => false,
+            ConsoleExtension::PARAM_DISABLE_OUTPUT => false,
         ], $config))->get(RunCommand::class);
         $cwd = getcwd();
         $input = new ArrayInput($args);

--- a/tests/Benchmark/Console/Command/RunCommandBench.php
+++ b/tests/Benchmark/Console/Command/RunCommandBench.php
@@ -4,6 +4,8 @@ namespace PhpBench\Tests\Benchmark\Console\Command;
 
 use PhpBench\Console\Command\RunCommand;
 use PhpBench\Extension\ConsoleExtension;
+use PhpBench\Extension\CoreExtension;
+use PhpBench\Extension\RunnerExtension;
 use PhpBench\Tests\Benchmark\IntegrationBenchCase;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -43,7 +45,7 @@ class RunCommandBench extends IntegrationBenchCase
             'path' => '.',
             '--executor' => 'local',
         ], [
-            'env.enabled_providers' => [],
+            RunnerExtension::PARAM_ENABLED_PROVIDERS => [],
         ]);
     }
 

--- a/tests/Benchmark/IntegrationBenchCase.php
+++ b/tests/Benchmark/IntegrationBenchCase.php
@@ -3,6 +3,7 @@
 namespace PhpBench\Tests\Benchmark;
 
 use PhpBench\DependencyInjection\Container;
+use PhpBench\Extension\ConsoleExtension;
 use PhpBench\Extension\CoreExtension;
 use PhpBench\Extension\ExpressionExtension;
 use PhpBench\Extension\ReportExtension;
@@ -22,6 +23,7 @@ abstract class IntegrationBenchCase
     {
         $container = new Container([
             CoreExtension::class,
+            ConsoleExtension::class,
             RunnerExtension::class,
             ReportExtension::class,
             StorageExtension::class,

--- a/tests/Example/CommandsTest.php
+++ b/tests/Example/CommandsTest.php
@@ -40,8 +40,8 @@ class CommandsTest extends IntegrationTestCase
 
         $this->workspace()->put('phpbench.json', json_encode(array_merge([
             RunnerExtension::PARAM_ENABLED_PROVIDERS => [],
-            ConsoleExtension::PARAM_CONSOLE_OUTPUT_STREAM => $this->workspace()->path('output'),
-            ConsoleExtension::PARAM_CONSOLE_ERROR_STREAM => 'php://temp',
+            ConsoleExtension::PARAM_OUTPUT_STREAM => $this->workspace()->path('output'),
+            ConsoleExtension::PARAM_ERROR_STREAM => 'php://temp',
         ], json_decode($approval->getSection(0), true))));
 
         foreach ($commands as $command) {

--- a/tests/Example/CommandsTest.php
+++ b/tests/Example/CommandsTest.php
@@ -5,6 +5,7 @@ namespace PhpBench\Tests\Example;
 use Generator;
 use PhpBench\Console\Application;
 use PhpBench\Extension\ConsoleExtension;
+use PhpBench\Extension\RunnerExtension;
 use PhpBench\PhpBench;
 use PhpBench\Tests\IntegrationTestCase;
 use PhpBench\Tests\Util\Approval;
@@ -38,7 +39,7 @@ class CommandsTest extends IntegrationTestCase
         }, explode("\n", trim($approval->getSection(1))));
 
         $this->workspace()->put('phpbench.json', json_encode(array_merge([
-            'env.enabled_providers' => [],
+            RunnerExtension::PARAM_ENABLED_PROVIDERS => [],
             ConsoleExtension::PARAM_CONSOLE_OUTPUT_STREAM => $this->workspace()->path('output'),
             ConsoleExtension::PARAM_CONSOLE_ERROR_STREAM => 'php://temp',
         ], json_decode($approval->getSection(0), true))));

--- a/tests/Example/CommandsTest.php
+++ b/tests/Example/CommandsTest.php
@@ -40,21 +40,17 @@ class CommandsTest extends IntegrationTestCase
         $this->workspace()->put('phpbench.json', json_encode(array_merge([
             'env.enabled_providers' => [],
             CoreExtension::PARAM_CONSOLE_OUTPUT_STREAM => $this->workspace()->path('output'),
-            CoreExtension::PARAM_CONSOLE_ERROR_STREAM => 'php://temp'
+            CoreExtension::PARAM_CONSOLE_ERROR_STREAM => 'php://temp',
         ], json_decode($approval->getSection(0), true))));
-
-        $cwd = getcwd();
-        chdir($this->workspace()->path());
 
         foreach ($commands as $command) {
             $input = new StringInput($command);
-            $container = PhpBench::loadContainer($input);
+            $container = PhpBench::loadContainer($input, $this->workspace()->path());
             $application = $container->get(Application::class);
             assert($application instanceof Application);
             $application->setAutoExit(false);
-            $application->run($input);
+            $application->run($input, $container->get(CoreExtension::SERVICE_OUTPUT_STD));
         }
-        chdir($cwd);
 
         $output = $this->workspace()->getContents('output');
         // hack to ignore the suite dates

--- a/tests/Example/CommandsTest.php
+++ b/tests/Example/CommandsTest.php
@@ -4,7 +4,7 @@ namespace PhpBench\Tests\Example;
 
 use Generator;
 use PhpBench\Console\Application;
-use PhpBench\Extension\CoreExtension;
+use PhpBench\Extension\ConsoleExtension;
 use PhpBench\PhpBench;
 use PhpBench\Tests\IntegrationTestCase;
 use PhpBench\Tests\Util\Approval;
@@ -39,8 +39,8 @@ class CommandsTest extends IntegrationTestCase
 
         $this->workspace()->put('phpbench.json', json_encode(array_merge([
             'env.enabled_providers' => [],
-            CoreExtension::PARAM_CONSOLE_OUTPUT_STREAM => $this->workspace()->path('output'),
-            CoreExtension::PARAM_CONSOLE_ERROR_STREAM => 'php://temp',
+            ConsoleExtension::PARAM_CONSOLE_OUTPUT_STREAM => $this->workspace()->path('output'),
+            ConsoleExtension::PARAM_CONSOLE_ERROR_STREAM => 'php://temp',
         ], json_decode($approval->getSection(0), true))));
 
         foreach ($commands as $command) {
@@ -49,7 +49,7 @@ class CommandsTest extends IntegrationTestCase
             $application = $container->get(Application::class);
             assert($application instanceof Application);
             $application->setAutoExit(false);
-            $application->run($input, $container->get(CoreExtension::SERVICE_OUTPUT_STD));
+            $application->run($input, $container->get(ConsoleExtension::SERVICE_OUTPUT_STD));
         }
 
         $output = $this->workspace()->getContents('output');

--- a/tests/Integration/ConfiguredReportsTest.php
+++ b/tests/Integration/ConfiguredReportsTest.php
@@ -4,6 +4,7 @@ namespace PhpBench\Tests\Integration;
 
 use Generator;
 use PhpBench\Extension\ConsoleExtension;
+use PhpBench\Extension\CoreExtension;
 use PhpBench\Extension\ReportExtension;
 use PhpBench\Report\ReportManager;
 use PhpBench\Tests\IntegrationTestCase;
@@ -22,7 +23,7 @@ class ConfiguredReportsTest extends IntegrationTestCase
      */
     public function testReport(string $generator, string $renderer): void
     {
-        $manager = $this->container([
+        $manager = $this->PARAM_OUTPUT_STREAM([
             ConsoleExtension::PARAM_CONSOLE_OUTPUT_STREAM => $this->workspace()->path('test')
         ])->get(ReportManager::class);
         assert($manager instanceof ReportManager);

--- a/tests/Integration/ConfiguredReportsTest.php
+++ b/tests/Integration/ConfiguredReportsTest.php
@@ -4,7 +4,6 @@ namespace PhpBench\Tests\Integration;
 
 use Generator;
 use PhpBench\Extension\ConsoleExtension;
-use PhpBench\Extension\CoreExtension;
 use PhpBench\Extension\ReportExtension;
 use PhpBench\Report\ReportManager;
 use PhpBench\Tests\IntegrationTestCase;
@@ -23,8 +22,8 @@ class ConfiguredReportsTest extends IntegrationTestCase
      */
     public function testReport(string $generator, string $renderer): void
     {
-        $manager = $this->PARAM_OUTPUT_STREAM([
-            ConsoleExtension::PARAM_CONSOLE_OUTPUT_STREAM => $this->workspace()->path('test')
+        $manager = $this->container([
+            ConsoleExtension::PARAM_OUTPUT_STREAM => $this->workspace()->path('test')
         ])->get(ReportManager::class);
         assert($manager instanceof ReportManager);
         $manager->renderReports(TestUtil::createCollection([

--- a/tests/Integration/ConfiguredReportsTest.php
+++ b/tests/Integration/ConfiguredReportsTest.php
@@ -3,7 +3,7 @@
 namespace PhpBench\Tests\Integration;
 
 use Generator;
-use PhpBench\Extension\CoreExtension;
+use PhpBench\Extension\ConsoleExtension;
 use PhpBench\Extension\ReportExtension;
 use PhpBench\Report\ReportManager;
 use PhpBench\Tests\IntegrationTestCase;
@@ -23,7 +23,7 @@ class ConfiguredReportsTest extends IntegrationTestCase
     public function testReport(string $generator, string $renderer): void
     {
         $manager = $this->container([
-            CoreExtension::PARAM_CONSOLE_OUTPUT_STREAM => $this->workspace()->path('test')
+            ConsoleExtension::PARAM_CONSOLE_OUTPUT_STREAM => $this->workspace()->path('test')
         ])->get(ReportManager::class);
         assert($manager instanceof ReportManager);
         $manager->renderReports(TestUtil::createCollection([

--- a/tests/IntegrationTestCase.php
+++ b/tests/IntegrationTestCase.php
@@ -3,6 +3,7 @@
 namespace PhpBench\Tests;
 
 use PhpBench\DependencyInjection\Container;
+use PhpBench\Extension\ConsoleExtension;
 use PhpBench\Extension\CoreExtension;
 use PhpBench\Extension\ExpressionExtension;
 use PhpBench\Extension\ReportExtension;
@@ -29,6 +30,7 @@ class IntegrationTestCase extends TestCase
             ReportExtension::class,
             StorageExtension::class,
             RunnerExtension::class,
+            ConsoleExtension::class,
         ], array_merge([
             ExpressionExtension::PARAM_SYNTAX_HIGHLIGHTING => false,
         ], $config)));

--- a/tests/System/RunTest.php
+++ b/tests/System/RunTest.php
@@ -567,7 +567,7 @@ class RunTest extends SystemTestCase
 
     public function testWithSpecificProfile(): void
     {
-        $this->workspace()->put('phpbench.json', '{"profiles": {"foobar":{"runner.path": "benchmarks/set4/NothingBench.php"}}}');
+        $this->workspace()->put('phpbench.json', '{"core.profiles": {"foobar":{"runner.path": "benchmarks/set4/NothingBench.php"}}}');
         $process = $this->phpbench(
             'run --profile=foobar'
         );
@@ -577,7 +577,7 @@ class RunTest extends SystemTestCase
 
     public function testErrorWhenUnknownProfileGiven(): void
     {
-        $this->workspace()->put('phpbench.json', '{"profiles": {"foobar":{"runner.path": "benchmarks/set4/NothingBench.php"}}}');
+        $this->workspace()->put('phpbench.json', '{"core.profiles": {"foobar":{"runner.path": "benchmarks/set4/NothingBench.php"}}}');
         $process = $this->phpbench(
             'run --profile=barfoo'
         );

--- a/tests/System/RunTest.php
+++ b/tests/System/RunTest.php
@@ -12,6 +12,8 @@
 
 namespace PhpBench\Tests\System;
 
+use PhpBench\Extension\RunnerExtension;
+
 class RunTest extends SystemTestCase
 {
     /**
@@ -565,7 +567,7 @@ class RunTest extends SystemTestCase
 
     public function testWithSpecificProfile(): void
     {
-        $this->workspace()->put('phpbench.json', '{"profiles": {"foobar":{"path": "benchmarks/set4/NothingBench.php"}}}');
+        $this->workspace()->put('phpbench.json', '{"profiles": {"foobar":{"runner.path": "benchmarks/set4/NothingBench.php"}}}');
         $process = $this->phpbench(
             'run --profile=foobar'
         );
@@ -575,7 +577,7 @@ class RunTest extends SystemTestCase
 
     public function testErrorWhenUnknownProfileGiven(): void
     {
-        $this->workspace()->put('phpbench.json', '{"profiles": {"foobar":{"path": "benchmarks/set4/NothingBench.php"}}}');
+        $this->workspace()->put('phpbench.json', '{"profiles": {"foobar":{"runner.path": "benchmarks/set4/NothingBench.php"}}}');
         $process = $this->phpbench(
             'run --profile=barfoo'
         );
@@ -587,8 +589,8 @@ class RunTest extends SystemTestCase
     public function testSpecifyRemoteScriptPath(): void
     {
         $this->workspace()->put('phpbench.json', (string)json_encode([
-            'remote_script_path' => $this->workspace()->path('remote'),
-            'remote_script_remove' => false,
+            RunnerExtension::PARAM_REMOTE_SCRIPT_PATH => $this->workspace()->path('remote'),
+            RunnerExtension::PARAM_REMOTE_SCRIPT_REMOVE => false,
         ]));
 
         $process = $this->phpbench(
@@ -601,7 +603,7 @@ class RunTest extends SystemTestCase
     public function testSpecifyMultiplePaths(): void
     {
         $this->workspace()->put('phpbench.json', (string)json_encode([
-            'path' => [
+            RunnerExtension::PARAM_PATH => [
                 'benchmarks/set4/NothingBench.php',
                 'benchmarks/set4/NothingBench.php',
             ]

--- a/tests/System/env/config_dist/phpbench.json.dist
+++ b/tests/System/env/config_dist/phpbench.json.dist
@@ -1,4 +1,4 @@
 {
-    "bootstrap": "../../bootstrap/foobar.bootstrap",
-    "path": "."
+    "runner.bootstrap": "../../bootstrap/foobar.bootstrap",
+    "runner.path": "."
 }

--- a/tests/System/env/config_set2/phpbench.json
+++ b/tests/System/env/config_set2/phpbench.json
@@ -1,4 +1,4 @@
 {
-    "bootstrap": "../../bootstrap/foobar.bootstrap",
-    "path": "../../benchmarks/set2"
+    "runner.bootstrap": "../../bootstrap/foobar.bootstrap",
+    "runner.path": "../../benchmarks/set2"
 }

--- a/tests/System/env/config_valid/phpbench.dist.json
+++ b/tests/System/env/config_valid/phpbench.dist.json
@@ -1,3 +1,3 @@
 {
-    "bootstrap": "shouldnotbecalled.php"
+    "runner.bootstrap": "shouldnotbecalled.php"
 }

--- a/tests/System/env/config_valid/phpbench.json
+++ b/tests/System/env/config_valid/phpbench.json
@@ -1,6 +1,6 @@
 {
-    "bootstrap": "../..//bootstrap/foobar.bootstrap",
-    "path": "../../benchmarks/set1",
+    "runner.bootstrap": "../..//bootstrap/foobar.bootstrap",
+    "runner.path": "../../benchmarks/set1",
     "runner.iterations": 1,
     "runner.revs": 1
 }

--- a/tests/Unit/Extension/RunnerExtensionTest.php
+++ b/tests/Unit/Extension/RunnerExtensionTest.php
@@ -13,6 +13,7 @@
 namespace PhpBench\Tests\Unit\Extension;
 
 use PhpBench\Benchmark\Metadata\Driver\ConfigDriver;
+use PhpBench\Extension\CoreExtension;
 use PhpBench\Extension\RunnerExtension;
 use PhpBench\Tests\IntegrationTestCase;
 
@@ -24,10 +25,10 @@ class RunnerExtensionTest extends IntegrationTestCase
     public function testRelativizePath(): void
     {
         $container = $this->container([
-            'path' => 'hello',
-            'config_path' => '/path/to/phpbench.json',
+            RunnerExtension::PARAM_PATH => 'hello',
+            CoreExtension::PARAM_CONFIG_PATH => '/path/to/phpbench.json',
         ]);
-        $this->assertEquals(['/path/to/hello'], $container->getParameter('path'));
+        $this->assertEquals(['/path/to/hello'], $container->getParameter(RunnerExtension::PARAM_PATH));
     }
 
     public function testConfigDriver(): void


### PR DESCRIPTION
This PR aims to stabalize the configuration options.

- All options prefixed with the extension to which they belong eg. `report.generators` instead of `reports`, `runner.bootstrap` instead of `bootstrap`