### PR TITLE
Remove webmozart/path-util

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,10 @@
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "seld/jsonlint": "^1.1",
         "symfony/console": "^4.2 || ^5.0  || ^6.0",
-        "symfony/filesystem": "^4.2 || ^5.0 || ^6.0",
+        "symfony/filesystem": "^5.4 || ^6.0",
         "symfony/finder": "^4.2 || ^5.0 || ^6.0",
         "symfony/options-resolver": "^4.2 || ^5.0 || ^6.0",
-        "symfony/process": "^4.2 || ^5.0 || ^6.0",
-        "webmozart/path-util": "^2.3"
+        "symfony/process": "^4.2 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "dantleech/invoke": "^2.0",

--- a/extensions/xdebug/lib/Command/Handler/OutputDirHandler.php
+++ b/extensions/xdebug/lib/Command/Handler/OutputDirHandler.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class OutputDirHandler
 {

--- a/extensions/xdebug/lib/Executor/ProfileExecutor.php
+++ b/extensions/xdebug/lib/Executor/ProfileExecutor.php
@@ -19,8 +19,8 @@ use PhpBench\Executor\ExecutionResults;
 use PhpBench\Extensions\XDebug\XDebugUtil;
 use PhpBench\Registry\Config;
 use RuntimeException;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Webmozart\PathUtil\Path;
 
 class ProfileExecutor implements BenchmarkExecutorInterface
 {

--- a/lib/Benchmark/BenchmarkFinder.php
+++ b/lib/Benchmark/BenchmarkFinder.php
@@ -17,8 +17,8 @@ use PhpBench\Benchmark\Metadata\BenchmarkMetadata;
 use PhpBench\Benchmark\Metadata\MetadataFactory;
 use Psr\Log\LoggerInterface;
 use SplFileInfo;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
-use Webmozart\PathUtil\Path;
 
 /**
  * This class finds a benchmark (or benchmarks depending on the path), loads

--- a/lib/Config/Processor/IncludeGlobProcessor.php
+++ b/lib/Config/Processor/IncludeGlobProcessor.php
@@ -4,7 +4,7 @@ namespace PhpBench\Config\Processor;
 
 use PhpBench\Config\ConfigLoader;
 use PhpBench\Config\ConfigProcessor;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class IncludeGlobProcessor implements ConfigProcessor
 {

--- a/lib/Config/Processor/IncludeProcessor.php
+++ b/lib/Config/Processor/IncludeProcessor.php
@@ -4,7 +4,7 @@ namespace PhpBench\Config\Processor;
 
 use PhpBench\Config\ConfigLoader;
 use PhpBench\Config\ConfigProcessor;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class IncludeProcessor implements ConfigProcessor
 {

--- a/lib/Extension/RunnerExtension.php
+++ b/lib/Extension/RunnerExtension.php
@@ -55,10 +55,10 @@ use PhpBench\Util\PathNormalizer;
 use PhpBench\Util\TimeUnit;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Process\ExecutableFinder;
-use Webmozart\PathUtil\Path;
 
 class RunnerExtension implements ExtensionInterface
 {

--- a/lib/Extension/StorageExtension.php
+++ b/lib/Extension/StorageExtension.php
@@ -29,8 +29,8 @@ use PhpBench\Storage\UuidResolver\ChainResolver;
 use PhpBench\Storage\UuidResolver\LatestResolver;
 use PhpBench\Storage\UuidResolver\TagResolver;
 use PhpBench\Util\TimeUnit;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Webmozart\PathUtil\Path;
 
 class StorageExtension implements ExtensionInterface
 {

--- a/lib/PhpBench.php
+++ b/lib/PhpBench.php
@@ -30,8 +30,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Path;
 use Throwable;
-use Webmozart\PathUtil\Path;
 use function set_error_handler;
 
 class PhpBench

--- a/lib/Report/Renderer/HtmlRenderer.php
+++ b/lib/Report/Renderer/HtmlRenderer.php
@@ -10,8 +10,8 @@ use PhpBench\Report\RendererInterface;
 use PhpBench\Template\ObjectRenderer;
 use RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Webmozart\PathUtil\Path;
 
 class HtmlRenderer implements RendererInterface
 {

--- a/lib/Util/PathNormalizer.php
+++ b/lib/Util/PathNormalizer.php
@@ -2,7 +2,7 @@
 
 namespace PhpBench\Util;
 
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class PathNormalizer
 {
@@ -14,7 +14,7 @@ class PathNormalizer
     public static function normalizePaths(string $baseDir, array $paths): array
     {
         return array_merge(...array_map(static function (string $path) use ($baseDir) {
-            $path = Path::isAbsolute($path) ? $path : Path::join([$baseDir, $path]);
+            $path = Path::isAbsolute($path) ? $path : Path::join($baseDir, $path);
 
             if (self::isGlob($path)) {
                 $globPaths = glob($path, GLOB_NOSORT);

--- a/tests/Util/Workspace.php
+++ b/tests/Util/Workspace.php
@@ -7,7 +7,7 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RuntimeException;
 use SplFileInfo;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class Workspace
 {


### PR DESCRIPTION
Currently, composer complains when installing phpbench, with the following message :
~~~
Package webmozart/path-util is abandoned, you should avoid using it. Use symfony/filesystem instead.
~~~

This problem was brought up in issue #978

Indeed, the symfony/filesystem package provides the same functionalities with the class `Symfony\Component\Filesystem\Path`

As a caveat, it is only available since v5.4 so it could be considered a breaking change for some end users.