### PR TITLE
Fix benchmark finder to only pick up *Bench files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 CHANGELOG
 =========
 
+1.0.x
+-----
+
+Bug fix:
+
+- Show warning if file is parsed but it is not a benchmark file.
+
+  Files that are not suffixed with `Bench.php` are are reflected and their
+  docblocks are parsed. Causing unexpected errors if unknown docblock tags are
+  present.
+
+  As this changing this behavior (introduced by error in 2016) is a B/C break,
+  it will not be changed in a bug-fix release.
+
+  An option `runner.file_pattern` has been added however to enable the
+  warnings to be resolved.
+
 1.0.2 (2021-05-28)
 ------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Bug fix:
   An option `runner.file_pattern` has been added however to enable the
   warnings to be resolved.
 
+Improvement:
+
+- Show warning if metadata could not be loaded for benchmark.
+
 1.0.2 (2021-05-28)
 ------------------
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-reflection": "*",
         "ext-spl": "*",
         "ext-tokenizer": "*",
-        "doctrine/annotations": "^1.6.0",
+        "doctrine/annotations": "^1.2.7",
         "phpbench/container": "^2.1",
         "phpbench/dom": "~0.3.1",
         "psr/log": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-reflection": "*",
         "ext-spl": "*",
         "ext-tokenizer": "*",
-        "doctrine/annotations": "^1.2.7",
+        "doctrine/annotations": "^1.6.0",
         "phpbench/container": "^2.1",
         "phpbench/dom": "~0.3.1",
         "psr/log": "^1.1",

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -416,11 +416,11 @@ Types: ``["string"]``
 runner.file_pattern
 ~~~~~~~~~~~~~~~~~~~
 
-Consider file names matching this pattern to be benchmarks
+Consider file names matching this pattern to be benchmarks. NOTE: In 2.0 this will be set to ``*Bench.php``
 
-Default: ``*Bench.php``
+Default: ``NULL``
 
-Types: ``["string"]``
+Types: ``["string","null"]``
 
 Report
 ------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -411,6 +411,17 @@ Default: ``^bench``
 
 Types: ``["string"]``
 
+.. _configuration_runner_file_pattern:
+
+runner.file_pattern
+~~~~~~~~~~~~~~~~~~~
+
+Consider file names matching this pattern to be benchmarks
+
+Default: ``*Bench.php``
+
+Types: ``["string"]``
+
 Report
 ------
 

