### PR TITLE
Executor experiment

### DIFF
--- a/tests/Benchmark/Executor/TemplateBench.php
+++ b/tests/Benchmark/Executor/TemplateBench.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace PhpBench\Tests\Benchmark\Executor;
+
+use function password_hash;
+
+class TemplateBench
+{
+    public function benchNothing(): void
+    {
+    }
+
+    public function benchMd5(): void
+    {
+        md5("hello");
+    }
+
+    public function benchBcrypt(): void
+    {
+        password_hash('hello', PASSWORD_BCRYPT);
+    }
+}

--- a/tests/Benchmark/Executor/phpbench.json
+++ b/tests/Benchmark/Executor/phpbench.json
@@ -1,0 +1,50 @@
+{
+    "runner.executors": {
+        "sample_inside": {
+            "executor": "remote",
+            "template": "./tests/Benchmark/Executor/template/sample_inside_the_loop.template"
+        },
+        "hrtime": {
+            "executor": "remote",
+            "template": "./tests/Benchmark/Executor/template/hrtime.template"
+        }
+    },
+    "report.generators": {
+        "executor_comp": {
+            "title": "Executor Comparison",
+            "generator": "component",
+            "filter": "benchmark_name = 'TemplateBench'",
+            "components": [
+                {
+                    "component": "bar_chart_aggregate",
+                    "x_partition": "'Revs: ' ~ variant_revs",
+                    "bar_partition": "suite_tag",
+                    "y_expr": "mode(partition['result_time_avg']) as time",
+                    "y_axes_label": "yValue as time"
+                },
+                {
+                    "component": "section",
+                    "partition": ["subject_name"],
+                    "title": "Executor Comparison",
+                    "components": [
+                        {
+                            "component": "table_aggregate",
+                            "title": "{{ first(frame['subject_name']) }}",
+                            "partition": ["benchmark_name", "subject_name", "variant_name", "variant_revs"],
+                            "row": {
+                                "revs": "first(partition['variant_revs'])",
+                                "by_executor": {
+                                    "type": "expand",
+                                    "partition": "suite_tag",
+                                    "cols": {
+                                        "{{ key }}": "mode(partition['result_time_avg']) as microseconds ~ '(' ~ sum(partition['result_time_net']) as microseconds ~ ' net) ' ~ rstdev(partition['result_time_avg'])"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/tests/Benchmark/Executor/template/hrtime.template
+++ b/tests/Benchmark/Executor/template/hrtime.template
@@ -1,0 +1,37 @@
+<?php
+
+$class = '{{ class }}';
+$file = '{{ file }}';
+
+require_once($file);
+
+$benchmark = new $class();
+
+// warmup
+$benchmark->{{ subject }}();
+
+$totalTime = 0;
+for ($i = 0; $i < {{ revolutions }}; $i++) {
+    $startTime = hrtime(true);
+    $benchmark->{{ subject }}();
+    $endTime = hrtime(true);
+    $totalTime += ($endTime - $startTime);
+}
+
+echo serialize([
+    'mem' => [
+        // observer effect - getting memory usage affects memory usage. order
+        // counts, peak is probably the best metric.
+        'peak' => memory_get_peak_usage(),
+        'final' => memory_get_usage(),
+        'real' => memory_get_usage(true),
+    ],
+    'time' => [
+        'revs' => {{ revolutions }} * 1000,
+        'net' => $totalTime,
+    ],
+    'buffer' => $buffer,
+]);
+
+exit(0);
+

--- a/tests/Benchmark/Executor/template/sample_inside_the_loop.template
+++ b/tests/Benchmark/Executor/template/sample_inside_the_loop.template
@@ -1,0 +1,35 @@
+<?php
+
+$class = '{{ class }}';
+$file = '{{ file }}';
+
+require_once($file);
+
+$benchmark = new $class();
+$benchmark->{{ subject }}();
+
+$totalTime = 0;
+for ($i = 0; $i < {{ revolutions }}; $i++) {
+    $startTime = microtime(true);
+    $benchmark->{{ subject }}();
+    $endTime = microtime(true);
+    $totalTime += ($endTime - $startTime) * 1000000;
+}
+
+echo serialize([
+    'mem' => [
+        // observer effect - getting memory usage affects memory usage. order
+        // counts, peak is probably the best metric.
+        'peak' => memory_get_peak_usage(),
+        'final' => memory_get_usage(),
+        'real' => memory_get_usage(true),
+    ],
+    'time' => [
+        'revs' => {{ revolutions }},
+        'net' => (int) $totalTime,
+    ],
+    'buffer' => $buffer,
+]);
+
+exit(0);
+


### PR DESCRIPTION
This experiment compares different ways of sampling the time taken to run an SUT:

![image](https://user-images.githubusercontent.com/530801/142734603-cf23200b-a328-4f51-bb04-b9b3b84882d2.png)

- `phpbench`: Current PHPBench "remote" executor: which samples the time taken to repeat the SUT _revs_ times.
- `sample_inside_loop`: Samples the time taken to execute the benchmark only (i.e. sample _in_ the loop)
Sample (for each executor):
- `hrtime`: Same as above but using `hrtime`

## Conclusions

- `hrtime` seems to remove necessity of sampling outside the loop.

## Env

![image](https://user-images.githubusercontent.com/530801/142734772-9d80aa80-b44e-4a42-b4ce-4c92029f0c3a.png)

(note that HR revs are exagerated as I multiplied the revolutions by 1000 to scale it down to microseconds)

## Method

For each executor
```
./bin/phpbench run \
    tests/Benchmark/Executor \
    --revs=1 \
    --revs=10 \
    --revs=100 \
    --iterations=10 \
    --warmup=1  \
    --executor=$excutor \
    --tag=sample_inside_loop
```

Report:

```
./bin/phpbench report --ref=phpbench --output=html --output=console --ref=sample_inside_loop --ref=hrtime --report=executor_comp
```

## Actions

- Introduce a `hrtime`  executor which will sample inside or outside the loop (configurable).
- Make this the default in 2.0