### PR TITLE
B c parameter execution context

### DIFF
--- a/lib/Console/Command/LogCommand.php
+++ b/lib/Console/Command/LogCommand.php
@@ -74,7 +74,7 @@ EOT
         $this->timeUnitHandler->timeUnitFromInput($input);
         $paginate = false === $input->getOption('no-pagination');
         $limit = $input->getOption('limit');
-        assert(is_numeric($limit) || is_bool($limit));
+        assert(is_null($limit) || is_numeric($limit) || is_bool($limit));
 
         // if we have an application, get the terminal dimensions, if the
         // terminal dimensions are null then set the height to the arbitrary

--- a/lib/Executor/Benchmark/LocalExecutor.php
+++ b/lib/Executor/Benchmark/LocalExecutor.php
@@ -38,7 +38,7 @@ class LocalExecutor implements BenchmarkExecutorInterface
         $benchmark = $this->createBenchmark($context);
 
         $methodName = $context->getMethodName();
-        $parameters = $context->getParameters()->toUnwrappedParameters();
+        $parameters = $context->getParameterSet()->toUnwrappedParameters();
 
         foreach ($context->getBeforeMethods() as $afterMethod) {
             $benchmark->$afterMethod($parameters);

--- a/lib/Executor/Benchmark/TemplateExecutor.php
+++ b/lib/Executor/Benchmark/TemplateExecutor.php
@@ -118,9 +118,9 @@ class TemplateExecutor implements BenchmarkExecutorInterface
     private function resolveParameterSet(ExecutionContext $context, Config $config): array
     {
         if (isset($config[self::OPTION_SAFE_PARAMETERS]) && $config[self::OPTION_SAFE_PARAMETERS]) {
-            return $context->getParameters()->toSerializedParameters();
+            return $context->getParameterSet()->toSerializedParameters();
         }
 
-        return $context->getParameters()->toUnwrappedParameters();
+        return $context->getParameterSet()->toUnwrappedParameters();
     }
 }

--- a/lib/Executor/ExecutionContext.php
+++ b/lib/Executor/ExecutionContext.php
@@ -116,7 +116,7 @@ final class ExecutionContext
         return $this->className;
     }
 
-    public function getParameters(): ParameterSet
+    public function getParameterSet(): ParameterSet
     {
         return $this->parameters;
     }

--- a/lib/Executor/ExecutionContext.php
+++ b/lib/Executor/ExecutionContext.php
@@ -116,6 +116,16 @@ final class ExecutionContext
         return $this->className;
     }
 
+    /**
+     * @deprecated Use getParameterSet will be removed in PHPBench 2.0
+     *
+     * @return parameters
+     */
+    public function getParameters(): array
+    {
+        return $this->parameters->toUnwrappedParameters();
+    }
+
     public function getParameterSet(): ParameterSet
     {
         return $this->parameters;

--- a/lib/Report/ComponentGenerator/BarChartAggregateComponentGenerator.php
+++ b/lib/Report/ComponentGenerator/BarChartAggregateComponentGenerator.php
@@ -9,6 +9,7 @@ use PhpBench\Report\ComponentGeneratorInterface;
 use PhpBench\Report\ComponentInterface;
 use PhpBench\Report\Model\BarChart;
 use PhpBench\Report\Model\BarChartDataSet;
+use RuntimeException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class BarChartAggregateComponentGenerator implements ComponentGeneratorInterface
@@ -78,7 +79,12 @@ class BarChartAggregateComponentGenerator implements ComponentGeneratorInterface
                     'frame' => $dataFrame,
                     'partition' => $setPartition
                 ]);
-                assert(is_int($yValue) || is_float($yValue));
+                if (!is_int($yValue) && !is_float($yValue)) {
+                    throw new RuntimeException(sprintf(
+                        'Y-Value must be either an int or a float, got "%s"',
+                        gettype($yValue)
+                    ));
+                }
                 $ySeries[$setLabel][$xLabel] = $yValue;
 
                 if (null === $config[self::PARAM_Y_ERROR_MARGIN]) {

--- a/lib/Report/ComponentGenerator/BarChartAggregateComponentGenerator.php
+++ b/lib/Report/ComponentGenerator/BarChartAggregateComponentGenerator.php
@@ -81,7 +81,7 @@ class BarChartAggregateComponentGenerator implements ComponentGeneratorInterface
                 ]);
                 if (!is_int($yValue) && !is_float($yValue)) {
                     throw new RuntimeException(sprintf(
-                        'Y-Value must be either an int or a float, got "%s"',
+                        'Y-Expression must evaluate to an int or a float, got "%s"',
                         gettype($yValue)
                     ));
                 }

--- a/tests/Unit/Report/ComponentGenerator/BarChartAggregateComponentGeneratorTest.php
+++ b/tests/Unit/Report/ComponentGenerator/BarChartAggregateComponentGeneratorTest.php
@@ -7,6 +7,7 @@ use PhpBench\Expression\ExpressionEvaluator;
 use PhpBench\Report\ComponentGenerator\BarChartAggregateComponentGenerator;
 use PhpBench\Report\ComponentGeneratorInterface;
 use PhpBench\Report\Model\BarChart;
+use RuntimeException;
 
 class BarChartAggregateComponentGeneratorTest extends ComponentGeneratorTestCase
 {
@@ -37,6 +38,18 @@ class BarChartAggregateComponentGeneratorTest extends ComponentGeneratorTestCase
         assert($barChart instanceof BarChart);
         self::assertInstanceOf(BarChart::class, $barChart);
         self::assertCount(1, $barChart->dataSets());
+    }
+
+    public function testExceptionIfYExpressionIsNotIntOrFloat(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Y-Expression must evaluate to an int or a float');
+        $this->generate(DataFrame::fromRowSeries([
+            [ 1 ],
+        ], ['col']), [
+            BarChartAggregateComponentGenerator::PARAM_X_PARTITION => ['col'],
+            BarChartAggregateComponentGenerator::PARAM_Y_EXPR => '[10]',
+        ]);
     }
 
     public function testGeneratesSeries(): void

--- a/tests/Unit/Report/ComponentGenerator/BarChartAggregateComponentGeneratorTest.php
+++ b/tests/Unit/Report/ComponentGenerator/BarChartAggregateComponentGeneratorTest.php
@@ -32,7 +32,7 @@ class BarChartAggregateComponentGeneratorTest extends ComponentGeneratorTestCase
             [ 1 ],
         ], ['col']), [
             BarChartAggregateComponentGenerator::PARAM_X_PARTITION => ['col'],
-            BarChartAggregateComponentGenerator::PARAM_Y_EXPR => '[10]',
+            BarChartAggregateComponentGenerator::PARAM_Y_EXPR => '10',
         ]);
         assert($barChart instanceof BarChart);
         self::assertInstanceOf(BarChart::class, $barChart);


### PR DESCRIPTION
Add B/C accessor for parameter set and fix failing `assert` calls, adding a test for the case where the Y-expression evaluates to a non-numeric value.