### PR TITLE
Fix: removing deprecation warning when passing --progress=blinken

### DIFF
--- a/lib/Util/TimeUnit.php
+++ b/lib/Util/TimeUnit.php
@@ -234,6 +234,10 @@ class TimeUnit
      */
     public function resolvePrecision($precision): ?int
     {
+        if (empty($precision)) {
+            return 0;
+        }
+
         if ($this->overriddenPrecision) {
             return $this->precision;
         }


### PR DESCRIPTION
Passing this arguments on benchmark runs:
```
php vendor/bin/phpbench run src/Tests/Benchmark/Algorithm1Bench.php --report=aggregate --retry-threshold=5 --progress=blinken
```
It returns this warning for each time you put on the annotation `Revs`.:
```
Deprecated: number_format(): Passing null to parameter #2 ($decimals) of type int is deprecated in /var/www/html/vendor/phpbench/phpbench/lib/Progress/Logger/PhpBenchLogger.php on line 195
```
This should fix it. :)