### PR TITLE
Detect xdebug.use_compression and set correct extension

### DIFF
--- a/extensions/xdebug/lib/Command/ProfileCommand.php
+++ b/extensions/xdebug/lib/Command/ProfileCommand.php
@@ -20,25 +20,33 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
 class ProfileCommand extends Command
 {
+    /**
+     * @var RunnerHandler
+     */
     private $runnerHandler;
-    private $filesystem;
+    /**
+     * @var OutputDirHandler
+     */
     private $outputDirHandler;
+    /**
+     * @var XDebugUtil
+     */
+    private $xdebugUtil;
 
     public function __construct(
         RunnerHandler $runnerHandler,
         OutputDirHandler $outputDirHandler,
-        Filesystem $filesystem = null
+        XDebugUtil $xdebugUtil
     ) {
         parent::__construct();
         $this->runnerHandler = $runnerHandler;
-        $this->filesystem = $filesystem ?: new Filesystem();
         $this->outputDirHandler = $outputDirHandler;
+        $this->xdebugUtil = $xdebugUtil;
     }
 
     public function configure(): void
@@ -79,7 +87,7 @@ EOT
                 'executor' => 'xdebug_profile',
                 'output_dir' => $outputDir,
                 'callback' => function ($iteration) use ($outputDir, $guiBin, &$generatedFiles): void {
-                    $generatedFiles[] = $generatedFile = $outputDir . DIRECTORY_SEPARATOR . XDebugUtil::filenameFromContext($iteration, '.cachegrind');
+                    $generatedFiles[] = $generatedFile = $outputDir . DIRECTORY_SEPARATOR . $this->xdebugUtil->filenameFromContext($iteration, $this->xdebugUtil->getCachegrindExtensionOfGeneratedFile());
 
                     if ($guiBin) {
                         $process = Process::fromShellCommandline(sprintf(

--- a/extensions/xdebug/lib/XDebugExtension.php
+++ b/extensions/xdebug/lib/XDebugExtension.php
@@ -44,10 +44,14 @@ class XDebugExtension implements ExtensionInterface
 
     public function load(Container $container): void
     {
+        $container->register(XDebugUtil::class, function (Container $container) {
+            return XDebugUtil::fromEnvironment();
+        });
         $container->register(ProfileCommand::class, function (Container $container) {
             return new ProfileCommand(
                 $container->get(RunnerHandler::class),
-                $container->get(self::PARAM_OUTPUT_DIR)
+                $container->get(self::PARAM_OUTPUT_DIR),
+                $container->get(XDebugUtil::class)
             );
         }, [
             ConsoleExtension::TAG_CONSOLE_COMMAND => []
@@ -64,6 +68,7 @@ class XDebugExtension implements ExtensionInterface
             return new CompositeExecutor(
                 new ProfileExecutor(
                     $container->get(RemoteExecutor::class),
+                    $container->get(XDebugUtil::class),
                     $container->getParameter(CoreExtension::PARAM_WORKING_DIR)
                 ),
                 $container->get(RemoteMethodExecutor::class)

--- a/extensions/xdebug/lib/XDebugUtil.php
+++ b/extensions/xdebug/lib/XDebugUtil.php
@@ -13,10 +13,37 @@
 namespace PhpBench\Extensions\XDebug;
 
 use PhpBench\Executor\ExecutionContext;
+use RuntimeException;
 
 class XDebugUtil
 {
-    public static function filenameFromContext(ExecutionContext $context, $extension = ''): string
+    public static function fromEnvironment(): XDebugUtil
+    {
+        $xdebugVersion = phpversion('xdebug');
+        $xdebugUseCompression = ini_get('xdebug.use_compression') === '1';
+
+        return new XDebugUtil($xdebugVersion, $xdebugUseCompression);
+    }
+
+    /**
+     * @var string|false
+     */
+    private $xdebugVersion;
+    /**
+     * @var bool
+     */
+    private $xdebugUseCompression;
+
+    /**
+     * @param string|false     $xdebugVersion
+     */
+    public function __construct($xdebugVersion, bool $xdebugUseCompression)
+    {
+        $this->xdebugVersion = $xdebugVersion;
+        $this->xdebugUseCompression = $xdebugUseCompression;
+    }
+
+    public function filenameFromContext(ExecutionContext $context, $extension = ''): string
     {
         $name = sprintf(
             '%s%s%s',
@@ -27,5 +54,27 @@ class XDebugUtil
 
 
         return md5($name) . $extension;
+    }
+
+    public function getCachegrindExtensionOfGeneratedFile(): string
+    {
+        $xdebugVersion = $this->discoverXdebugMajorVersion();
+
+        if ($xdebugVersion === '3' && $this->xdebugUseCompression) {
+            return '.cachegrind.gz';
+        }
+
+        return '.cachegrind';
+    }
+
+    public function discoverXdebugMajorVersion(): string
+    {
+        if ($this->xdebugVersion === false) {
+            throw new RuntimeException(
+                'Xdebug is not installed'
+            );
+        }
+
+        return substr($this->xdebugVersion, 0, 1);
     }
 }

--- a/extensions/xdebug/tests/Unit/XDebugUtilTest.php
+++ b/extensions/xdebug/tests/Unit/XDebugUtilTest.php
@@ -39,12 +39,26 @@ class XDebugUtilTest extends TestCase
             'className' => $class,
             'methodName' => $subject,
         ];
+        $xdebugUtil = new XDebugUtil('3.1.2', false);
 
-        $result = XDebugUtil::filenameFromContext(Invoke::new(ExecutionContext::class, $params));
+        $result = $xdebugUtil->filenameFromContext(Invoke::new(ExecutionContext::class, $params));
         $this->assertEquals(
             $expected,
             $result
         );
+    }
+
+    /**
+     *
+     * @dataProvider provideXdebugVersion
+     */
+    public function testCacheGrindExtension($xdebugVersion, $useCompression, $expectedExtension): void
+    {
+        $xdebugUtil = new XDebugUtil($xdebugVersion, $useCompression);
+
+        $cacheGrindExtension = $xdebugUtil->getCachegrindExtensionOfGeneratedFile();
+
+        $this->assertEquals($expectedExtension, $cacheGrindExtension);
     }
 
     public function provideGenerate()
@@ -60,6 +74,15 @@ class XDebugUtilTest extends TestCase
                 'Subject\\//asd',
                 '25133125bf4eca7a08502711d2c8403d'
             ],
+        ];
+    }
+
+    public function provideXdebugVersion(): array
+    {
+        return [
+            ['2.8.1', false, '.cachegrind'],
+            ['3.1.2', false, '.cachegrind'],
+            ['3.1.2', true, '.cachegrind.gz']
         ];
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,6 +3,7 @@ parameters:
     paths:
         - lib
         - examples/Extension
+        - extensions/xdebug/lib
     excludePaths:
         - lib/Attributes
         - lib/Benchmark/Metadata/Driver/AttributeDriver.php


### PR DESCRIPTION
Xdebug 3.1 enables compression of the cachegrind files automatically so the extension of the output by default is not .cachegrind but .cachegrind.gz.

This patch adds a check to see if compression is enabled and then uses .cachegrind.gz instead of .cachegrind as extension.