### PR TITLE
Fix mode() when population has NULL values

### DIFF
--- a/lib/Expression/Ast/DelimitedListNode.php
+++ b/lib/Expression/Ast/DelimitedListNode.php
@@ -38,4 +38,14 @@ abstract class DelimitedListNode extends PhpValue
             return $node->value();
         }, $this->nodes);
     }
+
+    /**
+     * @return mixed[]
+     */
+    public function nonNullPhpValues(): array
+    {
+        return array_values(array_filter($this->phpValues(), function ($value) {
+            return $value !== null;
+        }));
+    }
 }

--- a/lib/Expression/Func/MaxFunction.php
+++ b/lib/Expression/Func/MaxFunction.php
@@ -11,7 +11,7 @@ final class MaxFunction
 {
     public function __invoke(ListNode $values): PhpValue
     {
-        $values = $values->phpValues();
+        $values = $values->nonNullPhpValues();
 
         if (empty($values)) {
             return new NullNode();

--- a/lib/Expression/Func/MeanFunction.php
+++ b/lib/Expression/Func/MeanFunction.php
@@ -11,6 +11,8 @@ final class MeanFunction
 {
     public function __invoke(ListNode $values): PhpValue
     {
-        return PhpValueFactory::fromValue(Statistics::mean($values->phpValues()));
+        return PhpValueFactory::fromValue(Statistics::mean(
+            $values->nonNullPhpValues()
+        ));
     }
 }

--- a/lib/Expression/Func/MinFunction.php
+++ b/lib/Expression/Func/MinFunction.php
@@ -6,13 +6,12 @@ use PhpBench\Expression\Ast\ListNode;
 use PhpBench\Expression\Ast\NullNode;
 use PhpBench\Expression\Ast\PhpValue;
 use PhpBench\Expression\Ast\PhpValueFactory;
-use RuntimeException;
 
 final class MinFunction
 {
     public function __invoke(ListNode $values): PhpValue
     {
-        $values = $values->phpValues();
+        $values = $values->nonNullPhpValues();
 
         if (empty($values)) {
             return new NullNode();
@@ -21,9 +20,7 @@ final class MinFunction
         $result = min($values);
 
         if (!is_float($result) && !is_int($result)) {
-            throw new RuntimeException(
-                'Could not evaluate min'
-            );
+            return new NullNode();
         }
 
         return PhpValueFactory::fromValue($result);

--- a/lib/Expression/Func/ModeFunction.php
+++ b/lib/Expression/Func/ModeFunction.php
@@ -11,6 +11,6 @@ final class ModeFunction
 {
     public function __invoke(ListNode $values, ?IntegerNode $space = null): FloatNode
     {
-        return new FloatNode(Statistics::kdeMode($values->phpValues(), $space ? $space->value() : 512));
+        return new FloatNode(Statistics::kdeMode($values->nonNullPhpValues(), $space ? $space->value() : 512));
     }
 }

--- a/lib/Expression/Func/RStDevFunction.php
+++ b/lib/Expression/Func/RStDevFunction.php
@@ -13,7 +13,10 @@ final class RStDevFunction
     public function __invoke(ListNode $values, ?BooleanNode $sample = null): RelativeDeviationNode
     {
         return new RelativeDeviationNode(
-            new FloatNode(Statistics::rstdev($values->phpValues(), $sample ? $sample->value() : false))
+            new FloatNode(Statistics::rstdev(
+                $values->nonNullPhpValues(),
+                $sample ? $sample->value() : false
+            ))
         );
     }
 }

--- a/lib/Expression/Func/StDevFunction.php
+++ b/lib/Expression/Func/StDevFunction.php
@@ -11,6 +11,6 @@ final class StDevFunction
 {
     public function __invoke(ListNode $values, ?BooleanNode $sample = null): FloatNode
     {
-        return new FloatNode(Statistics::stdev($values->phpValues(), $sample ? $sample->value() : false));
+        return new FloatNode(Statistics::stdev($values->nonNullPhpValues(), $sample ? $sample->value() : false));
     }
 }

--- a/lib/Expression/Func/VarianceFunction.php
+++ b/lib/Expression/Func/VarianceFunction.php
@@ -11,6 +11,6 @@ final class VarianceFunction
 {
     public function __invoke(ListNode $values, ?BooleanNode $sample = null): FloatNode
     {
-        return new FloatNode(Statistics::variance($values->phpValues(), $sample ? $sample->value() : false));
+        return new FloatNode(Statistics::variance($values->nonNullPhpValues(), $sample ? $sample->value() : false));
     }
 }

--- a/lib/Report/Generator/ComponentGenerator.php
+++ b/lib/Report/Generator/ComponentGenerator.php
@@ -80,7 +80,7 @@ class ComponentGenerator implements ComponentGeneratorInterface, GeneratorInterf
      */
     public function generate(SuiteCollection $collection, Config $config): Reports
     {
-        $dataFrame = $this->transformer->suiteToFrame($collection);
+        $dataFrame = $this->transformer->suiteToFrame($collection, true);
         $component = $this->generateComponent($dataFrame, $config->getArrayCopy());
         assert($component instanceof Report);
 

--- a/tests/Unit/Expression/Func/MaxFunctionTest.php
+++ b/tests/Unit/Expression/Func/MaxFunctionTest.php
@@ -9,6 +9,14 @@ use PhpBench\Tests\Unit\Expression\FunctionTestCase;
 
 class MaxFunctionTest extends FunctionTestCase
 {
+    public function testEvalNullValues(): void
+    {
+        self::assertEquals(6, $this->eval(
+            new MaxFunction(),
+            '[2, 6, null, null, null]'
+        )->value());
+    }
+
     public function testEval(): void
     {
         self::assertEquals(new IntegerNode(6), $this->eval(

--- a/tests/Unit/Expression/Func/MeanFunctionTest.php
+++ b/tests/Unit/Expression/Func/MeanFunctionTest.php
@@ -8,6 +8,13 @@ use PhpBench\Tests\Unit\Expression\FunctionTestCase;
 
 class MeanFunctionTest extends FunctionTestCase
 {
+    public function testEvalNullValues(): void
+    {
+        self::assertEquals(4, $this->eval(
+            new MeanFunction(),
+            '[2, 6, null, null, null]'
+        )->value());
+    }
     public function testEval(): void
     {
         self::assertEquals(new IntegerNode(4), $this->eval(

--- a/tests/Unit/Expression/Func/MinFunctionTest.php
+++ b/tests/Unit/Expression/Func/MinFunctionTest.php
@@ -9,6 +9,14 @@ use PhpBench\Tests\Unit\Expression\FunctionTestCase;
 
 class MinFunctionTest extends FunctionTestCase
 {
+    public function testEvalNullValues(): void
+    {
+        self::assertEquals(2, $this->eval(
+            new MinFunction(),
+            '[2, 6, null, null, null]'
+        )->value());
+    }
+
     public function testEval(): void
     {
         self::assertEquals(

--- a/tests/Unit/Expression/Func/ModeFunctionTest.php
+++ b/tests/Unit/Expression/Func/ModeFunctionTest.php
@@ -7,6 +7,13 @@ use PhpBench\Tests\Unit\Expression\FunctionTestCase;
 
 class ModeFunctionTest extends FunctionTestCase
 {
+    public function testEvalNullValues(): void
+    {
+        self::assertEqualsWithDelta(3.99, $this->eval(
+            new ModeFunction(),
+            '[2, null, 4, null, 6]'
+        )->value(), 0.1);
+    }
     public function testEval(): void
     {
         self::assertEqualsWithDelta(3.99, $this->eval(

--- a/tests/Unit/Expression/Func/RStDevFunctionTest.php
+++ b/tests/Unit/Expression/Func/RStDevFunctionTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PhpBench\Tests\Unit\Expression\Func;
+
+use PhpBench\Expression\Func\RStDevFunction;
+use PhpBench\Tests\Unit\Expression\FunctionTestCase;
+
+class RStDevFunctionTest extends FunctionTestCase
+{
+    public function testEvalWithNull(): void
+    {
+        self::assertEqualsWithDelta(33.33, $this->eval(
+            new RStDevFunction(),
+            '[1, 2, null, null]'
+        )->value(), 0.1);
+    }
+
+    public function testEval(): void
+    {
+        self::assertEqualsWithDelta(33.33, $this->eval(
+            new RStDevFunction(),
+            '[1, 2]'
+        )->value(), 0.1);
+    }
+}

--- a/tests/Unit/Expression/Func/StDevFunctionTest.php
+++ b/tests/Unit/Expression/Func/StDevFunctionTest.php
@@ -7,6 +7,13 @@ use PhpBench\Tests\Unit\Expression\FunctionTestCase;
 
 class StDevFunctionTest extends FunctionTestCase
 {
+    public function testEvalWithNull(): void
+    {
+        self::assertEquals(0.5, $this->eval(
+            new StDevFunction(),
+            '[1, 2, null, null]'
+        )->value());
+    }
     public function testEval(): void
     {
         self::assertEquals(0.5, $this->eval(

--- a/tests/Unit/Expression/Func/VarianceFunctionTest.php
+++ b/tests/Unit/Expression/Func/VarianceFunctionTest.php
@@ -7,6 +7,14 @@ use PhpBench\Tests\Unit\Expression\FunctionTestCase;
 
 class VarianceFunctionTest extends FunctionTestCase
 {
+    public function testEvalWithNull(): void
+    {
+        self::assertEquals(0.25, $this->eval(
+            new VarianceFunction(),
+            '[1, 2, null, null]'
+        )->value());
+    }
+
     public function testEval(): void
     {
         self::assertEquals(0.25, $this->eval(


### PR DESCRIPTION
Need to consider this and apply it also to other aggregate functions.