### PR TITLE
Allow float value instead of int

### DIFF
--- a/lib/Color/Gradient.php
+++ b/lib/Color/Gradient.php
@@ -79,7 +79,7 @@ use function array_fill;
         return new static(...$colors);
     }
 
-    public function colorAtPercentile(int $percentile): Color
+    public function colorAtPercentile(float $percentile): Color
     {
         $percentile = $percentile < 0 ? 0 : min(100, abs($percentile));
 

--- a/tests/Unit/Expression/Theme/Util/GradientTest.php
+++ b/tests/Unit/Expression/Theme/Util/GradientTest.php
@@ -97,7 +97,7 @@ class GradientTest extends TestCase
     /**
      * @dataProvider provideColorAtPercentile
      */
-    public function testColorAtPercentile(Gradient $gradient, int $percentile, Color $expected): void
+    public function testColorAtPercentile(Gradient $gradient, float $percentile, Color $expected): void
     {
         self::assertEquals($expected, $gradient->colorAtPercentile($percentile));
     }
@@ -123,6 +123,12 @@ class GradientTest extends TestCase
             Gradient::start(Color::fromRgb(0, 0, 0))->to(Color::fromRgb(0, 0, 10), 9),
             50,
             Color::fromRgb(0, 0, 5)
+        ];
+
+        yield [
+            Gradient::start(Color::fromRgb(0, 0, 0))->to(Color::fromRgb(0, 0, 10), 9),
+            43.5,
+            Color::fromRgb(0, 0, 4)
         ];
 
         yield 'more than 100' => [


### PR DESCRIPTION
There are parts of the application that would send float values to
this method.

This change intends to address a PHP Deprecation in PHP 8.1.