### PR TITLE
Address Package name change

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -28,7 +28,7 @@ jobs:
                 run: sudo apt-get update
 
             -   name: "Install Sphinx dependencies"
-                run: sudo apt-get install python-dev build-essential
+                run: sudo apt-get install python3-dev build-essential
 
             -   name: "Cache pip"
                 uses: actions/cache@v3


### PR DESCRIPTION
Using v3 seems to be the correct move: https://github.com/sphinx-doc/sphinx/blob/v5.3.0/Makefile#L1

This small PR should allow me to achieve non-first-contributor status, and no longer require you pressing a button for me to be able to run workflows.