### PR TITLE
Experimental Opcache flag

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -218,6 +218,28 @@ Default: ``[]``
 
 Types: ``["array"]``
 
+.. _configuration_runner_php_opcache:
+
+runner.php_opcache
+~~~~~~~~~~~~~~~~~~
+
+Enable PHP opcache when executing out-of-band benchmarks
+
+Default: ``false``
+
+Types: ``["bool"]``
+
+.. _configuration_runner_php_opcache_dir:
+
+runner.php_opcache_dir
+~~~~~~~~~~~~~~~~~~~~~~
+
+
+
+Default: ``.phpbench/opcache``
+
+Types: ``["string"]``
+
 .. _configuration_runner_php_disable_ini:
 
 runner.php_disable_ini

--- a/lib/Benchmark/Feature/OpcacheFeature.php
+++ b/lib/Benchmark/Feature/OpcacheFeature.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace PhpBench\Benchmark\Feature;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+final class OpcacheFeature
+{
+    public function __construct(
+        private Filesystem $filesystem,
+        private readonly bool $opcache,
+        private readonly ?string $opcacheDir,
+    ) {
+    }
+
+    public function enable(): bool
+    {
+        return $this->opcache;
+    }
+
+    /**
+     * @return array<string,scalar>
+     */
+    public function phpConfig(): array
+    {
+        return [
+            'opcache.enable_cli' => true,
+            'opcache.file_cache' => $this->opcacheDir(),
+        ];
+    }
+
+    private function opcacheDir(): string
+    {
+        if (!file_exists($this->opcacheDir)) {
+            $this->filesystem->mkdir($this->opcacheDir);
+        }
+
+        return $this->opcacheDir;
+    }
+}

--- a/lib/Benchmark/Feature/OpcacheFeature.php
+++ b/lib/Benchmark/Feature/OpcacheFeature.php
@@ -37,4 +37,9 @@ final class OpcacheFeature
 
         return $this->opcacheDir;
     }
+
+    public static function disabled(): self
+    {
+        return new self(new Filesystem(), false, '');
+    }
 }

--- a/lib/Benchmark/RunnerConfig.php
+++ b/lib/Benchmark/RunnerConfig.php
@@ -18,7 +18,7 @@ use PhpBench\Model\SuiteCollection;
 /**
  * The benchmark runner context.
  */
-class RunnerConfig
+/** final */class RunnerConfig
 {
     /** @var string|array<string,mixed> */
     private string|array $executor = 'remote';
@@ -62,6 +62,8 @@ class RunnerConfig
 
     /** @var string[] */
     private array $variantFilters = [];
+
+    private bool $opcache;
 
     private function __construct()
     {
@@ -458,5 +460,12 @@ class RunnerConfig
             $field,
             $value
         ));
+    }
+
+    public function withOpcache(bool $opcache): self
+    {
+        $this->opcache = true;
+
+        return $this;
     }
 }

--- a/lib/Console/Command/Handler/RunnerHandler.php
+++ b/lib/Console/Command/Handler/RunnerHandler.php
@@ -42,6 +42,7 @@ class RunnerHandler
     final public const OPT_PHP_DISABLE_INI = 'php-disable-ini';
     final public const OPT_FORMAT = 'format';
     final public const OPT_VARIANT_FILTER = 'variant';
+    final public const OPT_OPCACHE = 'opcache';
 
     public function __construct(
         private readonly Runner $runner,
@@ -82,6 +83,7 @@ class RunnerHandler
         $command->addOption(self::OPT_PHP_CONFIG, null, InputOption::VALUE_REQUIRED, 'JSON-like object of PHP INI settings');
         $command->addOption(self::OPT_PHP_WRAPPER, null, InputOption::VALUE_REQUIRED, 'Prefix process launch command with this string');
         $command->addOption(self::OPT_PHP_DISABLE_INI, null, InputOption::VALUE_NONE, 'Do not load the PHP INI file');
+        $command->addOption(self::OPT_OPCACHE, null, InputOption::VALUE_NONE, 'Enable opcache');
     }
 
     public function runFromInput(InputInterface $input, OutputInterface $output, RunnerConfig $config): Suite

--- a/lib/Console/Command/Handler/RunnerHandler.php
+++ b/lib/Console/Command/Handler/RunnerHandler.php
@@ -94,6 +94,7 @@ class RunnerHandler
             ->withStopOnError($input->getOption(self::OPT_STOP_ON_ERROR))
             ->withAssertions($input->getOption(self::OPT_ASSERT))
             ->withVariantFilters($input->getOption(self::OPT_VARIANT_FILTER))