--- a/lib/Benchmark/BenchmarkFinder.php
+++ b/lib/Benchmark/BenchmarkFinder.php
@@ -128,13 +128,14 @@ class BenchmarkFinder
         }
 
         foreach ($finder as $file) {
-            if ($this->benchPattern === null && substr($file->getPathInfo(), 0, -9) !== 'Bench.php') {
+            assert($file instanceof SplFileInfo);
+
+            if ($this->benchPattern === null && substr($file->getFilename(), -9) !== 'Bench.php') {
                 $this->logger->warning(sprintf(
                     'File "%s" has been identified as a benchmark file but it does not end with ' .
-                    '`Bench.php` and no `runner.file_pattern` has been specified. ' .
-                    'It is recommended to set a file pattern. In PHPBench 2.0 the pattern will be ' .
-                    '`*Bench.php` by default.',
-                    $file->getPathInfo()
+                    '`Bench.php`. This behavior is incorrect and will be fixed in PHPBench 2.0. ' .
+                    'Set a `runner.file_pattern` to `*Bench.php` to avoid this.',
+                    $file->getFilename()
                 ));
             }
 

--- a/lib/Benchmark/BenchmarkFinder.php
+++ b/lib/Benchmark/BenchmarkFinder.php
@@ -35,10 +35,16 @@ class BenchmarkFinder
      */
     private $cwd;
 
-    public function __construct(MetadataFactory $factory, string $cwd)
+    /**
+     * @var string
+     */
+    private $benchPattern;
+
+    public function __construct(MetadataFactory $factory, string $cwd, string $benchPattern = null)
     {
         $this->factory = $factory;
         $this->cwd = $cwd;
+        $this->benchPattern = $benchPattern ?: '*.php';
     }
 
     /**
@@ -98,7 +104,7 @@ class BenchmarkFinder
 
             if (is_dir($path)) {
                 $search = true;
-                $finder->in($path)->name('*.php');
+                $finder->in($path)->name($this->benchPattern);
 
                 continue;
             }

--- a/lib/Benchmark/BenchmarkFinder.php
+++ b/lib/Benchmark/BenchmarkFinder.php
@@ -133,8 +133,8 @@ class BenchmarkFinder
             if ($this->benchPattern === null && substr($file->getFilename(), -9) !== 'Bench.php') {
                 $this->logger->warning(sprintf(
                     'File "%s" has been identified as a benchmark file but it does not end with ' .
-                    '`Bench.php`. This behavior is incorrect and will be fixed in PHPBench 2.0. ' .
-                    'Set a `runner.file_pattern` to `*Bench.php` to avoid this.',
+                    '`Bench.php`. This behavior is incorrect and will be fixed in a future version. ' .
+                    'Set `runner.file_pattern` to `*Bench.php` in `phpbench.json` to avoid this.',
                     $file->getFilename()
                 ));
             }

--- a/lib/Benchmark/Metadata/AnnotationReader.php
+++ b/lib/Benchmark/Metadata/AnnotationReader.php
@@ -18,6 +18,7 @@ use Doctrine\Common\Annotations\DocParser;
 use Doctrine\Common\Annotations\TokenParser;
 use PhpBench\Reflection\ReflectionClass;
 use PhpBench\Reflection\ReflectionMethod;
+use PhpBench\Tests\Unit\Benchmark\Metadata\Exception\CouldNotLoadMetadataException;
 
 /**
  * Annotation reader.
@@ -214,10 +215,10 @@ class AnnotationReader
             $annotations = $this->docParser->parse($input, $context);
         } catch (AnnotationException $e) {
             if (!preg_match('/The annotation "(.*)" .* was never imported/', $e->getMessage(), $matches)) {
-                throw $e;
+                throw new CouldNotLoadMetadataException($e->getMessage(), 0, $e);
             }
 
-            throw new \InvalidArgumentException(sprintf(
+            throw new CouldNotLoadMetadataException(sprintf(
                 'Unrecognized annotation %s, valid PHPBench annotations: @%s',
                 $matches[1],
                 implode(', @', array_keys(self::$phpBenchImports))

--- a/lib/Benchmark/Metadata/AnnotationReader.php
+++ b/lib/Benchmark/Metadata/AnnotationReader.php
@@ -212,7 +212,7 @@ class AnnotationReader
     private function parse($input, $context = ''): array
     {
         try {
-            $annotations = $this->docParser->parse($input, $context);
+            $annotations = @$this->docParser->parse($input, $context);
         } catch (AnnotationException $e) {
             if (!preg_match('/The annotation "(.*)" .* was never imported/', $e->getMessage(), $matches)) {
                 throw new CouldNotLoadMetadataException($e->getMessage(), 0, $e);

--- a/lib/Benchmark/Metadata/MetadataFactory.php
+++ b/lib/Benchmark/Metadata/MetadataFactory.php
@@ -17,6 +17,7 @@ use PhpBench\Reflection\ReflectionHierarchy;
 use PhpBench\Reflection\ReflectorInterface;
 use PhpBench\Tests\Unit\Benchmark\Metadata\Exception\CouldNotLoadMetadataException;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 /**
  * Benchmark Metadata Factory.
@@ -38,11 +39,11 @@ class MetadataFactory
      */
     private $logger;
 
-    public function __construct(ReflectorInterface $reflector, DriverInterface $driver, LoggerInterface $logger)
+    public function __construct(ReflectorInterface $reflector, DriverInterface $driver, LoggerInterface $logger = null)
     {
         $this->reflector = $reflector;
         $this->driver = $driver;
-        $this->logger = $logger;
+        $this->logger = $logger ?: new NullLogger();
     }
 
     /**
@@ -75,6 +76,7 @@ class MetadataFactory
                 'Could not load metadata for file "%s" - is this file intended to be a benchmark? Perhaps setting the `runner.file_pattern` to `*Bench.php` will help: %s',
                 $file, $couldNotLoad->getMessage()
             ));
+
             return null;
         }
         $this->validateBenchmark($hierarchy, $metadata);

--- a/lib/Extension/RunnerExtension.php
+++ b/lib/Extension/RunnerExtension.php
@@ -179,7 +179,7 @@ class RunnerExtension implements ExtensionInterface
         $resolver->setAllowedTypes(self::PARAM_RUNNER_TIMEOUT, ['null', 'float', 'int']);
         $resolver->setAllowedTypes(self::PARAM_RUNNER_WARMUP, ['null', 'int', 'array']);
         $resolver->setAllowedTypes(self::PARAM_SUBJECT_PATTERN, ['string']);
-        $resolver->setAllowedTypes(self::PARAM_FILE_PATTERN, ['string']);
+        $resolver->setAllowedTypes(self::PARAM_FILE_PATTERN, ['string', 'null']);
         
         SymfonyOptionsResolverCompat::setInfos($resolver, [
             self::PARAM_ANNOTATIONS => 'Read metadata from annotations',
@@ -585,7 +585,8 @@ class RunnerExtension implements ExtensionInterface
         $container->register(MetadataFactory::class, function (Container $container) {
             return new MetadataFactory(
                 $container->get(RemoteReflector::class),
-                $container->get(ConfigDriver::class)
+                $container->get(ConfigDriver::class),
+                $container->get(LoggerInterface::class)
             );
         });
 

--- a/lib/Extension/RunnerExtension.php
+++ b/lib/Extension/RunnerExtension.php
@@ -147,7 +147,7 @@ class RunnerExtension implements ExtensionInterface
             self::PARAM_RUNNER_TIMEOUT => null,
             self::PARAM_RUNNER_WARMUP => null,
             self::PARAM_SUBJECT_PATTERN => '^bench',
-            self::PARAM_FILE_PATTERN => '*Bench.php',
+            self::PARAM_FILE_PATTERN => null,
         ]);
 
         $resolver->setAllowedTypes(self::PARAM_ANNOTATIONS, ['bool']);
@@ -211,7 +211,7 @@ class RunnerExtension implements ExtensionInterface
             self::PARAM_RUNNER_TIMEOUT => 'Default :ref:`metadata_timeout`',
             self::PARAM_RUNNER_WARMUP => 'Default :ref:`metadata_warmup`',
             self::PARAM_SUBJECT_PATTERN => 'Subject pattern (regex) to use when finding benchmarks',
-            self::PARAM_FILE_PATTERN => 'Consider file names matching this pattern to be benchmarks',
+            self::PARAM_FILE_PATTERN => 'Consider file names matching this pattern to be benchmarks. NOTE: In 2.0 this will be set to ``*Bench.php``',
         ]);
     }
 

--- a/lib/Extension/RunnerExtension.php
+++ b/lib/Extension/RunnerExtension.php
@@ -609,7 +609,7 @@ class RunnerExtension implements ExtensionInterface
             return new BenchmarkFinder(
                 $container->get(MetadataFactory::class),
                 $container->getParameter(CoreExtension::PARAM_WORKING_DIR),
-                $container->getParameter(RunnerExtension::PARAM_FILE_PATTERN),
+                $container->getParameter(RunnerExtension::PARAM_FILE_PATTERN)
             );
         });
 

--- a/lib/Extension/RunnerExtension.php
+++ b/lib/Extension/RunnerExtension.php
@@ -610,6 +610,7 @@ class RunnerExtension implements ExtensionInterface
             return new BenchmarkFinder(
                 $container->get(MetadataFactory::class),
                 $container->getParameter(CoreExtension::PARAM_WORKING_DIR),
+                $container->get(LoggerInterface::class),
                 $container->getParameter(RunnerExtension::PARAM_FILE_PATTERN)
             );
         });

--- a/lib/Extension/RunnerExtension.php
+++ b/lib/Extension/RunnerExtension.php
@@ -98,6 +98,7 @@ class RunnerExtension implements ExtensionInterface
     public const PARAM_RUNNER_TIMEOUT = 'runner.timeout';
     public const PARAM_RUNNER_WARMUP = 'runner.warmup';
     public const PARAM_SUBJECT_PATTERN = 'runner.subject_pattern';
+    public const PARAM_FILE_PATTERN = 'runner.file_pattern';
 
     public const SERVICE_REGISTRY_EXECUTOR = 'runner.benchmark_registry.executor';
     public const SERVICE_VARIANT_SUMMARY_FORMATTER = 'runner.progress_logger_variant_summary_formatter';
@@ -146,6 +147,7 @@ class RunnerExtension implements ExtensionInterface
             self::PARAM_RUNNER_TIMEOUT => null,
             self::PARAM_RUNNER_WARMUP => null,
             self::PARAM_SUBJECT_PATTERN => '^bench',
+            self::PARAM_FILE_PATTERN => '*Bench.php',
         ]);
 
         $resolver->setAllowedTypes(self::PARAM_ANNOTATIONS, ['bool']);
@@ -177,6 +179,7 @@ class RunnerExtension implements ExtensionInterface
         $resolver->setAllowedTypes(self::PARAM_RUNNER_TIMEOUT, ['null', 'float', 'int']);
         $resolver->setAllowedTypes(self::PARAM_RUNNER_WARMUP, ['null', 'int', 'array']);
         $resolver->setAllowedTypes(self::PARAM_SUBJECT_PATTERN, ['string']);
+        $resolver->setAllowedTypes(self::PARAM_FILE_PATTERN, ['string']);
         
         SymfonyOptionsResolverCompat::setInfos($resolver, [
             self::PARAM_ANNOTATIONS => 'Read metadata from annotations',
@@ -208,6 +211,7 @@ class RunnerExtension implements ExtensionInterface
             self::PARAM_RUNNER_TIMEOUT => 'Default :ref:`metadata_timeout`',
             self::PARAM_RUNNER_WARMUP => 'Default :ref:`metadata_warmup`',
             self::PARAM_SUBJECT_PATTERN => 'Subject pattern (regex) to use when finding benchmarks',
+            self::PARAM_FILE_PATTERN => 'Consider file names matching this pattern to be benchmarks',
         ]);
     }
 
@@ -604,7 +608,8 @@ class RunnerExtension implements ExtensionInterface
         $container->register(BenchmarkFinder::class, function (Container $container) {
             return new BenchmarkFinder(
                 $container->get(MetadataFactory::class),
-                $container->getParameter(CoreExtension::PARAM_WORKING_DIR)
+                $container->getParameter(CoreExtension::PARAM_WORKING_DIR),
+                $container->getParameter(RunnerExtension::PARAM_FILE_PATTERN),
             );
         });
 

--- a/lib/Logger/ConsoleLogger.php
+++ b/lib/Logger/ConsoleLogger.php
@@ -40,8 +40,11 @@ class ConsoleLogger extends AbstractLogger
                 }
 
                 break;
-            case LogLevel::ERROR:
             case LogLevel::WARNING:
+                $decoration = 'fg=yellow';
+
+                break;
+            case LogLevel::ERROR:
             case LogLevel::CRITICAL:
             case LogLevel::EMERGENCY:
             case LogLevel::ALERT:

--- a/tests/Benchmark/Expression/ParserFoo.php
+++ b/tests/Benchmark/Expression/ParserFoo.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace PhpBench\Tests\Benchmark\Expression;
+
+use Generator;
+use PhpBench\DependencyInjection\Container;
+use PhpBench\Expression\Lexer;
+use PhpBench\Expression\Parser;
+use PhpBench\Extension\ExpressionExtension;
+
+/**
+ * @BeforeMethods({"setUp"})
+ */
+class ParserFoo
+{
+    /**
+     * @var Parser
+     */
+    private $parser;
+
+    /**
+     * @var Lexer
+     */
+    private $lexer;
+
+
+    public function setUp(): void
+    {
+        $container = new Container([
+            ExpressionExtension::class
+        ]);
+        $container->init();
+        $this->parser = $container->get(Parser::class);
+        $this->lexer = $container->get(Lexer::class);
+    }
+
+    /**
+     * @ParamProviders({"provideExpressions"})
+     *
+     * @param array<mixed> $params
+     */
+    public function benchEvaluate(array $params): void
+    {
+        $this->parser->parse($this->lexer->lex($params['expr']));
+    }
+
+    /**
+     * @return Generator<mixed>
+     */
+    public function provideExpressions(): Generator
+    {
+        yield 'comp. w/tol' => [
+            'expr' => '10 seconds < 10 seconds +/- 10 seconds',
+        ];
+
+        yield 'comp.' => [
+            'expr' => '10 seconds < 10 seconds',
+        ];
+    }
+}

--- a/tests/Unit/Benchmark/BenchmarkFinderTest.php
+++ b/tests/Unit/Benchmark/BenchmarkFinderTest.php
@@ -58,6 +58,7 @@ class BenchmarkFinderTest extends TestCase
         $benchmarks = $this->createFinder()->findBenchmarks([__DIR__ . '/findertest']);
 
         $this->assertCount(2, $benchmarks);
+        $this->logger->warning(Argument::containingString('but it does not end with'))->shouldHaveBeenCalledTimes(1);
     }
 
     public function testBuildCollectionByGlob(): void

--- a/tests/Unit/Benchmark/Metadata/Driver/AnnotationDriverTest.php
+++ b/tests/Unit/Benchmark/Metadata/Driver/AnnotationDriverTest.php
@@ -23,6 +23,7 @@ use PhpBench\Reflection\ReflectionHierarchy;
 use PhpBench\Reflection\ReflectionMethod;
 use PhpBench\Reflection\ReflectorInterface;
 use PhpBench\Tests\TestCase;
+use PhpBench\Tests\Unit\Benchmark\Metadata\Exception\CouldNotLoadMetadataException;
 
 class AnnotationDriverTest extends TestCase
 {
@@ -78,6 +79,30 @@ EOT;
 
         $this->createDriver()->getMetadataForHierarchy($hierarchy);
         $this->addToAssertionCount(1);
+    }
+
+    public function testExceptionOnUnknownAnnotation(): void
+    {
+        $this->expectException(CouldNotLoadMetadataException::class);
+        $reflection = new ReflectionClass();
+        $reflection->class = 'Test';
+        $reflection->path = 'foo';
+        $hierarchy = new ReflectionHierarchy();
+        $hierarchy->addReflectionClass($reflection);
+
+        $method = new ReflectionMethod();
+        $method->reflectionClass = $reflection;
+        $method->class = 'Test';
+        $method->name = 'benchFoo';
+        $method->comment = <<<'EOT'
+    /**
+     * @unknown
+     */
+EOT;
+        $reflection->methods[$method->name] = $method;
+
+        $metadata = $this->createDriver()->getMetadataForHierarchy($hierarchy);
+        $subjects = $metadata->getSubjects();
     }
 
     /**

--- a/tests/Unit/Benchmark/Metadata/Exception/CouldNotLoadMetadataException.php
+++ b/tests/Unit/Benchmark/Metadata/Exception/CouldNotLoadMetadataException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PhpBench\Tests\Unit\Benchmark\Metadata\Exception;
+
+use InvalidArgumentException;
+
+class CouldNotLoadMetadataException extends InvalidArgumentException
+{
+}

--- a/tests/Unit/Benchmark/findertestnobenchsuffix/NoBenchSuffix.php
+++ b/tests/Unit/Benchmark/findertestnobenchsuffix/NoBenchSuffix.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PhpBench\Tests\Unit\Benchmark\findertestnobenchsuffix;
+
+class NoBenchSuffix
+{
+}


### PR DESCRIPTION
This "bug" has been present since 2016.

It is [documented](https://phpbench.readthedocs.io/en/latest/quick-start.html#create-a-benchmark) that we only run files suffixed with `Bench.php` and this was completely my understanding, however since version 0.10.0 PHPBench will take into account any PHP file in the benchmark `path`.

This is not good because:

- It will try and read annotations from non-benchmark classes (https://github.com/phpbench/phpbench/issues/643)
- People who read the documentation (or listened to anything I said) would not expect this behavior.
- The "reflector" will execute code in non `*Bench` files, which increases the chance of unintentional code execution.

Fixing it however means a non-fatal change in behavior:

- Anybody depending on benchmark classes not having the suffix will need to set the new option `runner.file_pattern` option to `*.php`

---

This PR adds the option `runner.file_pattern` but sets it to NULL by default to preserve the existing behavior. If it is NULL and a benchmark file does not end in `Bench.php` a warning is displayed:

![image](https://user-images.githubusercontent.com/530801/124198471-a7e43f80-dac8-11eb-8b5f-48603dc39497.png)

