### PR TITLE
Fix performance issue

### DIFF
--- a/lib/Expression/Ast/ListNode.php
+++ b/lib/Expression/Ast/ListNode.php
@@ -4,20 +4,53 @@ namespace PhpBench\Expression\Ast;
 
 final class ListNode extends DelimitedListNode
 {
+    private $values;
+
     /**
      * @param array<mixed> $values
      */
     public static function fromValues(array $values): self
     {
-        $listValues = [];
+        $new = new self([]);
+        $new->values = $values;
 
-        foreach ($values as $key => $value) {
-            if (is_array($value)) {
-                $listValues[$key] = ListNode::fromValues($value);
-            }
-            $listValues[$key] = PhpValueFactory::fromValue($value);
+        return $new;
+    }
+
+    /**
+     * @return Node[]
+     */
+    public function nodes(): array
+    {
+        if (null === $this->values) {
+            return parent::nodes();
         }
 
-        return new self($listValues);
+        return array_map(function ($v) {
+            return PhpValueFactory::fromValue($v);
+        }, $this->values);
+    }
+
+    public function value(): array
+    {
+        if (null === $this->values) {
+            return parent::value();
+        }
+
+        return $this->values;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function nonNullPhpValues(): array
+    {
+        if (null === $this->values) {
+            return parent::nonNullPhpValues();
+        }
+
+        return array_values(array_filter($this->values, function ($value) {
+            return $value !== null;
+        }));
     }
 }

--- a/lib/Expression/Ast/ListNode.php
+++ b/lib/Expression/Ast/ListNode.php
@@ -2,8 +2,17 @@
 
 namespace PhpBench\Expression\Ast;
 
+/**
+ * Optimisation note: When `fromValues` is used, the source of truth is
+ * switched from a list of nodes to a list of primitive values. This avoids the
+ * overhead of converting nodes back to values and improves performance
+ * significantly.
+ */
 final class ListNode extends DelimitedListNode
 {
+    /**
+     * @var mixed[]
+     */
     private $values;
 
     /**
@@ -52,5 +61,13 @@ final class ListNode extends DelimitedListNode
         return array_values(array_filter($this->values, function ($value) {
             return $value !== null;
         }));
+    }
+
+    /**
+     * Return a vanilla node list (for comparisons in tests)
+     */
+    public function toNodeList(): self
+    {
+        return new self($this->nodes());
     }
 }

--- a/lib/Expression/Ast/PhpValueFactory.php
+++ b/lib/Expression/Ast/PhpValueFactory.php
@@ -33,13 +33,7 @@ final class PhpValueFactory
         }
 
         if (is_array($value)) {
-            $listValues = [];
-
-            foreach ($value as $key => $listValue) {
-                $listValues[$key] = self::fromValue($listValue);
-            }
-
-            return new ListNode($listValues);
+            return ListNode::fromValues($value);
         }
 
         if ($value instanceof DataFrame) {

--- a/tests/Unit/Expression/Ast/ListNodeTest.php
+++ b/tests/Unit/Expression/Ast/ListNodeTest.php
@@ -17,7 +17,7 @@ class ListNodeTest extends TestCase
     public function testFromValues(array $values, ListNode $expected): void
     {
         $node = ListNode::fromValues($values);
-        self::assertEquals($expected, $node, 'Node');
+        self::assertEquals($expected->value(), $node->value(), 'Node');
         self::assertEquals($values, $node->value(), 'To Array');
     }
 

--- a/tests/Unit/Expression/NodeEvaluator/AccessEvaluatorTest.php
+++ b/tests/Unit/Expression/NodeEvaluator/AccessEvaluatorTest.php
@@ -56,7 +56,7 @@ class AccessEvaluatorTest extends EvaluatorTestCase
                 ['one' => 2],
             ])),
             new StringNode('one'),
-            new ListNode([new IntegerNode(1), new IntegerNode(2)])
+            ListNode::fromValues([1, 2])
         ];
 
         yield 'null safe data frame' => [

--- a/tests/Unit/Expression/NodeEvaluator/DataFrameEvaluatorTest.php
+++ b/tests/Unit/Expression/NodeEvaluator/DataFrameEvaluatorTest.php
@@ -37,7 +37,7 @@ class DataFrameEvaluatorTest extends EvaluatorTestCase
                 ['foo' => 'bar']
             ]),
             new StringNode('foo'),
-            new ListNode([new StringNode('bar')])
+            ListNode::fromValues(['bar'])
         ];
 
         yield 'filter expression' => [

--- a/tests/Unit/Report/ComponentGenerator/TableAggregateComponentTest.php
+++ b/tests/Unit/Report/ComponentGenerator/TableAggregateComponentTest.php
@@ -4,7 +4,6 @@ namespace PhpBench\Tests\Unit\Report\ComponentGenerator;
 
 use PhpBench\Data\DataFrame;
 use PhpBench\Expression\Ast\ListNode;
-use PhpBench\Expression\Ast\StringNode;
 use PhpBench\Report\Bridge\ExpressionBridge;
 use PhpBench\Report\ComponentGenerator\TableAggregateComponent;
 use PhpBench\Report\ComponentGeneratorInterface;
@@ -104,12 +103,12 @@ class TableAggregateComponentTest extends ComponentGeneratorTestCase
         self::assertCount(2, $table->rows());
         self::assertEquals(TableBuilder::create()->addRowsFromArray([
             [
-                'hello' => new ListNode([new StringNode('hello')]),
-                'goodbye' => new ListNode([new StringNode('hello'), new StringNode('goodbye')]),
+                'hello' => ListNode::fromValues(['hello']),
+                'goodbye' => ListNode::fromValues(['hello', 'goodbye']),
             ],
             [
-                'hello' => new ListNode([new StringNode('goodbye')]),
-                'goodbye' => new ListNode([new StringNode('hello'), new StringNode('goodbye')]),
+                'hello' => ListNode::fromValues(['goodbye']),
+                'goodbye' => ListNode::fromValues(['hello', 'goodbye']),
             ]
         ])->build(), $table);
     }


### PR DESCRIPTION
This PR fixes the performance bottleneck which was caused by always converting primitive values to nodes and back again during evaluation. Now, if a ListNode is instantiated from primitives, it does not eagerly convert them to nodes.

This results in a x4 speed improvement when compared to `1.0.x`