+            ->withOpcache($input->getOption(self::OPT_OPCACHE))
             ->withFormat($input->getOption(self::OPT_FORMAT));
 
         $parameters = $this->getParameters($input->getOption(self::OPT_PARAMETERS));

--- a/lib/Console/Command/Handler/RunnerHandler.php
+++ b/lib/Console/Command/Handler/RunnerHandler.php
@@ -42,7 +42,7 @@ class RunnerHandler
     final public const OPT_PHP_DISABLE_INI = 'php-disable-ini';
     final public const OPT_FORMAT = 'format';
     final public const OPT_VARIANT_FILTER = 'variant';
-    final public const OPT_OPCACHE = 'opcache';
+    final public const OPT_OPCACHE = 'php-opcache';
 
     public function __construct(
         private readonly Runner $runner,

--- a/lib/Extension/RunnerExtension.php
+++ b/lib/Extension/RunnerExtension.php
@@ -2,6 +2,7 @@
 
 namespace PhpBench\Extension;
 
+use PhpBench\Benchmark\Feature\OpcacheFeature;
 use PhpBench\Environment\Provider\Uname;
 use PhpBench\Environment\Provider\Php;
 use PhpBench\Environment\Provider\Opcache;
@@ -43,6 +44,7 @@ use PhpBench\Expression\ExpressionLanguage;
 use PhpBench\Expression\Printer;
 use PhpBench\Expression\Printer\EvaluatingPrinter;
 use PhpBench\Json\JsonDecoder;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 use PhpBench\Progress\Logger\BlinkenLogger;
 use PhpBench\Progress\Logger\DotsLogger;
@@ -88,6 +90,8 @@ class RunnerExtension implements ExtensionInterface
     final public const PARAM_PHP_BINARY = 'runner.php_binary';
     final public const PARAM_PHP_CONFIG = 'runner.php_config';
     final public const PARAM_PHP_DISABLE_INI = 'runner.php_disable_ini';
+    final public const PARAM_PHP_OPCACHE = 'runner.php_opcache';
+    final public const PARAM_PHP_OPCACHE_DIR = 'runner.php_opcache_dir';
     final public const PARAM_PHP_WRAPPER = 'runner.php_wrapper';
     final public const PARAM_PHP_ENV = 'runner.php_env';
     final public const PARAM_PROGRESS = 'runner.progress';
@@ -137,6 +141,8 @@ class RunnerExtension implements ExtensionInterface
             self::PARAM_PATH => null,
             self::PARAM_PHP_BINARY => null,
             self::PARAM_PHP_CONFIG => [],
+            self::PARAM_PHP_OPCACHE => false,
+            self::PARAM_PHP_OPCACHE_DIR => '.phpbench/opcache',
             self::PARAM_PHP_DISABLE_INI => false,
             self::PARAM_PHP_WRAPPER => null,
             self::PARAM_PHP_ENV => null,
@@ -170,6 +176,7 @@ class RunnerExtension implements ExtensionInterface
         $resolver->setAllowedTypes(self::PARAM_PATH, ['string', 'array', 'null']);
         $resolver->setAllowedTypes(self::PARAM_PHP_BINARY, ['string', 'null']);
         $resolver->setAllowedTypes(self::PARAM_PHP_CONFIG, ['array']);
+        $resolver->setAllowedTypes(self::PARAM_PHP_OPCACHE, ['bool']);
         $resolver->setAllowedTypes(self::PARAM_PHP_DISABLE_INI, ['bool']);
         $resolver->setAllowedTypes(self::PARAM_PHP_WRAPPER, ['string', 'null']);
         $resolver->setAllowedTypes(self::PARAM_PHP_ENV, ['array', 'null']);
@@ -203,6 +210,7 @@ class RunnerExtension implements ExtensionInterface
             self::PARAM_PATH => 'Path or paths to the benchmarks',
             self::PARAM_PHP_BINARY => 'Specify a PHP binary to use when executing out-of-band benchmarks, e.g. ``/usr/bin/php6``, defaults to the version of PHP used to invoke PHPBench',
             self::PARAM_PHP_CONFIG => 'Map of PHP ini settings to use when executing out-of-band benchmarks',
+            self::PARAM_PHP_OPCACHE => 'Enable PHP opcache when executing out-of-band benchmarks',
             self::PARAM_PHP_DISABLE_INI => 'Disable reading the default PHP configuration',
             self::PARAM_PHP_WRAPPER => 'Wrap the PHP binary with this command (e.g. ``blackfire run``)',
             self::PARAM_PHP_ENV => 'Key-value set of environment variables to pass to the PHP process',
@@ -402,7 +410,19 @@ class RunnerExtension implements ExtensionInterface
                 $container->hasParameter(self::PARAM_PHP_BINARY) ? $container->getParameter(self::PARAM_PHP_BINARY) : null,
                 $container->hasParameter(self::PARAM_PHP_CONFIG) ? $container->getParameter(self::PARAM_PHP_CONFIG) : null,
                 $container->hasParameter(self::PARAM_PHP_WRAPPER) ? $container->getParameter(self::PARAM_PHP_WRAPPER) : null,
-                $container->hasParameter(self::PARAM_PHP_DISABLE_INI) ? $container->getParameter(self::PARAM_PHP_DISABLE_INI) : false
+                $container->hasParameter(self::PARAM_PHP_DISABLE_INI) ? $container->getParameter(self::PARAM_PHP_DISABLE_INI) : false,
+                new OpcacheFeature(
+                    new Filesystem(),
+                    $container->hasParameter(
+                        self::PARAM_PHP_OPCACHE
+                    ) ? $container->getParameter(self::PARAM_PHP_OPCACHE) : false,
+                    $container->hasParameter(
+                        self::PARAM_PHP_OPCACHE_DIR
+                    ) ? Path::makeAbsolute(
+                        $container->getParameter(self::PARAM_PHP_OPCACHE_DIR),
+                        $container->getParameter(CoreExtension::PARAM_WORKING_DIR),
+                    ) : false,
+                ),
             );
         });
 

