### PR TITLE
Config Initialization command and extend Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 master
 ------
 
+- Add command to initialize the configuration file (`config:init`) @dantleech
+- Add command to add a new service config based on a prototype (`config:extend`) @dantleech
 - Ignore `@template` and other generic annotations #1097 @dantleech
 - Hide noisy log messages for missing fields #1095 @dantleech
 - Defer character reader until command execution @jbboher #1092

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -84,6 +84,12 @@ Create a ``phpbench.json`` file in the projects root directory:
         "runner.bootstrap": "vendor/autoload.php"
     }
 
+.. note::
+
+    You can also run `phpbench config:init` to automatically create an
+    **empty** config file, but you will need to manually set the
+    `runner.bootstrap` option.
+
 Above we also added the optional ``$schema`` which should enable auto-completion and
 validation in your IDE.
 

--- a/lib/Config/ConfigManipulator.php
+++ b/lib/Config/ConfigManipulator.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace PhpBench\Config;
+
+use RuntimeException;
+use stdClass;
+
+final class ConfigManipulator
+{
+    public function __construct(private string $schemaPath, private string $configPath)
+    {
+    }
+
+    public function configPath(): string
+    {
+        return $this->configPath;
+    }
+
+    public function initialize(): void
+    {
+        $json = $this->openConfig();
+        $json->{'$schema'} = $this->schemaPath;
+        $this->writeConfig($json);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function set(string $key, $value): void
+    {
+        $json = $this->openConfig();
+        $json->{$key} = $value;
+        $this->writeConfig($json);
+    }
+
+    public function delete(string $key): void
+    {
+        $json = $this->openConfig();
+        unset($json->{$key});
+        $this->writeConfig($json);
+    }
+
+    private function createConfig(): string
+    {
+        $value = [ '$schema' => $this->schemaPath ];
+
+        return json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+    }
+
+    private function openConfig(): stdClass
+    {
+        if (!file_exists($this->configPath)) {
+            if (false === file_put_contents($this->configPath, $this->createConfig())) {
+                throw new RuntimeException(sprintf(
+                    'Could not write config file to "%s"',
+                    $this->configPath
+                ));
+            }
+        }
+
+        $config = file_get_contents($this->configPath);
+
+        if (false === $config) {
+            throw new RuntimeException(sprintf(
+                'Could not read config file "%s"',
+                $this->configPath
+            ));
+        }
+
+        $json = json_decode($config);
+
+        if (!$json instanceof stdClass) {
+            throw new RuntimeException(sprintf(
+                'Could not decode JSON file "%s"',
+                $this->configPath
+            ));
+        }
+
+        return $json;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function writeConfig($value): void
+    {
+        file_put_contents($this->configPath, json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+
+    /**
+     * @param array<mixed> $value
+     */
+    public function merge(string $key, array $value): void
+    {
+        $config = $this->openConfig();
+
+        if (!isset($config->{$key})) {
+            $config->{$key} = new stdClass();
+        }
+
+        if (!is_object($config->{$key})) {
+            throw new RuntimeException(sprintf(
+                'Cannot merge value on a non-object (%s) for key: %s',
+                get_debug_type($config->{$key}),
+                $key
+            ));
+        }
+        $array = (array)$config->{$key};
+        $config->{$key} = array_merge($array, $value);
+        $this->writeConfig($config);
+    }
+
+}

--- a/lib/Console/Command/ConfigExtendCommand.php
+++ b/lib/Console/Command/ConfigExtendCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace PhpBench\Console\Command;
+
+use PhpBench\Config\ConfigManipulator;
+use PhpBench\Registry\ConfigurableRegistry;
+use PhpBench\Registry\Registries;
+use RuntimeException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class ConfigExtendCommand extends Command
+{
+    public const ARG_REGISTRY = 'registry';
+    public const ARG_PROTOTYPE = 'prototype';
+    private const ARG_NAME = 'name';
+
+
+    public function __construct(
+        private ConfigManipulator $manipulator,
+        private Registries $registries,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setName('config:extend');
+        $this->setDescription('Generate a new service configuration baesd on a named prototype');
+        $this->addArgument(self::ARG_REGISTRY, InputArgument::REQUIRED, 'Registry name, e.g. "generator"');
+        $this->addArgument(self::ARG_PROTOTYPE, InputArgument::REQUIRED, 'Prototype service, e.g. "default"');
+        $this->addArgument(self::ARG_NAME, InputArgument::REQUIRED, 'New service name, e.g. "acme"');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $registryName = $input->getArgument(self::ARG_REGISTRY);
+        $serviceName = $input->getArgument(self::ARG_PROTOTYPE);
+        $name = $input->getArgument(self::ARG_NAME);
+
+        $registry = $this->registries->get($registryName);
+
+        if (!$registry instanceof ConfigurableRegistry) {
+            throw new RuntimeException('Service is not configurable');
+        }
+
+        $service = $registry->getConfig($serviceName);
+        $this->manipulator->merge(
+            $registry->getOptionName(),
+            [
+                $name => $service->getArrayCopy(),
+            ],
+        );
+        $output->writeln(sprintf('<info>Updated:</> %s', $this->manipulator->configPath()));
+        $output->writeln(sprintf(
+            '<info>Set </>%s<info> named </>%s</info> <info>based on </>%s<info> at</> %s',
+            $registryName,
+            $name,
+            $serviceName,
+            $registry->getOptionName(),
+        ));
+
+        return 0;
+    }
+}

--- a/lib/Console/Command/ConfigInitCommand.php
+++ b/lib/Console/Command/ConfigInitCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace PhpBench\Console\Command;
+
+use Phar;
+use PhpBench\Config\ConfigManipulator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class ConfigInitCommand extends Command
+{
+    public function __construct(private ConfigManipulator $initializer)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setName('config:initialize');
+        $this->setDescription('Initialize the configuration file or update the location of the JSON schema');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->writeln('<comment>// This command creates (or updates) the config ensuring the JSON $schema is set</comment>.');
+
+        if (class_exists(Phar::class) && Phar::running() !== '') {
+            $output->writeln(
+                <<<EOT
+                This command is not supported in the Phar environment as the
+                schema file cannot be directly referenced from the JSON file.
+                EOT
+            );
+
+            return 1;
+        }
+
+        $created = !file_exists($this->initializer->configPath());
+        $this->initializer->initialize();
+
+        if ($created) {
+            $output->writeln(sprintf('Created %s', $this->initializer->configPath()));
+
+            return 0;
+        }
+
+        $output->writeln(sprintf('<info>Updated:</> %s', $this->initializer->configPath()));
+
+        return 0;
+    }
+}

--- a/lib/Extension/ReportExtension.php
+++ b/lib/Extension/ReportExtension.php
@@ -165,7 +165,8 @@ class ReportExtension implements ExtensionInterface
                 $registry = new ConfigurableRegistry(
                     $registryType,
                     $container,
-                    $container->get(JsonDecoder::class)
+                    $container->get(JsonDecoder::class),
+                    $optionName,
                 );
 
                 foreach ($container->getServiceIdsForTag('report.' . $registryType) as $serviceId => $attributes) {
@@ -182,7 +183,11 @@ class ReportExtension implements ExtensionInterface
                 }
 
                 return $registry;
-            });
+            }, [
+                CoreExtension::TAG_REGISTRY => [
+                    'name' => $registryType,
+                ]
+            ]);
         }
     }
 

