### PR TITLE
feat: Assouplissement des dépendances de Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,20 +23,19 @@
         "ext-reflection": "*",
         "ext-spl": "*",
         "ext-tokenizer": "*",
-        "doctrine/annotations": "^2.0",
+        "doctrine/annotations": "^1.0 || ^2.0",
         "phpbench/container": "^2.2",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "seld/jsonlint": "^1.1",
-        "symfony/console": "^6.1 || ^7.0",
-        "symfony/filesystem": "^6.1 || ^7.0",
-        "symfony/finder": "^6.1 || ^7.0",
-        "symfony/options-resolver": "^6.1 || ^7.0",
-        "symfony/process": "^6.1 || ^7.0",
+        "symfony/console": "^5.4 || ^6.1 || ^7.0",
+        "symfony/filesystem": "^5.4 || ^6.1 || ^7.0",
+        "symfony/finder": "^5.4 || ^6.1 || ^7.0",
+        "symfony/options-resolver": "^5.4 || ^6.1 || ^7.0",
+        "symfony/process": "^5.4 || ^6.1 || ^7.0",
         "webmozart/glob": "^4.6"
     },
     "require-dev": {
         "dantleech/invoke": "^2.0",
-        "ergebnis/composer-normalize": "^2.39",
         "friendsofphp/php-cs-fixer": "^3.0",
         "jangregor/phpstan-prophecy": "^1.0",
         "phpspec/prophecy": "^1.22",
@@ -45,8 +44,8 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^10.4 || ^11.0",
         "rector/rector": "^1.2",
-        "symfony/error-handler": "^6.1 || ^7.0",
-        "symfony/var-dumper": "^6.1 || ^7.0"
+        "symfony/error-handler": "^5.4 || ^6.1 || ^7.0",
+        "symfony/var-dumper": "^5.4 || ^6.1 || ^7.0"
     },
     "suggest": {
         "ext-xdebug": "For Xdebug profiling extension."
@@ -74,7 +73,6 @@
     ],
     "config": {
         "allow-plugins": {
-            "ergebnis/composer-normalize": true,
             "phpstan/extension-installer": true
         },
         "sort-packages": true


### PR DESCRIPTION
- Assouplissement des contraintes de version pour les composants Symfony et Doctrine afin de permettre une meilleure compatibilité avec d'autres projets.
- Suppression de la dépendance de développement `ergebnis/composer-normalize` pour éviter les conflits potentiels.