### PR TITLE
[Fix] CONFIGURATION PRELUDE: Typo in `configuration`

### DIFF
--- a/docs/configuration-prelude.rst
+++ b/docs/configuration-prelude.rst
@@ -22,7 +22,7 @@ that order and use one if it exists.
         }
     }
 
-You can include more configuratoin files with the ``$include`` and
+You can include more configuration files with the ``$include`` and
 ``$include-glob`` directives:
 
 .. code-block:: json


### PR DESCRIPTION
This PR resolves a small typo in the word configuration.