### PR TITLE
improvement: Use automatic time unit for expression report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ master
 
 Features:
 
+- Data Frame and Expression Filtering #831
 - Allow multiple benchmark paths to be specified from CLI #834
 - Functions which require at least one value return NULL when values are
   empty #835
+
+Improvement:
+
+- Use automatic time unit for expression report #838
 
 1.0.1 (2021-05-11)
 ------------------

--- a/lib/Report/Generator/ExpressionGenerator.php
+++ b/lib/Report/Generator/ExpressionGenerator.php
@@ -86,7 +86,7 @@ display_as_time(
     %s, 
     coalesce(
         first(subject_time_unit),
-        "microseconds"
+        "time"
     ), 
     first(subject_time_precision), 
     first(subject_time_mode))


### PR DESCRIPTION
`microseconds` was hardcoded as the default instead of `time` which will automatically determine the unit