### PR TITLE
Automatically creates missing dirs and refactors payload test

### DIFF
--- a/lib/Remote/Payload.php
+++ b/lib/Remote/Payload.php
@@ -49,11 +49,6 @@ class Payload
     private $tokens = [];
 
     /**
-     * Symfony Process instance.
-     */
-    private $process;
-
-    /**
      * @var bool
      */
     private $disableIni = false;
@@ -208,7 +203,7 @@ class Payload
                 return;
             }
 
-            if (@mkdir($directory, 0744)) {
+            if (@mkdir($directory, 0744, true)) {
                 return;
             }
 

--- a/lib/Remote/Payload.php
+++ b/lib/Remote/Payload.php
@@ -59,7 +59,7 @@ class Payload
     private $iniStringBuilder;
 
     /**
-     * @var ProcessFactory
+     * @var ProcessFactoryInterface
      */
     private $processFactory;
 
@@ -89,7 +89,7 @@ class Payload
         array $tokens = [],
         ?string $phpPath = PHP_BINARY,
         ?float $timeout = null,
-        ProcessFactory $processFactory = null,
+        ProcessFactoryInterface $processFactory = null,
         string $scriptPath = null,
         bool $scriptRemove = false
     ) {

--- a/lib/Remote/ProcessFactory.php
+++ b/lib/Remote/ProcessFactory.php
@@ -6,7 +6,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\Process\Process;
 
-class ProcessFactory
+class ProcessFactory implements ProcessFactoryInterface
 {
     /**
      * @var LoggerInterface

--- a/lib/Remote/ProcessFactoryInterface.php
+++ b/lib/Remote/ProcessFactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace PhpBench\Remote;
+
+use Symfony\Component\Process\Process;
+
+interface ProcessFactoryInterface
+{
+    public function create(string $commandLine, ?float $timeout = null): Process;
+}

--- a/tests/Unit/Remote/PayloadTest.php
+++ b/tests/Unit/Remote/PayloadTest.php
@@ -15,7 +15,6 @@ namespace PhpBench\Tests\Unit\Remote;
 use PhpBench\Remote\Payload;
 use PhpBench\Remote\ProcessFactory;
 use PhpBench\Tests\TestCase;
-use PHPUnit\Framework\MockObject\Invocation;
 use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
 use RuntimeException;
 use Symfony\Component\Process\Process;

--- a/tests/Unit/Remote/PayloadTest.php
+++ b/tests/Unit/Remote/PayloadTest.php
@@ -13,7 +13,7 @@
 namespace PhpBench\Tests\Unit\Remote;
 
 use PhpBench\Remote\Payload;
-use PhpBench\Remote\ProcessFactory;
+use PhpBench\Remote\ProcessFactoryInterface;
 use PhpBench\Tests\TestCase;
 use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
 use RuntimeException;
@@ -27,7 +27,7 @@ class PayloadTest extends TestCase
     protected function setUp(): void
     {
         $this->process = $this->createMock(Process::class);
-        $this->processFactory = $this->createMock(ProcessFactory::class);
+        $this->processFactory = $this->createMock(ProcessFactoryInterface::class);
     }
 
     /**
@@ -137,7 +137,7 @@ class PayloadTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Could not find script template');
-        $processFactory = $this->createMock(ProcessFactory::class);
+        $processFactory = $this->createMock(ProcessFactoryInterface::class);
         $payload = new Payload(
             __DIR__ . '/template/not-existing-filename.template',
             [],


### PR DESCRIPTION
I wanted to write  a regression test for the change, but it's a private method and the created file is temporary anyway. 
So I started refactoring your tests in order to iteratively understand your code.
**prophesize()** is deprecated and will be removed in PHPUnit 10 https://phpunit.de/supported-versions.html
I mocked `ProcessFactory` now, actually Sebastian Bergmann only wants you to mock interfaces. I didn't create an Interface for `ProcessFactory` now. Maybe you don't want to mock `ProcessFactory` but instantiate it, because you want to test its behaviour too? Otherwise, we could think about creating an Interface for it. But just a suggestion.