--- a/lib/Extension/RunnerExtension.php
+++ b/lib/Extension/RunnerExtension.php
@@ -536,7 +536,8 @@ class RunnerExtension implements ExtensionInterface
             $registry = new ConfigurableRegistry(
                 'executor',
                 $container,
-                $container->get(JsonDecoder::class)
+                $container->get(JsonDecoder::class),
+                self::PARAM_EXECUTORS,
             );
 
             foreach ($container->getServiceIdsForTag(self::TAG_EXECUTOR) as $serviceId => $attributes) {

--- a/lib/Registry/ConfigurableRegistry.php
+++ b/lib/Registry/ConfigurableRegistry.php
@@ -51,6 +51,7 @@ class ConfigurableRegistry extends Registry
         string $serviceType,
         Container $container,
         private readonly JsonDecoder $jsonDecoder,
+        private string $optionName,
         array $nameToServiceIdMap = []
     ) {
         parent::__construct($serviceType, $container);
@@ -58,6 +59,11 @@ class ConfigurableRegistry extends Registry
         foreach ($nameToServiceIdMap as $name => $serviceId) {
             $this->registerService($name, $serviceId);
         }
+    }
+
+    public function getOptionName(): string
+    {
+        return $this->optionName;
     }
 
     /**

--- a/lib/Registry/Registries.php
+++ b/lib/Registry/Registries.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace PhpBench\Registry;
+
+use RuntimeException;
+
+final class Registries
+{
+    /**
+     * @param array<string,Registry<object>> $registries
+     */
+    public function __construct(private array $registries)
+    {
+    }
+    /**
+     * @return Registry<object>
+     */
+    public function get(string $name): Registry
+    {
+        if (!isset($this->registries[$name])) {
+            throw new RuntimeException(sprintf(
+                'Registry "%s" not found, known registries: "%s"',
+                $name,
+                implode('", "', array_keys($this->registries))
+            ));
+        }
+
+        return $this->registries[$name];
+    }
+}

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "./phpbench.schema.json",
+    "$schema": "phpbench.schema.json",
     "$include-glob": "examples/Benchmark/*/*.json",
     "runner.file_pattern": "*Bench.php",
     "core.extensions": [

--- a/tests/System/ConfigExtendCommandTest.php
+++ b/tests/System/ConfigExtendCommandTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace PhpBench\Tests\System;
+
+use stdClass;
+
+class ConfigExtendCommandTest extends SystemTestCase
+{
+    public function testExtend(): void
+    {
+        $this->workspace()->reset();
+        $this->phpbench('config:initialize');
+        $config = $this->getDecodedConfig();
+        $process = $this->phpbench('config:extend generator expression test');
+        self::assertExitCode(0, $process);
+
+        $config = $this->getDecodedConfig();
+        self::assertIsObject($config->{'report.generators'});
+        self::assertIsObject($config->{'report.generators'}->{'test'});
+
+        $process = $this->phpbench(
+            [
+                'run',
+                __DIR__ . '/benchmarks/set4/NothingBench.php',
+                '--report=test',
+                '--iterations=1',
+                '--revs=1'
+            ]
+        );
+
+        self::assertExitCode(0, $process);
+    }
+
+    private function getDecodedConfig(): stdClass
+    {
+        return json_decode($this->workspace()->getContents('phpbench.json'));
+    }
+}

--- a/tests/System/ConfigInitCommandTest.php
+++ b/tests/System/ConfigInitCommandTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the PHPBench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace PhpBench\Tests\System;
+
+class ConfigInitCommandTest extends SystemTestCase
+{
+    public function testInitialize(): void
+    {
+        $this->workspace()->reset();
+        $process = $this->phpbench(
+            'config:initialize',
+        );
+        self::assertEquals(0, $process->getExitCode());
+        $output = $process->getErrorOutput();
+        self::assertStringContainsString('Created', $output);
+    }
+}

--- a/tests/System/SystemTestCase.php
+++ b/tests/System/SystemTestCase.php
@@ -55,23 +55,32 @@ class SystemTestCase extends IntegrationTestCase
         return $document;
     }
 
