### PR TITLE
Fix expected glob behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ master
 Improvements:
 
 - Update PHPStan to 1.0 and fix new errors #1006
+- Use `webmozart/glob` instead of `glob` for benchmark paths and config
+  include paths #1005
+
+Bug fixes:
+
+- Fix bad exception call #1002 @TRowbotham
 
 1.2.6
 -----

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "symfony/finder": "^4.2 || ^5.0 || ^6.0",
         "symfony/options-resolver": "^4.2 || ^5.0 || ^6.0",
         "symfony/process": "^4.2 || ^5.0 || ^6.0",
+        "webmozart/glob": "^4.6",
         "webmozart/path-util": "^2.3"
     },
     "require-dev": {

--- a/lib/Config/Processor/IncludeGlobProcessor.php
+++ b/lib/Config/Processor/IncludeGlobProcessor.php
@@ -4,6 +4,7 @@ namespace PhpBench\Config\Processor;
 
 use PhpBench\Config\ConfigLoader;
 use PhpBench\Config\ConfigProcessor;
+use Webmozart\Glob\Glob;
 use Webmozart\PathUtil\Path;
 
 class IncludeGlobProcessor implements ConfigProcessor
@@ -19,7 +20,7 @@ class IncludeGlobProcessor implements ConfigProcessor
         foreach ((array)$config[self::DIRECTIVE] as $globPath) {
             $globPath = Path::makeAbsolute($globPath, dirname($path));
 
-            foreach (glob($globPath) as $includePath) {
+            foreach (Glob::glob($globPath) as $includePath) {
                 $config = array_merge_recursive(
                     $config,
                     $loader->load($includePath)

--- a/lib/Util/PathNormalizer.php
+++ b/lib/Util/PathNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace PhpBench\Util;
 
+use Webmozart\Glob\Glob;
 use Webmozart\PathUtil\Path;
 
 class PathNormalizer
@@ -17,7 +18,7 @@ class PathNormalizer
             $path = Path::isAbsolute($path) ? $path : Path::join([$baseDir, $path]);
 
             if (self::isGlob($path)) {
-                $globPaths = glob($path, GLOB_NOSORT);
+                $globPaths = Glob::glob($path);
 
                 if (empty($globPaths)) {
                     return [];


### PR DESCRIPTION
Use `webmozrt/glob` instead of PHP's `glob` to enable `/**/` to wildcard on directory levels.

Fixes #1004 