--- a/lib/Extension/RunnerExtension.php
+++ b/lib/Extension/RunnerExtension.php
@@ -177,6 +177,7 @@ class RunnerExtension implements ExtensionInterface
         $resolver->setAllowedTypes(self::PARAM_PHP_BINARY, ['string', 'null']);
         $resolver->setAllowedTypes(self::PARAM_PHP_CONFIG, ['array']);
         $resolver->setAllowedTypes(self::PARAM_PHP_OPCACHE, ['bool']);
+        $resolver->setAllowedTypes(self::PARAM_PHP_OPCACHE_DIR, ['string']);
         $resolver->setAllowedTypes(self::PARAM_PHP_DISABLE_INI, ['bool']);
         $resolver->setAllowedTypes(self::PARAM_PHP_WRAPPER, ['string', 'null']);
         $resolver->setAllowedTypes(self::PARAM_PHP_ENV, ['array', 'null']);

--- a/lib/PhpBench.php
+++ b/lib/PhpBench.php
@@ -15,6 +15,8 @@ namespace PhpBench;
 use Composer\InstalledVersions;
 use PhpBench\Config\ConfigLoader;
 use PhpBench\Console\Application;
+use PhpBench\Console\Command\Handler\RunnerHandler;
+use PhpBench\Console\Command\RunCommand;
 use PhpBench\DependencyInjection\Container;
 use PhpBench\Exception\ConfigurationPreProcessingError;
 use PhpBench\Extension\ConsoleExtension;
