### PR TITLE
Make it easy to copy composer install command on github

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Installation
 ------------
 
 ```bash
-$ composer require phpbench/phpbench --dev
+composer require phpbench/phpbench --dev
 ```
 
 See the [installation instructions](http://phpbench.readthedocs.io/en/latest/installing.html) for more options.


### PR DESCRIPTION
This will allow users to click the 'copy to clipboard' button in the github interface