### PR TITLE
Allow lazy evaluation for functions

### DIFF
--- a/docs/expression.rst
+++ b/docs/expression.rst
@@ -346,6 +346,7 @@ if
 ~~
 
 Provide one value if the given expression is true, else return the other value.
+Arguments are evaluated lazily.
 
 .. literalinclude:: ../examples/Expression/if_1
 

--- a/lib/Expression/ExpressionFunctions.php
+++ b/lib/Expression/ExpressionFunctions.php
@@ -35,20 +35,25 @@ final class ExpressionFunctions
         $this->functionMap[$name] = $callable;
     }
 
-    /**
-     * @param mixed[] $args
-     */
-    public function execute(string $functionName, array $args): Node
+    public function get(string $name): callable
     {
-        if (!isset($this->functionMap[$functionName])) {
+        if (!isset($this->functionMap[$name])) {
             throw new RuntimeException(sprintf(
                 'Unknown function "%s", known functions "%s"',
-                $functionName,
+                $name,
                 implode('", "', array_keys($this->functionMap))
             ));
         }
 
-        $function = $this->functionMap[$functionName];
+        return $this->functionMap[$name];
+    }
+
+    /**
+     * @param Node[] $args
+     */
+    public function execute(Evaluator $evaluator, string $functionName, array $args): Node
+    {
+        $function = $this->get($functionName);
         $evaluated = $function(...$args);
 
         if (!$evaluated instanceof Node) {

--- a/lib/Expression/Func/IfFunction.php
+++ b/lib/Expression/Func/IfFunction.php
@@ -3,15 +3,19 @@
 namespace PhpBench\Expression\Func;
 
 use PhpBench\Expression\Ast\PhpValue;
+use PhpBench\Expression\LazyExpr;
+use PhpBench\Expression\LazyFunction;
 
-final class IfFunction
+final class IfFunction implements LazyFunction
 {
-    public function __invoke(PhpValue $condition, PhpValue $trueVal, PhpValue $falseVal): PhpValue
+    public function __invoke(LazyExpr $condition, LazyExpr $trueVal, LazyExpr $falseVal): PhpValue
     {
+        $condition = $condition->expect(PhpValue::class);
+
         if ((bool)$condition->value() === true) {
-            return $trueVal;
+            return $trueVal->expect(PhpValue::class);
         }
 
-        return $falseVal;
+        return $falseVal->expect(PhpValue::class);
     }
 }

--- a/lib/Expression/LazyExpr.php
+++ b/lib/Expression/LazyExpr.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace PhpBench\Expression;
+
+use PhpBench\Expression\Ast\Node;
+
+final class LazyExpr
+{
+    /**
+     * @param parameters $params
+     */
+    public function __construct(private Evaluator $evaluator, private Node $node, private array $params)
+    {
+    }
+    /**
+     * @template TClass of Node
+     *
+     * @param class-string<TClass> $class
+     *
+     * @return TClass
+     */
+    public function expect(string $class): Node
+    {
+        $result = $this->evaluator->evaluateType($this->node, $class, $this->params);
+
+        if (!$result instanceof $class) {
+            throw new \RuntimeException(sprintf(
+                'Expected expression to to evaluate to %s, but it evaluated to %s',
+                $class,
+                $result::class
+            ));
+        }
+
+        return $result;
+    }
+
+    public function evaluate(): Node
+    {
+        return $this->evaluator->evaluate($this->node, $this->params);
+    }
+}

--- a/lib/Expression/LazyFunction.php
+++ b/lib/Expression/LazyFunction.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PhpBench\Expression;
+
+interface LazyFunction
+{
+}

--- a/lib/Expression/NodeEvaluator/FunctionEvaluator.php
+++ b/lib/Expression/NodeEvaluator/FunctionEvaluator.php
@@ -9,7 +9,10 @@ use PhpBench\Expression\Ast\PhpValue;
 use PhpBench\Expression\Evaluator;
 use PhpBench\Expression\Exception\EvaluationError;
 use PhpBench\Expression\ExpressionFunctions;
+use PhpBench\Expression\LazyExpr;
+use PhpBench\Expression\LazyFunction;
 use PhpBench\Expression\NodeEvaluator;
+use RuntimeException;
 use Throwable;
 
 class FunctionEvaluator implements NodeEvaluator
@@ -19,7 +22,7 @@ class FunctionEvaluator implements NodeEvaluator
     }
 
     /**
-        * @param parameters $params
+     * @param parameters $params
      */
     public function evaluate(Evaluator $evaluator, Node $node, array $params): ?Node
     {
@@ -27,13 +30,43 @@ class FunctionEvaluator implements NodeEvaluator
             return null;
         }
 
-        try {
-            return $this->functions->execute(
+        $result = $this->doEvaluate($evaluator, $node, $params);
+
+        if (!$result instanceof Node) {
+            throw new RuntimeException(sprintf(
+                'Function "%s" must return a Node, got "%s"',
                 $node->name(),
+                gettype($result)
+            ));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param parameters $params
+     */
+    public function doEvaluate(Evaluator $evaluator, FunctionNode $node, array $params): ?Node
+    {
+        try {
+            $function = $this->functions->get($node->name());
+
+            if ($function instanceof LazyFunction) {
+                $args = array_map(function (Node $node) use ($evaluator, $params) {
+                    return new LazyExpr($evaluator, $node, $params);
+                }, $this->args($node->args()));
+
+                return $function(...$args);
+            }
+
+            $result = $function(
+                ...
                 array_map(function (Node $node) use ($evaluator, $params) {
                     return $evaluator->evaluateType($node, PhpValue::class, $params);
                 }, $this->args($node->args()))
             );
+
+            return $result;
         } catch (Throwable $throwable) {
             throw new EvaluationError($node, $throwable->getMessage(), $throwable);
         }

--- a/tests/Unit/Expression/Func/FormatFunctionTest.php
+++ b/tests/Unit/Expression/Func/FormatFunctionTest.php
@@ -2,7 +2,7 @@
 
 namespace PhpBench\Tests\Unit\Expression\Func;
 
-use ArgumentCountError;
+use PhpBench\Expression\Exception\EvaluationError;
 use PhpBench\Expression\Func\FormatFunction;
 use PhpBench\Tests\Unit\Expression\FunctionTestCase;
 
@@ -18,7 +18,7 @@ class FormatFunctionTest extends FunctionTestCase
 
     public function testTooManyPlaceholders(): void
     {
-        $this->expectException(ArgumentCountError::class);
+        $this->expectException(EvaluationError::class);
         $this->eval(
             new FormatFunction(),
             '"%s %s %s %s", 2, "foo", 6'

--- a/tests/Unit/Expression/Func/IfFunctionTest.php
+++ b/tests/Unit/Expression/Func/IfFunctionTest.php
@@ -15,6 +15,7 @@ class IfFunctionTest extends FunctionTestCase
     #[TestWith(['"", true, false', false])]
     #[TestWith(['0, true, false', false])]
     #[TestWith(['1, true, false', true])]
+    #[TestWith(['false, foo["not_existing"], false', false])] // lazy evaluation so invalid expr not executed
     public function testFormat(string $paramExpr, mixed $expected): void
     {
         self::assertEquals($expected, $this->eval(

--- a/tests/Unit/Expression/FunctionTestCase.php
+++ b/tests/Unit/Expression/FunctionTestCase.php
@@ -2,16 +2,34 @@
 
 namespace PhpBench\Tests\Unit\Expression;
 
+use PhpBench\Expression\Ast\ArgumentListNode;
+use PhpBench\Expression\Ast\FunctionNode;
 use PhpBench\Expression\Ast\PhpValue;
+use PhpBench\Expression\Evaluator;
 use PhpBench\Expression\ExpressionFunctions;
+use PhpBench\Expression\NodeEvaluator\FunctionEvaluator;
 
 class FunctionTestCase extends ParserTestCase
 {
     public function eval(callable $callable, string $argString): PhpValue
     {
-        // @phpstan-ignore-next-line
-        return (new ExpressionFunctions([
+        $result = (new FunctionEvaluator(new ExpressionFunctions([
             'func' => $callable
-        ]))->execute('func', $this->parse(sprintf('[%s]', $argString))->nodes()); // @phpstan-ignore-line
+        ])))->evaluate(
+            $this->container()->get(Evaluator::class),
+            new FunctionNode('func', new ArgumentListNode((function (string $argString) {
+                /** @var ArgumentListNode */
+                $args = $this->parse(
+                    sprintf('[%s]', $argString)
+                );
+
+                return $args->nodes();
+            })($argString))),
+            []
+        );
+
+        self::assertInstanceOf(PhpValue::class, $result);
+
+        return $result;
     }
 }


### PR DESCRIPTION
Effectively allow the `if(predicate, expr1, expr2)` function to lazily evaluate its arguments