### PR TITLE
Tell composer that the master branch is 1.2-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1-dev"
+            "dev-master": "1.2-dev"
         }
     },
     "autoload": {


### PR DESCRIPTION
Currently, Packagist and Composer believe that the master branch contains version 1.1-dev. But since that branch is ahead of the 1.2.x releases, that seems to be a lie. 🙂 