### PR TITLE
Enable 8.1 in GH actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,21 +126,21 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - '7.2'
                     - '7.3'
                     - '7.4'
+                    - '8.0'
                 dependency:
                     - 'lowest'
                     - 'highest'
                 with-examples: ['yes']
                 allow-failures: [false]
                 include:
-                    - php-version: '7.2'
+                    - php-version: '7.3'
                       dependency: 'lowest'
                       with-examples: 'no'
                       allow-failures: false
                       coverage: xdebug
-                    - php-version: '8.0'
+                    - php-version: '8.1'
                       dependency: 'highest'
                       with-examples: 'no'
                       allow-failures: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -145,6 +145,7 @@ jobs:
                       with-examples: 'no'
                       allow-failures: true
                       coverage: xdebug
+                      skip_xdebug_tests: "true"
 
         steps:
             - name: "Checkout code"
@@ -173,6 +174,8 @@ jobs:
 
             - name: "Run tests with PHPUnit"
               run: vendor/bin/phpunit --verbose
+              env:
+                  SKIP_XDEBUG_TESTS: "${{ matrix.skip_xdebug_tests }}"
 
             - name: "Run benchmarks with PHPBench"
               run: bin/phpbench run --report=env --progress=dots

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - '7.2'
+                    - '7.3'
 
         steps:
             -
@@ -50,7 +50,7 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - '7.2'
+                    - '7.3'
 
         steps:
             -
@@ -87,7 +87,7 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - '7.2'
+                    - '7.3'
 
         steps:
             -

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-reflection": "*",
         "ext-spl": "*",
         "ext-tokenizer": "*",
-        "doctrine/annotations": "^1.2.7",
+        "doctrine/annotations": "^1.13",
         "phpbench/container": "^2.1",
         "phpbench/dom": "~0.3.1",
         "psr/log": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.3 || ^8.0",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-pcre": "*",

--- a/extensions/xdebug/lib/Command/ProfileCommand.php
+++ b/extensions/xdebug/lib/Command/ProfileCommand.php
@@ -51,6 +51,7 @@ EOT
         );
         RunnerHandler::configure($this);
         OutputDirHandler::configure($this);
+
         $this->addOption('gui', null, InputOption::VALUE_NONE);
         $this->addOption('gui-bin', null, InputOption::VALUE_REQUIRED, 'Bin to use to display cachegrind output', 'kcachegrind');
     }

--- a/extensions/xdebug/tests/System/XDebugTestCase.php
+++ b/extensions/xdebug/tests/System/XDebugTestCase.php
@@ -19,6 +19,10 @@ class XDebugTestCase extends SystemTestCase
 {
     protected function setUp(): void
     {
+        if (getenv('SKIP_XDEBUG_TESTS')) {
+            $this->markTestSkipped('Tests disabled by CI.');
+        }
+
         if (!extension_loaded('xdebug')) {
             $this->markTestSkipped('XDebug not enabled.');
         }

--- a/phpbench.json
+++ b/phpbench.json
@@ -29,16 +29,7 @@
             "core.extensions": [
                 "PhpBench\\Examples\\Extension\\AcmeExtension"
             ],
-            "runner.path": "examples/Benchmark",
-            "runner.php_disable_ini": true,
-            "runner.php_config": {
-                "extension": [
-                    "tokenizer.so",
-                    "dom.so",
-                    "json.so",
-                    "iconv.so"
-                ]
-            }
+            "runner.path": "examples/Benchmark"
         }
     }
 }


### PR DESCRIPTION
This PR adds a CI run for PHP 8.1 and drops support for PHP 7.2