### PR TITLE
Do not show ERROR log message if field not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 CHANGELOG
 =========
 
+master
+------
+
+- Hide noisy log messages for missing fields #1095 @dantleech
+- Defer character reader until command execution @jbboher #1092
+- Import Attribute symbol @gsteel #1075
+- Improved types etc @aivchen #1064 #1064 #1070 #1071 #1074 #1081...
+- Improved tests @aivchen
+- Improved code-style @aivchen #1057 #1076 #1070
+- Removed useless polyfills @aivchen
+
 1.2.15
 ------
 

--- a/lib/Logger/ConsoleLogger.php
+++ b/lib/Logger/ConsoleLogger.php
@@ -25,12 +25,11 @@ class ConsoleLogger extends AbstractLogger
             case LogLevel::DEBUG:
             case LogLevel::INFO:
             case LogLevel::NOTICE:
+            case LogLevel::WARNING:
                 if (!$this->enable) {
                     return;
                 }
 
-                break;
-            case LogLevel::WARNING:
                 $decoration = 'fg=yellow';
 
                 break;

--- a/lib/Report/Generator/ExpressionGenerator.php
+++ b/lib/Report/Generator/ExpressionGenerator.php
@@ -197,7 +197,7 @@ EOT
                     );
                 } catch (EvaluationError $e) {
                     $evaledRow[$name] = new StringNode('ERR');
-                    $this->logger->error(sprintf(
+                    $this->logger->warning(sprintf(
                         'Expression error (column "%s"): %s %s',
                         $name,
                         $e->getMessage(),

--- a/lib/Report/Generator/ExpressionGenerator.php
+++ b/lib/Report/Generator/ExpressionGenerator.php
@@ -198,10 +198,9 @@ EOT
                 } catch (EvaluationError $e) {
                     $evaledRow[$name] = new StringNode('ERR');
                     $this->logger->warning(sprintf(
-                        'Expression error (column "%s"): %s %s',
+                        'Expression error (column "%s"): %s',
                         $name,
                         $e->getMessage(),
-                        $e->getTraceAsString()
                     ));
                 }
             }


### PR DESCRIPTION
Not all executors provide the fields used by the default reports which can result in disturbing error messages being logged.

This commit changes the log level to WARNING for evaluation errors and moves the "show messages" log level to WARNING.

Previously:

![image](https://github.com/phpbench/phpbench/assets/530801/d01b3b9b-7307-4a0e-a67b-d843db05b1e7)
