### PR TITLE
Fixed TypeError in MemoryUnit.php

### DIFF
--- a/lib/Util/MemoryUnit.php
+++ b/lib/Util/MemoryUnit.php
@@ -85,9 +85,9 @@ class MemoryUnit
     }
 
     /**
-     * Resolve an binary unit
+     * Resolve a binary unit
      */
-    public static function resolveSuitableBinaryUnit(?string $unit, ?float $value): string
+    public static function resolveSuitableBinaryUnit(string $unit, ?float $value): string
     {
         if ($unit !== self::AUTO) {
             return $unit;
@@ -115,7 +115,7 @@ class MemoryUnit
     /**
      * Resolve an SI unit
      */
-    public static function resolveSuitableUnit(?string $unit, ?float $value): string
+    public static function resolveSuitableUnit(string $unit, ?float $value): string
     {
         if ($unit !== self::AUTO) {
             return $unit;

--- a/tests/Unit/Util/MemoryUnitTest.php
+++ b/tests/Unit/Util/MemoryUnitTest.php
@@ -115,6 +115,13 @@ class MemoryUnitTest extends TestCase
             ];
     }
 
+    public function testResolveSuitableUnitWithCustomUnit(): void
+    {
+        $unit = 'my-unit';
+
+        self::assertEquals($unit, MemoryUnit::resolveSuitableUnit($unit, 1.0));
+    }
+
     /**
      * @dataProvider provideSuitableUnit
      */
@@ -141,6 +148,13 @@ class MemoryUnitTest extends TestCase
         yield [1_000_000, MemoryUnit::MEGABYTES];
 
         yield [1_000_000_000, MemoryUnit::GIGABYTES];
+    }
+
+    public function testResolveSuitableBinaryUnitWithCustomUnit(): void
+    {
+        $unit = 'my-unit';
+
+        self::assertEquals($unit, MemoryUnit::resolveSuitableBinaryUnit($unit, 1.0));
     }
 
     /**


### PR DESCRIPTION
There are two methods in `lib/Util/MemoryUnit.php`:

https://github.com/phpbench/phpbench/blob/5f12699b84926d7674fc5ad54e319a7556d0fc50/lib/Util/MemoryUnit.php#L90-L94

and

https://github.com/phpbench/phpbench/blob/5f12699b84926d7674fc5ad54e319a7556d0fc50/lib/Util/MemoryUnit.php#L118-L122

`$unit` is nullable and can be returned as is. But return type of the methods is string. So if `$unit === null` we get `TypeError: PhpBench\Util\MemoryUnit::resolveSuitableBinaryUnit(): Return value must be of type string, null returned`