### PR TITLE
Disabled fully_qualified_strict_types for php-cs-fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -57,7 +57,6 @@ return (new Config())
         'no_superfluous_phpdoc_tags' => [
             'allow_mixed' => true
         ],
-        'fully_qualified_strict_types' => true,
+        'fully_qualified_strict_types' => false,
     ])
-    ->setFinder($finder)
-    ;
+    ->setFinder($finder);


### PR DESCRIPTION
New release https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.47.0
breaks a lot of things. That's why I disabled `fully_qualified_strict_types`.