### PR TITLE
Revert "Removed useless polyfills (#1056)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ master
 - Improved types etc @aivchen #1064 #1064 #1070 #1071 #1074 #1081...
 - Improved tests @aivchen
 - Improved code-style @aivchen #1057 #1076 #1070
-- Removed useless polyfills @aivchen
 
 1.2.15
 ------

--- a/composer.json
+++ b/composer.json
@@ -49,10 +49,6 @@
         "symfony/error-handler": "^6.1 || ^7.0",
         "symfony/var-dumper": "^6.1 || ^7.0"
     },
-    "replace": {
-        "symfony/polyfill-php80": "*",
-        "symfony/polyfill-php81": "*"
-    },
     "suggest": {
         "ext-xdebug": "For Xdebug profiling extension."
     },


### PR DESCRIPTION
This reverts commit 3a9e8836ed264c0efac6651c0e20bede9ace2ecc.

Defauly Symfony projects already `replace` all teh polyfills, leading to an error that can onoly be solved by removing the `replace` in the consuming project:

```
composer update
Loading composer repositories with package information
Restricting packages listed in "symfony/symfony" to "7.0.*"
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - __root__ is present at version dev-main and cannot be modified by Composer
    - phpbench/phpbench[dev-master, 1.2.x-dev] cannot be installed as that would require removing __root__[dev-main]. They both replace symfony/polyfill-php81 and thus cannot coexist.
    - Root composer.json requires phpbench/phpbench dev-master -> satisfiable by phpbench/phpbench[dev-master].
    - ```
```

I'm not sure if there's another way to fix this, but I think it woudl be better to revert this commit for now.