-    public function phpbench(string $command, ?string $cwd = null): Process
+    /**
+     * @param list<string>|string $command
+     */
+    public function phpbench(array|string $command, ?string $cwd = null): Process
     {
         $cwd = $this->workspace()->path($cwd);
 
-        $bin = __DIR__ . '/../../bin/phpbench --verbose --no-ansi';
-        $process = Process::fromShellCommandline($bin . ' ' . $command, $cwd);
+        $bin = __DIR__ . '/../../bin/phpbench';
+
+        if (is_array($command)) {
+            $process = new Process([$bin, ...$command], $cwd);
+        } else {
+            $bin .= ' --verbose --no-ansi';
+            $process = Process::fromShellCommandline($bin . ' ' . $command, $cwd);
+        }
         $process->run();
 
         return $process;
     }
 
-    protected function assertExitCode(int $expected, Process $process): void
+    protected static function assertExitCode(int $expected, Process $process): void
     {
         $exitCode = $process->getExitCode();
 
         if ($exitCode !== $expected) {
-            $this->fail(sprintf(
+            self::fail(sprintf(
                 'Expected exit code "%s" from "%s" but got "%s": STDOUT: %s ERR: %s',
                 $expected,
                 $process->getCommandLine(),
@@ -81,7 +90,7 @@ class SystemTestCase extends IntegrationTestCase
             ));
         }
 
-        $this->assertEquals($expected, $exitCode);
+        self::assertEquals($expected, $exitCode);
     }
 
     protected function assertXPathCount(int $count, string $xmlString, string $query): void

--- a/tests/Unit/Config/ConfigManipulatorTest.php
+++ b/tests/Unit/Config/ConfigManipulatorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace PhpBench\Tests\Unit\Config;
+
+use PHPUnit\Framework\TestCase;
+use PhpBench\Config\ConfigManipulator;
+use PhpBench\Tests\Util\Workspace;
+
+class ConfigManipulatorTest extends TestCase
+{
+    private Workspace $workspace;
+
+    protected function setUp(): void
+    {
+        $this->workspace = new Workspace(__DIR__ . '/../../Workspace');
+        $this->workspace->reset();
+    }
+
+    public function testCreateNewConfig(): void
+    {
+        self::assertFileDoesNotExist($this->workspace->path('phpbench.json'));
+
+        $schemaPath = 'path/to/json.schema';
+        $this->createManipulator($schemaPath)->initialize();
+
+        self::assertFileExists($this->workspace->path('phpbench.json'));
+        $contents = $this->workspace->getContents('phpbench.json');
+        self::assertJson($contents);
+        $config = json_decode($contents, true, JSON_THROW_ON_ERROR);
+        self::assertEquals($schemaPath, $config['$schema']);
+    }
+
+    public function testManipulateConfig(): void
+    {
+        $manipulator = $this->createManipulator();
+        $manipulator->initialize();
+        $manipulator->set('foo', ['bar' => 'baz']);
+        $manipulator->set('bar', 12);
+        $manipulator->delete('bar');
+
+        $contents = $this->workspace->getContents('phpbench.json');
+        $config = json_decode($contents, true, JSON_THROW_ON_ERROR);
+        self::assertArrayHasKey('foo', $config);
+        self::assertArrayNotHasKey('bar', $config);
+    }
+
+    public function testMergeToNonExisting(): void
+    {
+        $manipulator = $this->createManipulator();
+        $manipulator->initialize();
+        $manipulator->merge('foo', ['bar' => 'baz']);
+
+        $contents = $this->workspace->getContents('phpbench.json');
+        $config = json_decode($contents, true, JSON_THROW_ON_ERROR);
+        self::assertArrayHasKey('foo', $config);
+        self::assertEquals(['bar' => 'baz'], $config['foo']);
+    }
+
+    public function testMergeToExisting(): void
+    {
+        $manipulator = $this->createManipulator();
+        $manipulator->initialize();
+        $manipulator->set('foo', ['baz' => 'boo']);
+        $manipulator->merge('foo', ['bar' => 'baz']);
+
+        $contents = $this->workspace->getContents('phpbench.json');
+        $config = json_decode($contents, true, JSON_THROW_ON_ERROR);
+        self::assertArrayHasKey('foo', $config);
+        self::assertEquals([
+            'bar' => 'baz',
+            'baz' => 'boo',
+        ], $config['foo']);
+    }
+
+    private function createManipulator(string $schemaPath = 'path/to/json.schema'): ConfigManipulator
+    {
+        return (new ConfigManipulator(
+            $schemaPath,
+            $this->workspace->path('phpbench.json')
+        ));
+    }
+}

--- a/tests/Unit/Registry/ConfigurableRegistryTest.php
+++ b/tests/Unit/Registry/ConfigurableRegistryTest.php
@@ -35,7 +35,8 @@ class ConfigurableRegistryTest extends RegistryTest
         $configurableRegistry = new ConfigurableRegistry(
             'test',
             $this->container->reveal(),
-            new JsonDecoder()
+            new JsonDecoder(),
+            'test.option',
         );
         $this->registry = $configurableRegistry;
     }


### PR DESCRIPTION
- Add a command which creates (or updates) a `phpbench.json` file with a populated `$schema`.
- Adds a command to extend an existing service

![image](https://github.com/phpbench/phpbench/assets/530801/5733b27d-fe46-41b2-87f9-16f47a517ebd)

![image](https://github.com/phpbench/phpbench/assets/530801/fbaf86b3-835c-4e0c-884c-d732aa025a8a)