### PR TITLE
Forced `--no-ansi` in tests

### DIFF
--- a/tests/Example/CommandsTest.php
+++ b/tests/Example/CommandsTest.php
@@ -50,6 +50,7 @@ class CommandsTest extends IntegrationTestCase
             RunnerExtension::PARAM_ENABLED_PROVIDERS => [],
             ConsoleExtension::PARAM_OUTPUT_STREAM => $this->workspace()->path('output'),
             ConsoleExtension::PARAM_ERROR_STREAM => 'php://temp',
+            ConsoleExtension::PARAM_ANSI => false
         ], $decoded)));
 
         foreach ($commands as $command) {

--- a/tests/Integration/ConfiguredReportsTest.php
+++ b/tests/Integration/ConfiguredReportsTest.php
@@ -24,7 +24,8 @@ class ConfiguredReportsTest extends IntegrationTestCase
         foreach ($generators->getConfigNames() as $generator) {
             foreach (array_unique(array_merge($renderers->getServiceNames(), $renderers->getConfigNames())) as $renderer) {
                 $manager = $this->container([
-                    ConsoleExtension::PARAM_OUTPUT_STREAM => $this->workspace()->path('test')
+                    ConsoleExtension::PARAM_OUTPUT_STREAM => $this->workspace()->path('test'),
+                    ConsoleExtension::PARAM_ANSI => false
                 ])->get(ReportManager::class);
                 assert($manager instanceof ReportManager);
                 $manager->renderReports(TestUtil::createCollection([

--- a/tests/System/SystemTestCase.php
+++ b/tests/System/SystemTestCase.php
@@ -59,7 +59,7 @@ class SystemTestCase extends IntegrationTestCase
     {
         $cwd = $this->workspace()->path($cwd);
 
-        $bin = __DIR__ . '/../../bin/phpbench --verbose';
+        $bin = __DIR__ . '/../../bin/phpbench --verbose --no-ansi';
         $process = Process::fromShellCommandline($bin . ' ' . $command, $cwd);
         $process->run();
 

--- a/tests/Unit/Report/Generator/GeneratorTestCase.php
+++ b/tests/Unit/Report/Generator/GeneratorTestCase.php
@@ -67,7 +67,8 @@ abstract class GeneratorTestCase extends IntegrationTestCase
                 $config
             );
             $this->container([
-                ConsoleExtension::PARAM_OUTPUT_STREAM => $this->workspace()->path('out')
+                ConsoleExtension::PARAM_OUTPUT_STREAM => $this->workspace()->path('out'),
+                ConsoleExtension::PARAM_ANSI => false
             ])->get(ConsoleRenderer::class)->render($document, new Config('test', []));
 
             return $this->workspace()->getContents('out');

--- a/tests/Unit/Report/Renderer/ConsoleRendererTest.php
+++ b/tests/Unit/Report/Renderer/ConsoleRendererTest.php
@@ -23,7 +23,8 @@ class ConsoleRendererTest extends AbstractRendererCase
     protected function getRenderer(): RendererInterface
     {
         return $this->container([
-            ConsoleExtension::PARAM_OUTPUT_STREAM => $this->workspace()->path('out')
+            ConsoleExtension::PARAM_OUTPUT_STREAM => $this->workspace()->path('out'),
+            ConsoleExtension::PARAM_ANSI => false
         ])->get(ConsoleRenderer::class);
     }
 


### PR DESCRIPTION
Forced `--no-ansi` in tests as without this option it breaks tests if they are running from the terminal supporting colors.