### PR TITLE
Fix handling of non-array data sets

### DIFF
--- a/lib/Reflection/template/parameter_set_extractor.template
+++ b/lib/Reflection/template/parameter_set_extractor.template
@@ -17,17 +17,23 @@ function normalize_parameter_set($parameterSet)
         ));
     }
 
-    return array_combine(array_keys($parameterSet), array_map(function ($parameters) {
+    $normalizedParameterSet = [];
+
+    foreach ($parameterSet as $set => $parameters) {
         if (!is_array($parameters)) {
-            throw new \RuntimeException(
+            throw new \RuntimeException(sprintf(
                 'Parameters in set "%s" must be an array, got "%s"',
+                $set,
                 gettype($parameters)
-            );
+            ));
         }
-        return array_map(function ($value) {
+
+        $normalizedParameterSet[$set] = array_map(function ($value) {
             return serialize($value);
         }, $parameters);
-    }, $parameterSet));
+    }
+
+    return $normalizedParameterSet;
 }
 
 $bootstrap = '{{ bootstrap }}';


### PR DESCRIPTION
The following code results in a `TypeError` being thrown while trying to create an `Exception` when phpbench finds that the value of a data set is not an array, due to a missing `sprintf` call.

```php
<?php

declare(strict_types=1);

use PhpBench\Attributes as Bench;

class TestBench
{
    #[Bench\ParamProviders(['invalidProvider'])]
    public function benchTest(array $params): void
    {
    }

    public function invalidProvider(): array
    {
        return [8];
    }
}
```

```bash
vendor/bin/phpbench run TestBench.php
PHPBench (1.2.6) running benchmarks... #standwithukraine
with PHP version 8.0.21, xdebug ❌, opcache ✔


In Payload.php line 143:
PHP Fatal error:  Uncaught TypeError: Exception::__construct(): Argument #2 ($code) must be of type int, string giv
  en in /tmp/PhpBenchr9Cy2c:24
  Stack trace:
  #0 /tmp/PhpBenchr9Cy2c(24): Exception->__construct('Parameters in s...', 'integer')
  #1 [internal function]: PhpBench\{closure}(0)
  #2 /tmp/PhpBenchr9Cy2c(20): array_map(Object(Closure), Array)
  #3 /tmp/PhpBenchr9Cy2c(56): PhpBench\normalize_parameter_set(Array)
  #4 {main}
    thrown in /tmp/PhpBenchr9Cy2c on line 24
```



https://github.com/phpbench/phpbench/blob/c30fac992e72b505a1f131790583647f4d3255c3/lib/Reflection/template/parameter_set_extractor.template#L21-L26



Adding the `sprintf` call resulted in an `ArgumentCountException` being thrown as the `sprintf` call was missing the set name. Since the set name wasn't readily available in the `array_map` closure,  it seemed better to convert it to a `foreach` loop to get access to the set name.