### PR TITLE
Imporve expr errors in report

### DIFF
--- a/lib/Extension/CoreExtension.php
+++ b/lib/Extension/CoreExtension.php
@@ -92,6 +92,7 @@ EOT
 
         $container->register(LoggerInterface::class, function (Container $container) {
             return new ConsoleLogger(
+                $container->get(ConsoleExtension::SERVICE_OUTPUT_ERR),
                 $container->getParameter(self::PARAM_DEBUG)
             );
         });

--- a/lib/Logger/ConsoleLogger.php
+++ b/lib/Logger/ConsoleLogger.php
@@ -2,7 +2,6 @@
 
 namespace PhpBench\Logger;
 
-use PhpBench\Progress\LoggerInterface;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LogLevel;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -32,13 +31,14 @@ class ConsoleLogger extends AbstractLogger
     {
         $decoration = 'fg=cyan';
 
-        switch($level) {
+        switch ($level) {
             case LogLevel::DEBUG:
             case LogLevel::INFO:
             case LogLevel::NOTICE:
                 if (!$this->enable) {
                     return;
                 }
+
                 break;
             case LogLevel::ERROR:
             case LogLevel::WARNING:
@@ -46,9 +46,9 @@ class ConsoleLogger extends AbstractLogger
             case LogLevel::EMERGENCY:
             case LogLevel::ALERT:
                 $decoration = 'bg=red;fg=white';
+
                 break;
         }
         $this->output->writeln(sprintf("[<%s>%s</>] %s\n", $decoration, strtoupper($level), $message));
-
     }
 }

--- a/lib/Logger/ConsoleLogger.php
+++ b/lib/Logger/ConsoleLogger.php
@@ -2,7 +2,10 @@
 
 namespace PhpBench\Logger;
 
+use PhpBench\Progress\LoggerInterface;
 use Psr\Log\AbstractLogger;
+use Psr\Log\LogLevel;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class ConsoleLogger extends AbstractLogger
 {
@@ -11,9 +14,15 @@ class ConsoleLogger extends AbstractLogger
      */
     private $enable;
 
-    public function __construct(bool $enable)
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    public function __construct(OutputInterface $output, bool $enable)
     {
         $this->enable = $enable;
+        $this->output = $output;
     }
 
     /**
@@ -21,10 +30,25 @@ class ConsoleLogger extends AbstractLogger
      */
     public function log($level, $message, array $context = []): void
     {
-        if (false === $this->enable) {
-            return;
-        }
+        $decoration = 'fg=cyan';
 
-        fwrite(STDERR, sprintf("[%s] %s\n", $level, $message));
+        switch($level) {
+            case LogLevel::DEBUG:
+            case LogLevel::INFO:
+            case LogLevel::NOTICE:
+                if (!$this->enable) {
+                    return;
+                }
+                break;
+            case LogLevel::ERROR:
+            case LogLevel::WARNING:
+            case LogLevel::CRITICAL:
+            case LogLevel::EMERGENCY:
+            case LogLevel::ALERT:
+                $decoration = 'bg=red;fg=white';
+                break;
+        }
+        $this->output->writeln(sprintf("[<%s>%s</>] %s\n", $decoration, strtoupper($level), $message));
+
     }
 }

--- a/lib/Report/Generator/ExpressionGenerator.php
+++ b/lib/Report/Generator/ExpressionGenerator.php
@@ -220,8 +220,10 @@ EOT
                 try {
                     $evaledRow[$name] = $this->evaluator->evaluate($this->parser->parse($expr), $row);
                 } catch (EvaluationError $e) {
-                    $evaledRow[$name] = new StringNode('error: ' . $expr);
-                    $this->logger->error($e->getMessage());
+                    $evaledRow[$name] = new StringNode('ERR');
+                    $this->logger->error(sprintf(
+                        'Expression error (column "%s"): %s', $name, $e->getMessage()
+                    ));
                 }
             }
 

--- a/tests/Unit/Logger/ConsoleLoggerTest.php
+++ b/tests/Unit/Logger/ConsoleLoggerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace PhpBench\Tests\Unit\Logger;
+
+use PHPUnit\Framework\TestCase;
+use PhpBench\Logger\ConsoleLogger;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ConsoleLoggerTest extends TestCase
+{
+    public function testNoInfoWhenNotDebug(): void
+    {
+        $output = $this->createOutput();
+        $this->createLogger($output, false)->debug('asd');
+        $this->createLogger($output, false)->notice('asd');
+        $this->createLogger($output, false)->info('asd');
+        self::assertEmpty($output->fetch());
+    }
+
+    public function testLogInfoWhenDebug(): void
+    {
+        $output = $this->createOutput();
+        $this->createLogger($output, true)->debug('asd');
+        self::assertNotEmpty($output->fetch());
+        $this->createLogger($output, true)->info('asd');
+        self::assertNotEmpty($output->fetch());
+        $this->createLogger($output, true)->notice('asd');
+        self::assertNotEmpty($output->fetch());
+    }
+
+    private function createOutput(): BufferedOutput
+    {
+        return new BufferedOutput();
+    }
+
+    private function createLogger(OutputInterface $output, bool $debug): LoggerInterface
+    {
+        return new ConsoleLogger($output, $debug);
+    }
+}

--- a/tests/Unit/Logger/ConsoleLoggerTest.php
+++ b/tests/Unit/Logger/ConsoleLoggerTest.php
@@ -2,8 +2,8 @@
 
 namespace PhpBench\Tests\Unit\Logger;
 
-use PHPUnit\Framework\TestCase;
 use PhpBench\Logger\ConsoleLogger;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;


### PR DESCRIPTION
Simply shows `ERR` in report cells that errored, and ensures that ERROR level log messages are shown (as the ERR messages are logged)