### PR TITLE
Fix duplicated key "runner.php_config" on phpbench.json.dist

### DIFF
--- a/phpbench.json.dist
+++ b/phpbench.json.dist
@@ -5,7 +5,8 @@
     "runner.bootstrap": "vendor/autoload.php",
     "runner.path": "tests/Benchmark",
     "runner.php_config": {
-        "memory_limit": "1G"
+        "memory_limit": "1G",
+        "xdebug.mode": "none"
     },
     "runner.iterations": 10,
     "runner.retry_threshold": 5,
@@ -20,9 +21,6 @@
                 "aggregate"
             ]
         }
-    },
-    "runner.php_config": {
-        "xdebug.mode": "none"
     },
     "core.profiles": {
         "examples": {


### PR DESCRIPTION
The `phpbench.json.dist` file has the `"runner.php_config"` key duplicated.

Technically the JSON specification does not make any mention of duplicate keys being invalid or valid, but this could cause problems in some JSON libraries implementations.