### PR TITLE
Add Composer keywords for findability on Packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,13 @@
 {
     "name": "phpbench/phpbench",
     "description": "PHP Benchmarking Framework",
+    "keywords": [
+        "benchmarking",
+        "optimization",
+        "performance",
+        "profiling",
+        "testing"
+    ],
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
I almost didn't find you. 🙂 Composer keywords appear as filterable tags on Packagist, e.g., [#performance](https://packagist.org/search/?tags=performance).