### PR TITLE
[feature] Allow Multiple Paths to be specified from CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+master
+------
+
+Features:
+
+- Allow multiple benchmark paths to be specified from CLI #834
+
 1.0.1 (2021-05-11)
 ------------------
 

--- a/lib/Console/Command/Handler/RunnerHandler.php
+++ b/lib/Console/Command/Handler/RunnerHandler.php
@@ -83,7 +83,7 @@ class RunnerHandler
 
     public static function configure(Command $command): void
     {
-        $command->addArgument(self::ARG_PATH, InputArgument::OPTIONAL, 'Path to benchmark(s)');
+        $command->addArgument(self::ARG_PATH, InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'Path to benchmark(s)');
         $command->addOption(self::OPT_FILTER, [], InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Ignore all benchmarks not matching command filter (can be a regex)');
         $command->addOption(self::OPT_GROUP, [], InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Group to run (can be specified multiple times)');
         $command->addOption(self::OPT_PARAMETERS, null, InputOption::VALUE_REQUIRED, 'Override parameters to use in (all) benchmarks');

--- a/tests/System/RunTest.php
+++ b/tests/System/RunTest.php
@@ -78,6 +78,14 @@ class RunTest extends SystemTestCase
         $this->assertStringContainsString('You must either specify', $process->getErrorOutput());
     }
 
+    public function testCommandWithMultiplePaths(): void
+    {
+        $process = $this->phpbench('run benchmarks/set4/NothingBench.php benchmarks/set1/BenchmarkBench.php');
+        $this->assertExitCode(0, $process);
+        $this->assertStringContainsString('benchNothing', $process->getErrorOutput());
+        $this->assertStringContainsString('benchRandom', $process->getErrorOutput());
+    }
+
     /**
      * It should run and generate a report configuration.
      */
@@ -600,7 +608,7 @@ class RunTest extends SystemTestCase
         $this->assertFileExists($this->workspace()->path('remote/remote.template'));
     }
 
-    public function testSpecifyMultiplePaths(): void
+    public function testSpecifyuultiplePaths(): void
     {
         $this->workspace()->put('phpbench.json', (string)json_encode([
             RunnerExtension::PARAM_PATH => [


### PR DESCRIPTION
Allow multiple paths to be specified from the CLI. Multiple paths are
currently supported in configuration, this will enable passing multiple paths
as arguments to the `run` command.
