### PR TITLE
Use token for full namespace whenever available

### DIFF
--- a/lib/Reflection/RemoteReflector.php
+++ b/lib/Reflection/RemoteReflector.php
@@ -129,8 +129,9 @@ class RemoteReflector implements ReflectorInterface
                 if ($tokens[$i][0] === T_NAMESPACE) {
                     for ($j = $i + 1; $j < count($tokens); $j++) {
                         $tokenId = $tokens[$j][0];
+                        $namespaceToken = defined('T_NAME_QUALIFIED') ? T_NAME_QUALIFIED : T_STRING;
 
-                        if ($tokenId === T_STRING || $tokenId === 314) {
+                        if ($tokenId === T_STRING || $tokenId === $namespaceToken) {
                             $namespace .= '\\' . $tokens[$j][1];
                         } elseif ($tokens[$j] === '{' || $tokens[$j] === ';') {
                             break;


### PR DESCRIPTION
PHP 8.0 introduced a new token for fully qualified namespaces, represented
by the constant `T_NAME_QUALIFIED`, which in that version had the integer representation of 314.

With the upcoming version 8.1, the token received a different integer representation, thus breaking the logic with the previously hardcoded integer value.

Closes issue https://github.com/phpbench/phpbench/issues/905