### PR TITLE
Do not show reports if there were errors

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -23,7 +23,6 @@ return PhpCsFixer\Config::create()
                 'continue',
                 'declare',
                 'default',
-                'die',
                 'do',
                 'exit',
                 'for',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Features:
 
 Improvement:
 
+- Surpress reports if errors were encountered during the run #912
 - Support expressions in parttion specifications
 - Data can be accessed on any expression value (not just "parameters")
 - Use automatic time unit for expression report #838

--- a/lib/Console/Command/RunCommand.php
+++ b/lib/Console/Command/RunCommand.php
@@ -152,11 +152,11 @@ EOT
             }
         }
 
-        $this->reportHandler->reportsFromInput($input, $collection->mergeCollection($this->resolveBaselines($input)));
-
         if ($suite->getErrorStacks()) {
             return self::EXIT_CODE_ERROR;
         }
+
+        $this->reportHandler->reportsFromInput($input, $collection->mergeCollection($this->resolveBaselines($input)));
 
         if (false === $input->getOption(self::OPT_TOLERATE_FAILURE) && $suite->getFailures()) {
             return self::EXIT_CODE_FAILURE;

--- a/lib/Expression/Ast/ErrorNode.php
+++ b/lib/Expression/Ast/ErrorNode.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PhpBench\Expression\Ast;
+
+class ErrorNode extends Node
+{
+}

--- a/lib/Expression/NodePrinter/DisplayAsPrinter.php
+++ b/lib/Expression/NodePrinter/DisplayAsPrinter.php
@@ -56,6 +56,10 @@ class DisplayAsPrinter implements NodePrinter
             return sprintf('%s as %s', $printer->print($value), $unit);
         }
 
+        if ($value instanceof NullNode) {
+            return $printer->print($value);
+        }
+
         if (TimeUnit::isTimeUnit($unit)) {
             return $this->timeUnit(
                 $value->value(),

--- a/tests/System/RunTest.php
+++ b/tests/System/RunTest.php
@@ -448,6 +448,16 @@ class RunTest extends SystemTestCase
         $this->assertStringContainsString('benchNothingElse', $process->getErrorOutput());
     }
 
+    public function testDoesNotRenderReportsIfThereIsAnError(): void
+    {
+        $process = $this->phpbench(
+            'run benchmarks/set3/ErrorBench.php --report=default'
+        );
+
+        $this->assertExitCode(1, $process);
+        $this->assertStringNotContainsString('Expression error', $process->getErrorOutput());
+    }
+
     /**
      * It should stop on the first exception if an exception is encountered.
      */

--- a/tests/Unit/Expression/Parselet/DisplayAsParseletTest.php
+++ b/tests/Unit/Expression/Parselet/DisplayAsParseletTest.php
@@ -112,5 +112,6 @@ class DisplayAsParseletTest extends ParseletTestCase
         yield 'int to bytes with precision' => ['1000 as k precision 2', [], '1.00kb'];
 
         yield ['100000 as seconds < 1 second', [], '0.100s < 1 second'];
+        yield ['null as seconds', [], 'null'];
     }
 }

--- a/tests/Unit/Expression/Parselet/DisplayAsParseletTest.php
+++ b/tests/Unit/Expression/Parselet/DisplayAsParseletTest.php
@@ -112,6 +112,7 @@ class DisplayAsParseletTest extends ParseletTestCase
         yield 'int to bytes with precision' => ['1000 as k precision 2', [], '1.00kb'];
 
         yield ['100000 as seconds < 1 second', [], '0.100s < 1 second'];
+
         yield ['null as seconds', [], 'null'];
     }
 }


### PR DESCRIPTION
Do not show reports if there were errors, as there is too much noise.