@@ -131,6 +133,10 @@ class PhpBench
 
         if ($input->hasParameterOption(['--php-disable-ini'])) {
             $configOverride[RunnerExtension::PARAM_PHP_DISABLE_INI] = true;
+        }
+
+        if ($input->hasParameterOption(['--' . RunnerHandler::OPT_OPCACHE])) {
+            $configOverride[RunnerExtension::PARAM_PHP_OPCACHE] = true;
         }
 
         if ($value = $input->getParameterOption(['--profile'])) {

--- a/lib/PhpBench.php
+++ b/lib/PhpBench.php
@@ -16,7 +16,6 @@ use Composer\InstalledVersions;
 use PhpBench\Config\ConfigLoader;
 use PhpBench\Console\Application;
 use PhpBench\Console\Command\Handler\RunnerHandler;
-use PhpBench\Console\Command\RunCommand;
 use PhpBench\DependencyInjection\Container;
 use PhpBench\Exception\ConfigurationPreProcessingError;
 use PhpBench\Extension\ConsoleExtension;

--- a/lib/Remote/Launcher.php
+++ b/lib/Remote/Launcher.php
@@ -14,8 +14,6 @@ namespace PhpBench\Remote;
 
 use InvalidArgumentException;
 use PhpBench\Benchmark\Feature\OpcacheFeature;
-use RuntimeException;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\PhpExecutableFinder;
 
@@ -29,6 +27,8 @@ class Launcher
 
     private readonly ExecutableFinder $finder;
 
+    private readonly OpcacheFeature $opcacheFeature;
+
     /**
      * @param array<string, scalar|scalar[]> $phpConfig
      */
@@ -40,10 +40,11 @@ class Launcher
         private readonly array $phpConfig = [],
         private readonly ?string $phpWrapper = null,
         private readonly bool $phpDisableIni = false,
-        private readonly ?OpcacheFeature $opcacheFeature = null,
+        ?OpcacheFeature $opcacheFeature = null,
     ) {
         $this->payloadFactory = $payloadFactory ?: new PayloadFactory();
         $this->finder = $finder ?: new ExecutableFinder();
+        $this->opcacheFeature = $opcacheFeature ?: OpcacheFeature::disabled();
     }
 
     /**

--- a/lib/Remote/Launcher.php
+++ b/lib/Remote/Launcher.php
@@ -13,6 +13,9 @@
 namespace PhpBench\Remote;
 
 use InvalidArgumentException;
+use PhpBench\Benchmark\Feature\OpcacheFeature;
+use RuntimeException;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\PhpExecutableFinder;
 
@@ -36,7 +39,8 @@ class Launcher
         private readonly ?string $phpBinary = null,
         private readonly array $phpConfig = [],
         private readonly ?string $phpWrapper = null,
-        private readonly bool $phpDisableIni = false
+        private readonly bool $phpDisableIni = false,
+        private readonly ?OpcacheFeature $opcacheFeature = null,
     ) {
         $this->payloadFactory = $payloadFactory ?: new PayloadFactory();
         $this->finder = $finder ?: new ExecutableFinder();
@@ -70,6 +74,10 @@ class Launcher
 
         if ($this->phpConfig) {
             $payload->mergePhpConfig($this->phpConfig);
+        }
+
+        if ($this->opcacheFeature->enable()) {
+            $payload->mergePhpConfig($this->opcacheFeature->phpConfig());
         }
 
         if (true === $this->phpDisableIni) {

--- a/phpbench.schema.json
+++ b/phpbench.schema.json
@@ -125,6 +125,18 @@
                 "object"
             ]
         },
+        "runner.php_opcache": {
+            "description": "Enable PHP opcache when executing out-of-band benchmarks",
+            "type": [
+                "boolean"
+            ]
+        },
+        "runner.php_opcache_dir": {
+            "description": null,
+            "type": [
+                "string"
+            ]
+        },
         "runner.php_disable_ini": {
             "description": "Disable reading the default PHP configuration",
             "type": [

--- a/tests/System/RunTest.php
+++ b/tests/System/RunTest.php
@@ -704,7 +704,7 @@ class RunTest extends SystemTestCase
 
     public function testOpcache(): void
     {
-        $process = $this->phpbench('run benchmarks/set4/NothingBench.php --opcache');
+        $process = $this->phpbench('run benchmarks/set4/NothingBench.php --php-opcache');
         $this->assertExitCode(0, $process);
         self::assertStringContainsString('opcache', $process->getErrorOutput());
     }

--- a/tests/System/RunTest.php
+++ b/tests/System/RunTest.php
@@ -706,6 +706,6 @@ class RunTest extends SystemTestCase
     {
         $process = $this->phpbench('run benchmarks/set4/NothingBench.php --opcache');
         $this->assertExitCode(0, $process);
-        self::assertStringContainsString('Spawning', $process->getErrorOutput());
+        self::assertStringContainsString('opcache', $process->getErrorOutput());
     }
 }

--- a/tests/System/RunTest.php
+++ b/tests/System/RunTest.php
@@ -701,4 +701,11 @@ class RunTest extends SystemTestCase
         $this->assertExitCode(255, $process);
         self::assertStringContainsString('Unknown theme', $process->getErrorOutput());
     }
+
+    public function testOpcache(): void
+    {
+        $process = $this->phpbench('run benchmarks/set4/NothingBench.php --opcache');
+        $this->assertExitCode(0, $process);
+        self::assertStringContainsString('Spawning', $process->getErrorOutput());
+    }
 }


### PR DESCRIPTION
Add a flag to enable opcache on the CLI.

- Overrides the PHP config to `opcache.enable_cli`
- Sets `opcache.file_cache` directory and `opcache.file_cache_only` (is "only" needed?)

TODO:

- Current opcache "status" is misleading as it will be :heavy_check_mark:  when `opcache.enable` is true, but on CLI there is no opcache unless `enable_cli` is set.
- allow opcache to be _disabled_ as well as enabled 