### PR TITLE
If \PhpBench\Executor\Method\ErrorHandlingExecutorDecorator throws unhandled exception now is a bit clearer why

### DIFF
--- a/lib/Executor/Method/ErrorHandlingExecutorDecorator.php
+++ b/lib/Executor/Method/ErrorHandlingExecutorDecorator.php
@@ -24,11 +24,15 @@ class ErrorHandlingExecutorDecorator implements MethodExecutorInterface
         try {
             $this->executor->executeMethods($context, $methods);
         } catch (Throwable $throwable) {
-            throw new ExecutionError(sprintf(
-                'Could not execute method(s) "%s" on "%s"',
-                implode('", "', $methods),
-                $context->getBenchmarkClass()
-            ));
+            throw new ExecutionError(
+                sprintf(
+                    'Could not execute method(s) "%s" on "%s"',
+                    implode('", "', $methods),
+                    $context->getBenchmarkClass()
+                ),
+                0,
+                $throwable
+            );
         }
     }
 }

--- a/lib/Executor/Method/ErrorHandlingExecutorDecorator.php
+++ b/lib/Executor/Method/ErrorHandlingExecutorDecorator.php
@@ -17,7 +17,7 @@ class ErrorHandlingExecutorDecorator implements MethodExecutorInterface
     {
         try {
             $this->executor->executeMethods($context, $methods);
-        } catch (Throwable) {
+        } catch (Throwable $throwable) {
             throw new ExecutionError(sprintf(
                 'Could not execute method(s) "%s" on "%s"',
                 implode('", "', $methods),


### PR DESCRIPTION
3rd exception parameter $throwable can be used to get original exception. 

I think it could be useful when debugging exceptions.