### PR TITLE
Add Rector extension for refactoring PHPBench annotations to attributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
     "autoload": {
         "psr-4": {
             "PhpBench\\": "lib/",
+            "PhpBench\\Extensions\\Rector\\": "extensions/rector/lib/",
             "PhpBench\\Extensions\\XDebug\\": "extensions/xdebug/lib/"
         },
         "files": [

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -10,6 +10,7 @@ Built-in Extensions
 .. toctree::
    :maxdepth: 1
 
+   extensions/rector
    extensions/xdebug
 
 Community Extensions

--- a/docs/extensions/rector.rst
+++ b/docs/extensions/rector.rst
@@ -1,0 +1,45 @@
+Rector
+======
+
+The rector extension for refactoring PHPBench annotations to attributes.
+
+Configuration
+-------------
+
+Add the following to your rector configuration file:
+
+.. code-block:: php
+
+    use Rector\Config\RectorConfig;
+
+    return RectorConfig::configure()
+        ->withSets([
+            PhpBench\Extensions\Rector\Set\PhpBenchSetList::ANNOTATIONS_TO_ATTRIBUTES, // Added rector set
+        ]);
+
+Example
+-------
+
+.. code-block:: diff
+
+    -/**
+    - * @BeforeMethods({"setUp", "init"})
+    - *
+    - * @Revs(100)
+    - */
+    +use PhpBench\Attributes\BeforeMethods;
+    +use PhpBench\Attributes\Revs;
+    +
+    +#[BeforeMethods(['setUp', 'init'])]
+    +#[Revs(100)]
+     final class ExampleBench
+     {
+    -    /**
+    -     * @Revs(1000)
+    -     */
+    +    #[Revs(1000)]
+         public function benchExample(): void
+         {
+             // ...
+         }
+     }

--- a/extensions/rector/config/config.php
+++ b/extensions/rector/config/config.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {};

--- a/extensions/rector/config/set/annotations-to-attributes.php
+++ b/extensions/rector/config/set/annotations-to-attributes.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
+use Rector\Php80\ValueObject\AnnotationToAttribute;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__.'/../config.php');
+
+    $rectorConfig->ruleWithConfiguration(
+        AnnotationToAttributeRector::class,
+        array_reduce(
+            glob(__DIR__.'/../../../../lib/Attributes/*.php'),
+            static function (array $annotationToAttributes, string $file): array {
+                $filename = pathinfo($file, PATHINFO_FILENAME);
+
+                if ($filename === 'AbstractMethodsAttribute') {
+                    return $annotationToAttributes;
+
+                }
+
+                $annotationToAttributes[] = new AnnotationToAttribute($filename, "PhpBench\\Attributes\\$filename");
+
+                return $annotationToAttributes;
+            },
+            []
+        )
+    );
+};

--- a/extensions/rector/lib/Set/PhpBenchSetList.php
+++ b/extensions/rector/lib/Set/PhpBenchSetList.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpBench\Extensions\Rector\Set;
+
+/**
+ * @api
+ */
+final class PhpBenchSetList
+{
+    public const ANNOTATIONS_TO_ATTRIBUTES = __DIR__.'/../../config/set/annotations-to-attributes.php';
+}


### PR DESCRIPTION
## Configuration

```php
use Rector\Config\RectorConfig;

return RectorConfig::configure()
    ->withSets([
        PhpBench\Extensions\Rector\Set\PhpBenchSetList::ANNOTATIONS_TO_ATTRIBUTES, // Added rector set
    ]);
```

## Example

```diff
-/**
- * @BeforeMethods({"setUp", "init"})
- *
- * @Revs(100)
- */
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Revs;
+
+#[BeforeMethods(['setUp', 'init'])]
+#[Revs(100)]
 final class ExampleBench
 {
-    /**
-     * @Revs(1000)
-     */
+    #[Revs(1000)]
     public function benchExample(): void
     {
         // ...
     }
 }
```