### PR TITLE
Fix typo error on `config:extend` command help description

### DIFF
--- a/lib/Console/Command/ConfigExtendCommand.php
+++ b/lib/Console/Command/ConfigExtendCommand.php
@@ -28,7 +28,7 @@ final class ConfigExtendCommand extends Command
     protected function configure(): void
     {
         $this->setName('config:extend');
-        $this->setDescription('Generate a new service configuration baesd on a named prototype');
+        $this->setDescription('Generate a new service configuration based on a named prototype');
         $this->addArgument(self::ARG_REGISTRY, InputArgument::REQUIRED, 'Registry name, e.g. "generator"');
         $this->addArgument(self::ARG_PROTOTYPE, InputArgument::REQUIRED, 'Prototype service, e.g. "default"');
         $this->addArgument(self::ARG_NAME, InputArgument::REQUIRED, 'New service name, e.g. "acme"');


### PR DESCRIPTION
When we run `phpbench` without any arguments, the help panel is displayed and we can read 

```
 config
  config:extend         Generate a new service configuration baesd on a named prototype
```

Typo error on `based` 