### PR TITLE
Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
         "phpbench/dom": "~0.3.1",
         "psr/log": "^1.1",
         "seld/jsonlint": "^1.1",
-        "symfony/console": "^4.2 || ^5.0",
-        "symfony/filesystem": "^4.2 || ^5.0",
-        "symfony/finder": "^4.2 || ^5.0",
-        "symfony/options-resolver": "^4.2 || ^5.0",
-        "symfony/process": "^4.2 || ^5.0",
+        "symfony/console": "^4.2 || ^5.0  || ^6.0",
+        "symfony/filesystem": "^4.2 || ^5.0 || ^6.0",
+        "symfony/finder": "^4.2 || ^5.0 || ^6.0",
+        "symfony/options-resolver": "^4.2 || ^5.0 || ^6.0",
+        "symfony/process": "^4.2 || ^5.0 || ^6.0",
         "webmozart/path-util": "^2.3"
     },
     "require-dev": {
@@ -37,8 +37,8 @@
         "phpspec/prophecy": "^1.12",
         "phpstan/phpstan": "^0.12.7",
         "phpunit/phpunit": "^8.5.8 || ^9.0",
-        "symfony/error-handler": "^5.2",
-        "symfony/var-dumper": "^4.0 || ^5.0"
+        "symfony/error-handler": "^5.2 || ^6.0",
+        "symfony/var-dumper": "^4.0 || ^5.0 || ^6.0"
     },
     "scripts": {
         "integrate":[ 

--- a/tests/Unit/Remote/PayloadTest.php
+++ b/tests/Unit/Remote/PayloadTest.php
@@ -16,7 +16,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PhpBench\Remote\Payload;
 use PhpBench\Remote\ProcessFactoryInterface;
 use PhpBench\Tests\IntegrationTestCase;
-use Prophecy\Argument;
 use RuntimeException;
 use Symfony\Component\Process\Process;
 


### PR DESCRIPTION
Allow SF 6 and use PHPUnit mocking to avoid bug in Prophecy revealed when prophesing the 6.0 Process component (https://github.com/phpspec/prophecy/issues/527)