### PR TITLE
Prevent registering `#[ParamProviders(...)]` multiple times when benchmark methods are inherited

### DIFF
--- a/lib/Benchmark/Metadata/BenchmarkMetadata.php
+++ b/lib/Benchmark/Metadata/BenchmarkMetadata.php
@@ -30,7 +30,7 @@ class BenchmarkMetadata
     private $class;
 
     /**
-     * @var SubjectMetadata[]
+     * @var array<string, SubjectMetadata> indexed by subject name
      */
     private $subjects = [];
 
@@ -83,7 +83,7 @@ class BenchmarkMetadata
     /**
      * Get the subject metadata instances for this benchmark metadata.
      *
-     * @return SubjectMetadata[]
+     * @return array<string, SubjectMetadata> indexed by subject name
      */
     public function getSubjects(): array
     {

--- a/lib/Benchmark/Metadata/Driver/AttributeDriver.php
+++ b/lib/Benchmark/Metadata/Driver/AttributeDriver.php
@@ -13,6 +13,7 @@ use PhpBench\Benchmark\Metadata\SubjectMetadata;
 use PhpBench\Reflection\ReflectionClass;
 use PhpBench\Reflection\ReflectionHierarchy;
 use PhpBench\Reflection\ReflectionMethod;
+use function array_key_exists;
 
 class AttributeDriver implements DriverInterface
 {
@@ -39,7 +40,7 @@ class AttributeDriver implements DriverInterface
     private function buildBenchmark(BenchmarkMetadata $benchmark, ReflectionHierarchy $hierarchy): void
     {
         $attributes = [];
-        $reflectionHierarchy = array_reverse(iterator_to_array($hierarchy));
+        $reflectionHierarchy = iterator_to_array($hierarchy);
 
         foreach ($reflectionHierarchy as $reflection) {
             assert($reflection instanceof ReflectionClass);
@@ -76,6 +77,14 @@ class AttributeDriver implements DriverInterface
 
                 if (null === $subjectAttributes) {
                     $subjectAttributes = $reflectionMethod->attributes;
+                }
+
+                $subjects = $benchmark->getSubjects();
+
+                if (array_key_exists($reflectionMethod->name, $subjects)) {
+                    // A subject with the same name has already been processed: skip parent class subjects
+                    // with the same name.
+                    continue;
                 }
 
                 $subject = $benchmark->getOrCreateSubject($reflectionMethod->name);

--- a/lib/Reflection/ReflectionClass.php
+++ b/lib/Reflection/ReflectionClass.php
@@ -21,6 +21,7 @@ class ReflectionClass
     public $namespace;
     public $abstract = false;
     public $comment;
+    /** @var array<string, ReflectionMethod> */
     public $methods = [];
 
     public function __construct(?string $path = null, ?string $class = null)

--- a/lib/Reflection/ReflectionHierarchy.php
+++ b/lib/Reflection/ReflectionHierarchy.php
@@ -22,7 +22,7 @@ use IteratorAggregate;
 class ReflectionHierarchy implements IteratorAggregate
 {
     /**
-     * @var ReflectionClass[]
+     * @var ReflectionClass[] sorted by leaf class ("top") first
      */
     private $reflectionClasses;
 


### PR DESCRIPTION
In a test setup like following, PHPBench would run tests for one subject 4 times:

```php
abstract class MyGenericBench
{
    #[ParamProviders(['provideData'])]
    final public function benchSomething(): void { /* ... */ }
    abstract public function provideData(): array;
}

final class ConcreteBench extends MyGenericBench
{
    public function provideData(): array
    {
        return ['foo' => 1, 'bar' => 2];
    }
}
```

The executed tests datasets would look like following:

```
 * `foo` + `bar`
 * `bar` + `foo`
 * `foo` + `bar`
 * `bar` + `foo`
```

The reason for that is that the `AttributeDriver` processes subject metadata for
each class and for each method, and that happens multiple times in a hierarchy (because
inherited methods appear at each level of the hierarchy).

For example, a 3 level hierarchy would create 16 useless data provider permutations,
with the scenario above.

This patch fixes that by:

 * scanning benchmarks leaf-first (child classes being considered "concrete" benchmarks)
 * ignoring any duplicate subjects: if a subject has been found in a lower level of the inheritance, it is authoritative