### PR TITLE
Fix PHP 8.1 deprecations

### DIFF
--- a/lib/Color/Gradient.php
+++ b/lib/Color/Gradient.php
@@ -70,7 +70,7 @@ use function array_fill;
         }
 
         $colors = array_merge($this->colors, array_map(function (float $r, float $g, float $b) {
-            return DeprecatedColor::fromRgb(floor($r), floor($g), floor($b));
+            return DeprecatedColor::fromRgb((int)$r, (int)$g, (int)$b);
         }, ...$gradient));
 
         // remove the start color as it's already present

--- a/lib/Color/Gradient.php
+++ b/lib/Color/Gradient.php
@@ -69,8 +69,8 @@ use function array_fill;
             $gradient[$i] = range($cStart, $cEnd, $step);
         }
 
-        $colors = array_merge($this->colors, array_map(function (int $r, int $g, int $b) {
-            return DeprecatedColor::fromRgb($r, $g, $b);
+        $colors = array_merge($this->colors, array_map(function (float $r, float $g, float $b) {
+            return DeprecatedColor::fromRgb(floor($r), floor($g), floor($b));
         }, ...$gradient));
 
         // remove the start color as it's already present

--- a/lib/Data/DataFrame.php
+++ b/lib/Data/DataFrame.php
@@ -216,6 +216,7 @@ final class DataFrame implements IteratorAggregate, ArrayAccess
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return in_array($offset, $this->columns);
@@ -224,6 +225,7 @@ final class DataFrame implements IteratorAggregate, ArrayAccess
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->column($offset)->toValues();
@@ -232,6 +234,7 @@ final class DataFrame implements IteratorAggregate, ArrayAccess
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value): void
     {
         throw new BadMethodCallException('Not implemented');
@@ -240,6 +243,7 @@ final class DataFrame implements IteratorAggregate, ArrayAccess
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset): void
     {
         throw new BadMethodCallException('Not implemented');

--- a/lib/Data/DataFrame.php
+++ b/lib/Data/DataFrame.php
@@ -163,7 +163,7 @@ final class DataFrame implements IteratorAggregate, ArrayAccess
     /**
      * @return ArrayIterator<Row>
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->rows());
     }

--- a/lib/Data/DataFrames.php
+++ b/lib/Data/DataFrames.php
@@ -23,7 +23,7 @@ final class DataFrames implements IteratorAggregate
     /**
      * {@inheritDoc}
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->dataFrames);
     }

--- a/lib/Data/Row.php
+++ b/lib/Data/Row.php
@@ -46,7 +46,7 @@ final class Row implements IteratorAggregate, ArrayAccess
     /**
      * @return ArrayIterator<string,mixed>
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->map);
     }

--- a/lib/Data/Row.php
+++ b/lib/Data/Row.php
@@ -74,6 +74,7 @@ final class Row implements IteratorAggregate, ArrayAccess
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->map[$offset]);
@@ -82,6 +83,7 @@ final class Row implements IteratorAggregate, ArrayAccess
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->get($offset);
@@ -90,6 +92,7 @@ final class Row implements IteratorAggregate, ArrayAccess
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value): void
     {
         throw new BadMethodCallException('Not implemented');
@@ -98,6 +101,7 @@ final class Row implements IteratorAggregate, ArrayAccess
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset): void
     {
         throw new BadMethodCallException('Not implemented');

--- a/lib/Environment/Information.php
+++ b/lib/Environment/Information.php
@@ -45,6 +45,7 @@ class Information implements \ArrayAccess, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->information[$offset];
@@ -53,6 +54,7 @@ class Information implements \ArrayAccess, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value): void
     {
         throw new \BadMethodCallException(sprintf(
@@ -65,6 +67,7 @@ class Information implements \ArrayAccess, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset): bool
     {
         return array_key_exists($offset, $this->information);
@@ -73,6 +76,7 @@ class Information implements \ArrayAccess, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset): void
     {
         throw new \BadMethodCallException(sprintf(

--- a/lib/Expression/Exception/SyntaxError.php
+++ b/lib/Expression/Exception/SyntaxError.php
@@ -17,7 +17,7 @@ class SyntaxError extends ExpressionError
         $found = false;
 
         $expr = $tokens->toString();
-        $center = (int)$target->start() + ($target->length() / 2);
+        $center = floor((int)$target->start() + ($target->length() / 2));
 
         foreach ($tokens as $token) {
             if ($token === $target) {

--- a/lib/Expression/Exception/SyntaxError.php
+++ b/lib/Expression/Exception/SyntaxError.php
@@ -17,7 +17,7 @@ class SyntaxError extends ExpressionError
         $found = false;
 
         $expr = $tokens->toString();
-        $center = floor((int)$target->start() + ($target->length() / 2));
+        $center = (int)($target->start() + ($target->length() / 2));
 
         foreach ($tokens as $token) {
             if ($token === $target) {

--- a/lib/Math/Distribution.php
+++ b/lib/Math/Distribution.php
@@ -160,6 +160,7 @@ class Distribution implements IteratorAggregate, ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset): bool
     {
         return isset($this->stats[$offset]);
@@ -168,6 +169,7 @@ class Distribution implements IteratorAggregate, ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->getStat($offset);
@@ -176,6 +178,7 @@ class Distribution implements IteratorAggregate, ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value): void
     {
         throw new \BadMethodCallException('Distribution is read-only');
@@ -184,6 +187,7 @@ class Distribution implements IteratorAggregate, ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset): void
     {
         throw new \BadMethodCallException('Distribution is read-only');

--- a/lib/Model/ParameterSets.php
+++ b/lib/Model/ParameterSets.php
@@ -52,7 +52,7 @@ final class ParameterSets implements IteratorAggregate, Countable
     /**
      * @return ArrayIterator<string, ParameterSet>
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->parameterSets);
     }

--- a/lib/Model/ParameterSetsCollection.php
+++ b/lib/Model/ParameterSetsCollection.php
@@ -44,7 +44,7 @@ final class ParameterSetsCollection implements IteratorAggregate, Countable
     /**
      * @return ArrayIterator<int, ParameterSets>
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->parameterSets);
     }

--- a/lib/Model/Variant.php
+++ b/lib/Model/Variant.php
@@ -409,11 +409,13 @@ class Variant implements IteratorAggregate, ArrayAccess, Countable
         return count($this->iterations);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset): ?Iteration
     {
         return $this->getIteration($offset);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value): void
     {
         throw new \InvalidArgumentException(
@@ -424,6 +426,7 @@ class Variant implements IteratorAggregate, ArrayAccess, Countable
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset): void
     {
         throw new \InvalidArgumentException(
@@ -431,6 +434,7 @@ class Variant implements IteratorAggregate, ArrayAccess, Countable
         );
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset): bool
     {
         return array_key_exists($offset, $this->iterations);

--- a/lib/Reflection/ReflectionHierarchy.php
+++ b/lib/Reflection/ReflectionHierarchy.php
@@ -43,7 +43,7 @@ class ReflectionHierarchy implements IteratorAggregate
         $this->reflectionClasses[] = $reflectionClass;
     }
 
-    public function getIterator()
+    public function getIterator(): \ArrayObject
     {
         return new \ArrayObject($this->reflectionClasses);
     }

--- a/lib/Registry/Config.php
+++ b/lib/Registry/Config.php
@@ -41,6 +41,7 @@ class Config extends ArrayObject
         parent::__construct($config);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (!$this->offsetExists($offset)) {

--- a/lib/Remote/Payload.php
+++ b/lib/Remote/Payload.php
@@ -119,7 +119,7 @@ class Payload
 
     public function setPhpPath($phpPath): void
     {
-        $this->phpPath = escapeshellarg($phpPath);
+        $this->phpPath = $phpPath ? escapeshellarg($phpPath) : '';
     }
 
     public function disableIni(): void

--- a/lib/Report/Model/Reports.php
+++ b/lib/Report/Model/Reports.php
@@ -44,7 +44,7 @@ final class Reports implements IteratorAggregate
         return new self(array_merge($this->reports, $reports->reports));
     }
 
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->reports);
     }

--- a/lib/Report/Model/Table.php
+++ b/lib/Report/Model/Table.php
@@ -66,7 +66,7 @@ final class Table implements IteratorAggregate, ComponentInterface
     /**
      * {@inheritDoc}
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->rows);
     }

--- a/lib/Report/Model/TableRow.php
+++ b/lib/Report/Model/TableRow.php
@@ -35,7 +35,7 @@ final class TableRow implements IteratorAggregate, Countable
     /**
      * {@inheritDoc}
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->cells);
     }

--- a/lib/Serializer/XmlEncoder.php
+++ b/lib/Serializer/XmlEncoder.php
@@ -64,11 +64,11 @@ class XmlEncoder
 
         foreach ($suiteCollection->getSuites() as $suite) {
             $suiteEl = $rootEl->appendElement('suite');
-            $suiteEl->setAttribute('tag', $suite->getTag());
+            $suiteEl->setAttribute('tag', $suite->getTag() ?? '');
 
             // @deprecated context is deprecated and replaced by `tag`, to be
             //             removed in version 1.0
-            $suiteEl->setAttribute('context', $suite->getTag());
+            $suiteEl->setAttribute('context', $suite->getTag() ?? '');
             $suiteEl->setAttribute('date', $suite->getDate()->format('c'));
             $suiteEl->setAttribute('config-path', $suite->getConfigPath());
             $suiteEl->setAttribute('uuid', $suite->getUuid());

--- a/lib/Serializer/XmlEncoder.php
+++ b/lib/Serializer/XmlEncoder.php
@@ -70,7 +70,7 @@ class XmlEncoder
             //             removed in version 1.0
             $suiteEl->setAttribute('context', $suite->getTag() ?? '');
             $suiteEl->setAttribute('date', $suite->getDate()->format('c'));
-            $suiteEl->setAttribute('config-path', $suite->getConfigPath());
+            $suiteEl->setAttribute('config-path', $suite->getConfigPath() ?? '');
             $suiteEl->setAttribute('uuid', $suite->getUuid());
 
             $envEl = $suiteEl->appendElement('env');

--- a/lib/Storage/Driver/Fake/FakeHistoryIterator.php
+++ b/lib/Storage/Driver/Fake/FakeHistoryIterator.php
@@ -46,7 +46,7 @@ class FakeHistoryIterator implements HistoryIteratorInterface
      */
     public function valid(): bool
     {
-        return current($this->entries);
+        return (bool)current($this->entries);
     }
 
     /**

--- a/lib/Storage/Driver/Fake/FakeHistoryIterator.php
+++ b/lib/Storage/Driver/Fake/FakeHistoryIterator.php
@@ -20,7 +20,7 @@ class FakeHistoryIterator implements HistoryIteratorInterface
     /**
      * {@inheritDoc}
      */
-    public function current()
+    public function current(): HistoryEntry
     {
         return current($this->entries);
     }
@@ -36,7 +36,7 @@ class FakeHistoryIterator implements HistoryIteratorInterface
     /**
      * {@inheritDoc}
      */
-    public function key()
+    public function key(): int
     {
         return key($this->entries);
     }
@@ -44,7 +44,7 @@ class FakeHistoryIterator implements HistoryIteratorInterface
     /**
      * {@inheritDoc}
      */
-    public function valid()
+    public function valid(): bool
     {
         return current($this->entries);
     }

--- a/lib/Storage/Driver/Xml/HistoryIterator.php
+++ b/lib/Storage/Driver/Xml/HistoryIterator.php
@@ -45,6 +45,7 @@ class HistoryIterator implements HistoryIteratorInterface
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $this->init();
@@ -118,7 +119,7 @@ class HistoryIterator implements HistoryIteratorInterface
     /**
      * {@inheritdoc}
      */
-    public function valid()
+    public function valid(): bool
     {
         $this->init();
 


### PR DESCRIPTION
I am not 100% certain of all of these, but this at least gets my tests locally to pass, except for those that require the git binary.  My container doesn't have git in it so that fails.  At least I don't get any deprecation warnings.

This works only with the updated Dom library from this PR: https://github.com/phpbench/dom/pull/4

(I have edits allowed, so feel free to fix up anything you'd like done differently. I won't take offense. :smile: )