### PR TITLE
Defer CharacterReader initialization until command execution

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -51,7 +51,7 @@ return (new Config())
         'concat_space' => false,
         'no_unused_imports' => true,
         'php_unit_set_up_tear_down_visibility' => true,
-        'phpdoc_align' => [],
+        'phpdoc_align' => false,
         'phpdoc_indent' => false,
         'phpdoc_separation' => true,
         'no_superfluous_phpdoc_tags' => [

--- a/lib/Console/CharacterReader.php
+++ b/lib/Console/CharacterReader.php
@@ -14,17 +14,20 @@ namespace PhpBench\Console;
 
 class CharacterReader
 {
+    private static bool $initialized = false;
+
     /**
      * If readline is installed, then prevent the user having to
      * press <return> in order to paginate.
      */
-    public function __construct()
+    private static function initialize(): void
     {
         // we could use extension_loaded but HHVM returns true and
-        // still doesn't have this function..
-        if (function_exists('readline_callback_handler_install')) {
+        // still doesn't have this function...
+        if (self::$initialized === false && function_exists('readline_callback_handler_install')) {
             readline_callback_handler_install('', function (): void {
             });
+            self::$initialized = true;
         }
     }
 
@@ -35,6 +38,8 @@ class CharacterReader
      */
     public function read(): ?string
     {
+        self::initialize();
+
         while (false !== $character = fgetc(STDIN)) {
             return $character;
         }


### PR DESCRIPTION
The call to `readline_callback_handler_install` in `CharacterReader` is causing some junk output (see below) *in all commands* that was breaking the CSV output. Clearing out `TERM` and `COLORTERM` also prevents the issue.

This commit defers the installation of the readline callback handler until log is actually run.

```console
$ COLORTERM="truecolor" TERM="xterm-256color" php -r "readline_callback_handler_install('', function (): void {});" | xxd
00000000: 1b5b 3f32 3030 3468 1b5b 3f32 3030 346c  .[?2004h.[?2004l
00000010: 0d                                       .

$ COLORTERM= TERM= php -r "readline_callback_handler_install('', function (): void {});" | xxd

$ COLORTERM="truecolor" TERM="xterm-256color" php -r "" | xxd
```

Fixes #1090