### PR TITLE
#997 make Assert repeatable for PHP8+ attributes

### DIFF
--- a/lib/Attributes/Assert.php
+++ b/lib/Attributes/Assert.php
@@ -4,7 +4,7 @@ namespace PhpBench\Attributes;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class Assert
 {
     /**

--- a/tests/Unit/Attributes/AssertTest.php
+++ b/tests/Unit/Attributes/AssertTest.php
@@ -32,10 +32,7 @@ final class AssertTest extends TestCase
     }
 }
 
-#[
-    Assert('mode(variant.mem.peak) < 2097152'),
-    Assert('mode(variant.time.avg) < 10000000')
-]
+#[Assert('mode(variant.mem.peak) < 2097152'), Assert('mode(variant.time.avg) < 10000000')]
 class AttributeAssertUsedMultipleTimes
 {
 }

--- a/tests/Unit/Attributes/AssertTest.php
+++ b/tests/Unit/Attributes/AssertTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpBench\Tests\Unit\Attributes;
+
+use PhpBench\Attributes\Assert;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class AssertTest extends TestCase
+{
+    public function testHandlesMultipleAssert(): void
+    {
+        if ($this->shouldSkip()) {
+            $this->markTestSkipped('PHP 8 only');
+
+            return;
+        }
+
+        $reflection = new ReflectionClass(AttributeAssertUsedMultipleTimes::class);
+        $attributes = $reflection->getAttributes();
+        self::assertCount(2, $attributes);
+        foreach ($attributes as $attribute) {
+            $attribute->newInstance();
+        }
+    }
+
+    private function shouldSkip(): bool
+    {
+        return PHP_VERSION_ID < 80000;
+    }
+}
+
+#[
+    Assert('mode(variant.mem.peak) < 2097152'),
+    Assert('mode(variant.time.avg) < 10000000')
+]
+class AttributeAssertUsedMultipleTimes
+{
+}


### PR DESCRIPTION
Fix for missing `Attribute::IS_REPEATABLE` for the `Assert` attribute see #997