### PR TITLE
Add documentation about adding an environment provider

### DIFF
--- a/docs/customisation.rst
+++ b/docs/customisation.rst
@@ -8,4 +8,5 @@ Customisation
    customisation/command
    customisation/executor
    customisation/progress-logger
+   customisation/environment-provider
    customisation/report

--- a/docs/customisation/environment-provider.rst
+++ b/docs/customisation/environment-provider.rst
@@ -1,0 +1,22 @@
+Environment Provider
+====================
+
+Environment providers are used to record information about the running environment,
+they are called before the benchmark is run.
+
+Create a new environment provider class similar to the following:
+
+.. codeimport:: ../../examples/Extension/Environment/HomeProvider.php
+  :language: php
+
+And register with your DI container:
+
+.. codeimport:: ../../examples/Extension/AcmeExtension.php
+  :language: php
+  :sections: all,env_provider_di
+
+Run it with:
+
+.. code-block:: bash
+
+  $ phpbench run --report=env

--- a/docs/customisation/extension.rst
+++ b/docs/customisation/extension.rst
@@ -6,6 +6,7 @@ PHPBench allows you to create your own extensions, allowing you to register new:
 - :doc:`Benchmark Executors <executor>`
 - :doc:`Progress Loggers <progress-logger>`
 - :doc:`Commands <command>`
+- :doc:`Environment Providers <environment-provider>`
 - :doc:`Reports <report>`
 
 Create a new extension package

--- a/examples/Extension/AcmeExtension.php
+++ b/examples/Extension/AcmeExtension.php
@@ -7,6 +7,7 @@ use PhpBench\DependencyInjection\Container;
 use PhpBench\DependencyInjection\ExtensionInterface;
 // endsection: all
 use PhpBench\Examples\Extension\Command\CatsCommand;
+use PhpBench\Examples\Extension\Environment\HomeProvider;
 use PhpBench\Examples\Extension\Executor\AcmeExecutor;
 use PhpBench\Examples\Extension\ProgressLogger\CatLogger;
 use PhpBench\Examples\Extension\Report\AcmeGenerator;
@@ -80,6 +81,16 @@ class AcmeExtension implements ExtensionInterface
             ]
         ]);
         // endsection: executor_di
+
+        // section: env_provider_di
+        $container->register(AcmeExecutor::class, function (Container $container) {
+            return new HomeProvider();
+        }, [
+            RunnerExtension::TAG_ENV_PROVIDER => [
+                'name' => 'home',
+            ]
+        ]);
+        // endsection: env_provider_di
         // section: all
     }
 }

--- a/examples/Extension/AcmeExtension.php
+++ b/examples/Extension/AcmeExtension.php
@@ -1,9 +1,11 @@
 <?php
 
+// section: all
 namespace PhpBench\Examples\Extension;
 
 use PhpBench\DependencyInjection\Container;
 use PhpBench\DependencyInjection\ExtensionInterface;
+// endsection: all
 use PhpBench\Examples\Extension\Command\CatsCommand;
 use PhpBench\Examples\Extension\Executor\AcmeExecutor;
 use PhpBench\Examples\Extension\ProgressLogger\CatLogger;
@@ -12,9 +14,9 @@ use PhpBench\Extension\ConsoleExtension;
 use PhpBench\Extension\CoreExtension;
 use PhpBench\Extension\ReportExtension;
 use PhpBench\Extension\RunnerExtension;
+// section: all
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-// section: all
 class AcmeExtension implements ExtensionInterface
 {
     // endsection: all

--- a/examples/Extension/Environment/HomeProvider.php
+++ b/examples/Extension/Environment/HomeProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace PhpBench\Examples\Extension\Environment;
+
+use PhpBench\Environment\Information;
+use PhpBench\Environment\ProviderInterface;
+
+class HomeProvider implements ProviderInterface
+{
+    public function isApplicable(): bool
+    {
+        // Example: this provider requires the HOME environment variable to be set.
+        return (bool) getenv('HOME');
+    }
+
+    public function getInformation(): Information
+    {
+        // Example: return the value of the HOME environment variable.
+        return new Information('home', [
+            'directory' => getenv('HOME'),
+        ]);
+    }
+}


### PR DESCRIPTION
I worked on adding an [environment provider for MongoDB benchmarks](https://github.com/mongodb/mongo-php-library/blob/4e581cf0c5f9a901b189f1b247a3a7759be18d02/benchmark/Extension/EnvironmentProvider.php) and found some missing pieces of documentation.

This needs to be reviewed because I just started working with PHPBench. But I think this new documentation will be helpful if someone needs to create a custom env provider.

Also, I added the namespaces to the base extension example. I was disturbed to not knowing the actual class of `ExtensionInterface`.