### PR TITLE
Use tagged version of prophecy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "ergebnis/composer-normalize": "^2.39",
         "friendsofphp/php-cs-fixer": "^3.0",
         "jangregor/phpstan-prophecy": "^1.0",
-        "phpspec/prophecy": "dev-master",
+        "phpspec/prophecy": "^1.22",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",


### PR DESCRIPTION
When `dev-master` was required it was because the latest tag did not work.