### PR TITLE
Correct phpbench.schema.json

### DIFF
--- a/phpbench.schema.json
+++ b/phpbench.schema.json
@@ -83,13 +83,13 @@
         "runner.env_enabled_providers": {
             "description": "Select which environment samplers to use",
             "type": [
-                "object"
+                "array"
             ]
         },
         "runner.env_samplers": {
             "description": "Environment baselines (not to be confused with baseline comparisons when running benchmarks) are small benchmarks which run to sample the speed of the system (e.g. file I\/O, computation etc). This setting enables or disables these baselines",
             "type": [
-                "object"
+                "array"
             ]
         },
         "runner.env_sampler_callables": {


### PR DESCRIPTION
These two config options are arrays, not objects.

I think several of the other config options defined as objects are also arrays, but I've not used or tested them to be sure.